### PR TITLE
[codex] Fix conditional Acta/Predio requirements

### DIFF
--- a/frontend/src/components/AutocompleteField.test.js
+++ b/frontend/src/components/AutocompleteField.test.js
@@ -36,4 +36,19 @@ describe('AutocompleteField', () => {
     await wrapper.setProps({ error: '' })
     expect(wrapper.text()).toContain('Sin operadores configurados para esta unidad')
   })
+
+  it('shows a clear empty options message when the user opens an empty combo', async () => {
+    const wrapper = mount(AutocompleteField, {
+      props: {
+        label: 'Tipo de Proceso',
+        items: [],
+        emptyMessage: 'Sin procesos configurados para esta unidad',
+      },
+      global,
+    })
+
+    await wrapper.get('input').trigger('focus')
+
+    expect(wrapper.text()).toContain('Sin procesos configurados para esta unidad')
+  })
 })

--- a/frontend/src/services/actaPredioRules.js
+++ b/frontend/src/services/actaPredioRules.js
@@ -1,0 +1,28 @@
+const REQUIRED_PROCESS_NAMES = ['arauco']
+
+export function normalizeProcessName(value) {
+  return String(value || '')
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim()
+}
+
+export function processRequiresActaPredio(processName) {
+  const normalized = normalizeProcessName(processName)
+  if (!normalized) return false
+  if (REQUIRED_PROCESS_NAMES.includes(normalized)) return true
+  return normalized.includes('biomasa') && normalized.includes('gajos')
+}
+
+export function shouldShowActaPredioFields(processType) {
+  return processRequiresActaPredio(processType?.nombre || processType?.name || processType)
+}
+
+export function cleanActaPredioValues(form) {
+  form.acta = ''
+  form.predio_id = ''
+  form.rodal_id = ''
+  form.rodal_manual = ''
+}

--- a/frontend/src/services/actaPredioRules.test.js
+++ b/frontend/src/services/actaPredioRules.test.js
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  cleanActaPredioValues,
+  processRequiresActaPredio,
+  shouldShowActaPredioFields,
+} from './actaPredioRules'
+
+describe('acta/predio rules', () => {
+  it.each([
+    ['Arauco'],
+    ['arauco'],
+    ['Biomasa gajos'],
+    ['BIOMASA - GAJOS'],
+  ])('%s requires Acta and Predio', (processName) => {
+    expect(processRequiresActaPredio(processName)).toBe(true)
+    expect(shouldShowActaPredioFields({ nombre: processName })).toBe(true)
+  })
+
+  it.each([
+    ['Fresa'],
+    ['Papel'],
+    ['Trabajos eventuales'],
+    ['Biomasa general'],
+    ['Transju'],
+    ['Otros'],
+  ])('%s does not require Acta or Predio', (processName) => {
+    expect(processRequiresActaPredio(processName)).toBe(false)
+    expect(shouldShowActaPredioFields({ nombre: processName })).toBe(false)
+  })
+
+  it('cleans Acta and Predio location values when switching to a process that does not require them', () => {
+    const form = {
+      acta: '123',
+      predio_id: 77,
+      rodal_id: 88,
+      rodal_manual: 'A1',
+    }
+
+    cleanActaPredioValues(form)
+
+    expect(form).toEqual({
+      acta: '',
+      predio_id: '',
+      rodal_id: '',
+      rodal_manual: '',
+    })
+  })
+})

--- a/frontend/src/views/ProduccionFormView.vue
+++ b/frontend/src/views/ProduccionFormView.vue
@@ -712,90 +712,96 @@
           </button>
         </div>
 
-        <div class="mt-3">
-          <AutocompleteField
-            label="Acta"
-            :modelValue="form.acta"
-            :items="store.actas"
-            labelKey="numero"
-            valueKey="numero"
-            placeholder="— Buscar acta —"
-            :loading="catalogLoading('actas')"
-            :error="catalogError('actas')"
-            :errorMessage="catalogErrorMessage('actas')"
-            emptyMessage="Sin actas configuradas"
-            :stale="catalogStale('actas')"
-            @select="item => { form.acta = item ? item.numero : '' }"
-          />
-          <button
-            v-if="catalogHasError('actas')"
-            type="button"
-            class="mt-2 text-xs font-semibold text-primary underline underline-offset-2"
-            @click="store.retryCatalogo('actas')"
-          >
-            Reintentar actas
-          </button>
-        </div>
-
-        <div class="mt-3">
-          <AutocompleteField
-            label="Predio"
-            v-model="form.predio_id"
-            :items="store.predios"
-            labelKey="nombre"
-            valueKey="idPredio"
-            placeholder="— Buscar predio —"
-            :loading="catalogLoading('predios')"
-            :error="catalogError('predios')"
-            :errorMessage="catalogErrorMessage('predios')"
-            emptyMessage="Sin predios configurados"
-            :stale="catalogStale('predios')"
-            @select="onPredioChange"
-          />
-          <button
-            v-if="catalogHasError('predios')"
-            type="button"
-            class="mt-2 text-xs font-semibold text-primary underline underline-offset-2"
-            @click="store.retryCatalogo('predios')"
-          >
-            Reintentar predios
-          </button>
-        </div>
-
-        <div class="mt-3">
-          <AutocompleteField
-            v-if="store.rodales.length > 0"
-            label="Rodal"
-            v-model="form.rodal_id"
-            :items="store.rodales"
-            labelKey="rodal"
-            valueKey="idRodal"
-            placeholder="— Buscar rodal —"
-            :loading="catalogLoading('rodales')"
-            :error="catalogError('rodales')"
-            :errorMessage="catalogErrorMessage('rodales')"
-            emptyMessage="Sin rodales configurados para este predio"
-            :stale="catalogStale('rodales')"
-          />
-          <div v-else-if="catalogHasError('rodales')" class="app-surface-muted rounded-lg border p-3 text-sm text-neutral-600">
-            No se pudo cargar rodales.
+        <template v-if="actaPredioRequeridos">
+          <div class="mt-3">
+            <AutocompleteField
+              label="Acta"
+              :modelValue="form.acta"
+              :items="store.actas"
+              labelKey="numero"
+              valueKey="numero"
+              placeholder="— Buscar acta —"
+              :loading="catalogLoading('actas')"
+              :error="catalogError('actas')"
+              :errorMessage="catalogErrorMessage('actas')"
+              emptyMessage="Sin actas configuradas"
+              :stale="catalogStale('actas')"
+              @select="item => { form.acta = item ? item.numero : '' }"
+            />
             <button
+              v-if="catalogHasError('actas')"
               type="button"
-              class="font-semibold text-primary underline underline-offset-2"
-              @click="store.retryCatalogo('rodales', form.predio_id)"
+              class="mt-2 text-xs font-semibold text-primary underline underline-offset-2"
+              @click="store.retryCatalogo('actas')"
             >
-              Reintentar
+              Reintentar actas
             </button>
           </div>
-          <div v-else>
-            <label class="block text-sm font-medium text-neutral-700 mb-1">Rodal</label>
-            <input
-              type="text"
-              v-model="form.rodal_manual"
-              placeholder="Ingresá el rodal manualmente"
-              :class="fieldClass"
+
+          <div class="mt-3">
+            <AutocompleteField
+              label="Predio"
+              v-model="form.predio_id"
+              :items="store.predios"
+              labelKey="nombre"
+              valueKey="idPredio"
+              placeholder="— Buscar predio —"
+              :loading="catalogLoading('predios')"
+              :error="catalogError('predios')"
+              :errorMessage="catalogErrorMessage('predios')"
+              emptyMessage="Sin predios configurados"
+              :stale="catalogStale('predios')"
+              @select="onPredioChange"
             />
+            <button
+              v-if="catalogHasError('predios')"
+              type="button"
+              class="mt-2 text-xs font-semibold text-primary underline underline-offset-2"
+              @click="store.retryCatalogo('predios')"
+            >
+              Reintentar predios
+            </button>
           </div>
+
+          <div class="mt-3">
+            <AutocompleteField
+              v-if="store.rodales.length > 0"
+              label="Rodal"
+              v-model="form.rodal_id"
+              :items="store.rodales"
+              labelKey="rodal"
+              valueKey="idRodal"
+              placeholder="— Buscar rodal —"
+              :loading="catalogLoading('rodales')"
+              :error="catalogError('rodales')"
+              :errorMessage="catalogErrorMessage('rodales')"
+              emptyMessage="Sin rodales configurados para este predio"
+              :stale="catalogStale('rodales')"
+            />
+            <div v-else-if="catalogHasError('rodales')" class="app-surface-muted rounded-lg border p-3 text-sm text-neutral-600">
+              No se pudo cargar rodales.
+              <button
+                type="button"
+                class="font-semibold text-primary underline underline-offset-2"
+                @click="store.retryCatalogo('rodales', form.predio_id)"
+              >
+                Reintentar
+              </button>
+            </div>
+            <div v-else>
+              <label class="block text-sm font-medium text-neutral-700 mb-1">Rodal</label>
+              <input
+                type="text"
+                v-model="form.rodal_manual"
+                placeholder="Ingresá el rodal manualmente"
+                :class="fieldClass"
+              />
+            </div>
+          </div>
+        </template>
+
+        <div v-else class="app-surface-muted mt-3 rounded-lg border p-3 text-sm text-neutral-500">
+          Acta y Predio no aplican para este tipo de trabajo.
         </div>
         <div
           v-if="mostrarErrorUbicacion"
@@ -934,6 +940,7 @@ import InputField from '@/components/InputField.vue'
 import AutocompleteField from '@/components/AutocompleteField.vue'
 import AppIcon from '@/components/ui/AppIcon.vue'
 import motivosNoOperativos from '@/data/motivosNoOperativos.json'
+import { cleanActaPredioValues, shouldShowActaPredioFields } from '@/services/actaPredioRules'
 
 const router = useRouter()
 const authStore = useAuthStore()
@@ -1023,19 +1030,24 @@ function irAPaso(i) {
 // Campos dinámicos según tipo de proceso seleccionado
 const camposActivos = computed(() => {
   if (!form.tipo_de_proceso_id) return []
-  const tipo = store.tiposProceso.find(t => t.id === form.tipo_de_proceso_id)
-    || store.todosLosTipos.find(t => t.id === form.tipo_de_proceso_id)
+  const tipo = tipoProcesoSeleccionado.value
   if (!tipo || !tipo.campos) return []
   return tipo.campos.split(',').map(c => c.trim())
 })
 
+const tipoProcesoSeleccionado = computed(() => {
+  if (!form.tipo_de_proceso_id) return null
+  return store.tiposProceso.find(t => t.id === form.tipo_de_proceso_id)
+    || store.todosLosTipos.find(t => t.id === form.tipo_de_proceso_id)
+    || null
+})
+
 // Nombre del tipo de proceso seleccionado
 const tipoProcesoNombre = computed(() => {
-  if (!form.tipo_de_proceso_id) return ''
-  const tipo = store.tiposProceso.find(t => t.id === form.tipo_de_proceso_id)
-    || store.todosLosTipos.find(t => t.id === form.tipo_de_proceso_id)
-  return tipo?.nombre || ''
+  return tipoProcesoSeleccionado.value?.nombre || ''
 })
+
+const actaPredioRequeridos = computed(() => shouldShowActaPredioFields(tipoProcesoSeleccionado.value))
 
 const movilesFiltrados = computed(() => {
   const texto = (busquedaMovil.value || '').trim().toLowerCase()
@@ -1192,10 +1204,12 @@ const rodalCompleto = computed(() => {
 })
 
 const ubicacionValida = computed(() => {
+  if (!actaPredioRequeridos.value) return true
   return !!actaNormalizada.value && !!form.predio_id && rodalCompleto.value
 })
 
 const ubicacionCatalogosConError = computed(() => {
+  if (!actaPredioRequeridos.value) return []
   const catalogos = []
   if (catalogHasError('actas') && store.actas.length === 0) catalogos.push('actas')
   if (catalogHasError('predios') && store.predios.length === 0) catalogos.push('predios')
@@ -1204,10 +1218,11 @@ const ubicacionCatalogosConError = computed(() => {
 })
 
 const mensajeUbicacionIncompleta = computed(() => {
+  if (!actaPredioRequeridos.value) return ''
   if (ubicacionCatalogosConError.value.length > 0) {
     return `No se pudo cargar ${ubicacionCatalogosConError.value.join(', ')}. Reintentá el catálogo para completar la ubicación.`
   }
-  return 'Completá Acta, Predio y Rodal cuando sean solicitados para poder guardar.'
+  return 'Completá Acta, Predio y Rodal para Arauco o Biomasa gajos.'
 })
 
 const mostrarErrorHoras = computed(() => {
@@ -1406,6 +1421,12 @@ function guardarBorrador() {
   })
 }
 
+function limpiarUbicacionSiNoAplica() {
+  if (form.tipo_de_proceso_id && tipoProcesoSeleccionado.value && !actaPredioRequeridos.value) {
+    cleanActaPredioValues(form)
+  }
+}
+
 async function onOperadorChange() {
   if (!form.operador_id) return
   // Fetch asignaciones operativas + fallback legacy
@@ -1468,6 +1489,7 @@ function onTipoProcesoChange() {
   form.km_perfilado = 0
   form.hr_disposicion = 0
   form.km = 0
+  limpiarUbicacionSiNoAplica()
 
   autocompletarHoraInicio({ force: true })
   guardarPreferenciasProduccion()
@@ -1484,6 +1506,10 @@ async function onPredioChange() {
 // ─── Watch combustible toggle ───
 watch(cargoCombustible, (val) => {
   if (!val) form.combustible = 0
+})
+
+watch(() => [form.tipo_de_proceso_id, tipoProcesoNombre.value], () => {
+  limpiarUbicacionSiNoAplica()
 })
 
 // Removed old busquedaMovil watcher — selection/buscador now handled via mostrandoBuscador state
@@ -1613,7 +1639,7 @@ async function handleSubmit() {
   }
 
   try {
-    if (!actaNormalizada.value || actaNormalizada.value === '0') {
+    if (actaPredioRequeridos.value && (!actaNormalizada.value || actaNormalizada.value === '0')) {
       await Swal.fire({
         icon: 'warning',
         title: 'Acta obligatoria',
@@ -1647,7 +1673,7 @@ async function handleSubmit() {
       return
     }
 
-    if (!ubicacionValida.value) {
+    if (actaPredioRequeridos.value && !ubicacionValida.value) {
       await Swal.fire({
         icon: 'warning',
         title: 'Ubicación incompleta',
@@ -1684,9 +1710,9 @@ async function handleSubmit() {
       aceite_motor: form.aceite_motor,
       aceite_transmision: form.aceite_transmision,
       aceite_embrague: form.aceite_embrague,
-      acta: form.acta,
-      rodal: getRodalNombre(),
-      predio: getPredioNombre(form.predio_id),
+      acta: actaPredioRequeridos.value ? form.acta : '',
+      rodal: actaPredioRequeridos.value ? getRodalNombre() : '',
+      predio: actaPredioRequeridos.value ? getPredioNombre(form.predio_id) : '',
       m3: form.m3,
       carros: form.carros,
       tn_despachadas: form.tn_despachadas,


### PR DESCRIPTION
Refs #40

## Resumen funcional
- Centraliza la regla de Acta/Predio por tipo de proceso: solo `Arauco` y `Biomasa gajos` requieren Acta, Predio y Rodal.
- Oculta Acta/Predio/Rodal para Fresa, Papel, Trabajos eventuales, Biomasa general, Transju y otros tipos no aplicables.
- Limpia Acta/Predio/Rodal al cambiar desde un tipo que los requiere hacia uno que no los requiere.
- El submit ya no bloquea ni manda ubicación para tipos donde Acta/Predio no aplican.
- Se agrega cobertura explícita para combos vacíos en `AutocompleteField`.

## Archivos modificados
- `frontend/src/services/actaPredioRules.js`
- `frontend/src/services/actaPredioRules.test.js`
- `frontend/src/views/ProduccionFormView.vue`
- `frontend/src/components/AutocompleteField.test.js`

## Pruebas ejecutadas
- `npm test` en `Y:/registro_produccion/frontend`: 30 tests passed.
- `npm run build` en `Y:/registro_produccion/frontend`: build PWA OK. Mantiene warning existente de chunk > 500 kB.
- `python -m pytest` en `O:/registro_produccion/backend`: 19 passed.

## Validación en navegador
- Vite local en `http://127.0.0.1:5174/`.
- Playwright validó en navegador el módulo servido por Vite para: Arauco, Biomasa gajos, Fresa, Papel, Trabajos eventuales, Biomasa general y Transju.
- Evidencia local generada: `output/playwright/issue-40-browser-rule-results.json` y `output/playwright/issue-40-browser-rule-results.png`.
- Intenté recorrer el wizard completo con APIs de catálogo interceptadas; el recorrido quedó trabado en el buscador de máquina bajo ese mock local, así que no lo declaro como validación completa del flujo end-to-end.

## Quirolenco / Santa Ana
- Revisé el código de filtros de producción y no encontré un hardcode de Quirolenco ni una regla especial de Santa Ana en frontend/backend.
- Los filtros relevantes siguen viniendo de catálogos por UN, operador, móvil, tipo de proceso y predio/rodal. No agregué hardcodes.

## Offline / PWA
- La app ya cachea catálogos de producción con `NetworkFirst` en `vite.config.js` y el store conserva fallback Dexie para catálogos.
- El cambio es local a regla/validación/render del formulario; no modifica service worker, cola offline ni endpoints.

## Riesgos o pendientes
- La regla queda centralizada y testeada por nombre normalizado porque la API actual de `tipo_de_proceso` no expone un flag operativo para Acta/Predio.
- Si más adelante la base incorpora un atributo explícito, conviene reemplazar el mapeo por ese flag.
