### PR TITLE
Fix issue 44 modal error handling and relation loading

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,10 +1,11 @@
+import logging
 import re
-import traceback
 from datetime import datetime, timezone
 from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from sqlalchemy import text
+from sqlalchemy.exc import SQLAlchemyError
 from app.core.config import settings
 from app.core.database import engine
 from app.api.routes import items, auth, produccion, dashboard, admin, combustible
@@ -13,6 +14,9 @@ import pymysql
 
 pymysql.install_as_MySQLdb()
 app = FastAPI(title=settings.PROJECT_NAME)
+logger = logging.getLogger(__name__)
+SAFE_DATABASE_ERROR_DETAIL = "No se pudieron cargar los datos necesarios. Actualiza e intenta nuevamente."
+SAFE_SERVER_ERROR_DETAIL = "No se pudo completar la operacion. Intenta nuevamente en unos minutos."
 
 # CORS
 app.add_middleware(
@@ -29,18 +33,32 @@ def _is_allowed_origin(origin: str) -> bool:
     return origin in settings.ALLOWED_ORIGINS or bool(re.match(settings.ALLOWED_ORIGIN_REGEX, origin))
 
 
-@app.exception_handler(Exception)
-async def global_exception_handler(request: Request, exc: Exception):
-    traceback.print_exc()
+def _cors_headers_for_request(request: Request) -> dict[str, str]:
     origin = request.headers.get("origin", "")
     headers = {}
     if _is_allowed_origin(origin):
         headers["Access-Control-Allow-Origin"] = origin
         headers["Access-Control-Allow-Credentials"] = "true"
+    return headers
+
+
+@app.exception_handler(SQLAlchemyError)
+async def database_exception_handler(request: Request, exc: SQLAlchemyError):
+    logger.exception("Unhandled database error while processing %s %s", request.method, request.url.path)
+    return JSONResponse(
+        status_code=503,
+        content={"detail": SAFE_DATABASE_ERROR_DETAIL},
+        headers=_cors_headers_for_request(request),
+    )
+
+
+@app.exception_handler(Exception)
+async def global_exception_handler(request: Request, exc: Exception):
+    logger.exception("Unhandled application error while processing %s %s", request.method, request.url.path)
     return JSONResponse(
         status_code=500,
-        content={"detail": str(exc)},
-        headers=headers,
+        content={"detail": SAFE_SERVER_ERROR_DETAIL},
+        headers=_cors_headers_for_request(request),
     )
 
 # Include routers

--- a/backend/tests/test_app.py
+++ b/backend/tests/test_app.py
@@ -1,4 +1,5 @@
 from fastapi.testclient import TestClient
+from sqlalchemy.exc import OperationalError
 
 from app import main as main_module
 from app.main import app
@@ -81,3 +82,24 @@ def test_health_fails_when_expected_database_name_mismatches(monkeypatch):
     assert data["database"] == "ok"
     assert data["database_name"]["matches"] is False
     assert data["database_name"]["actual"] == "indufor"
+
+
+def test_database_errors_return_safe_message_without_sql():
+    async def broken_database_route():
+        raise OperationalError(
+            "SELECT personal.idPersonal FROM personal WHERE personal.idPersonal = %(idPersonal_1)s",
+            {"idPersonal_1": 951},
+            Exception("Lost connection to MySQL server during query"),
+        )
+
+    app.add_api_route("/__test__/database-error-safe-message", broken_database_route, methods=["GET"])
+    client = TestClient(app, raise_server_exceptions=False)
+
+    response = client.get("/__test__/database-error-safe-message")
+
+    assert response.status_code == 503
+    detail = response.json()["detail"]
+    assert detail == "No se pudieron cargar los datos necesarios. Actualiza e intenta nuevamente."
+    assert "SELECT" not in detail
+    assert "personal" not in detail
+    assert "Lost connection" not in detail

--- a/frontend/src/views/admin/AdminCrudView.test.js
+++ b/frontend/src/views/admin/AdminCrudView.test.js
@@ -10,6 +10,9 @@ vi.mock('vue-router', () => ({
 vi.mock('@/services/api', () => ({
   default: {
     get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
   },
 }))
 
@@ -21,6 +24,9 @@ describe('AdminCrudView tipos de proceso', () => {
     setActivePinia(createPinia())
     vi.clearAllMocks()
     api.get.mockResolvedValue({ data: [] })
+    api.post.mockResolvedValue({ data: {} })
+    api.put.mockResolvedValue({ data: {} })
+    api.delete.mockResolvedValue({ data: {} })
   })
 
   it('shows configurable Acta, Predio, and Rodal requirements in the process type form', async () => {
@@ -49,5 +55,44 @@ describe('AdminCrudView tipos de proceso', () => {
     expect(labels).toContain('Requiere Acta')
     expect(labels).toContain('Requiere Predio')
     expect(labels).toContain('Requiere Rodal')
+  })
+
+  it('shows a friendly message instead of raw SQL when saving fails', async () => {
+    api.post.mockRejectedValueOnce({
+      response: {
+        status: 503,
+        data: {
+          detail: "(pymysql.err.OperationalError) (2013, 'Lost connection to MySQL server during query') [SQL: SELECT personal.`idPersonal` FROM personal WHERE personal.`idPersonal` = %(idPersonal_1)s]",
+        },
+      },
+    })
+
+    const wrapper = mount(AdminCrudView, {
+      global: {
+        directives: {
+          motionPanel: {},
+          motionPop: {},
+        },
+        stubs: {
+          AppIcon: true,
+        },
+      },
+    })
+    await flushPromises()
+
+    const nuevo = wrapper.findAll('button').find((button) => button.text().includes('Nuevo'))
+    await nuevo.trigger('click')
+
+    const nombre = wrapper.findAll('input[type="text"]').at(1)
+    await nombre.setValue('Trabajos Eventuales')
+
+    const guardar = wrapper.findAll('button').find((button) => button.text().includes('Guardar'))
+    await guardar.trigger('click')
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('No se pudieron cargar los datos necesarios. Actualiza e intenta nuevamente.')
+    expect(wrapper.text()).not.toContain('SELECT personal')
+    expect(wrapper.text()).not.toContain('OperationalError')
+    expect(wrapper.text()).not.toContain('Lost connection')
   })
 })

--- a/frontend/src/views/admin/AdminCrudView.vue
+++ b/frontend/src/views/admin/AdminCrudView.vue
@@ -588,6 +588,9 @@ import AdminQuickAssignment from '@/components/admin/AdminQuickAssignment.vue'
 import { useAdminStore } from '@/stores/admin'
 import { validateAdminPassword } from '@/services/passwordValidation'
 
+const SAFE_LOAD_ERROR_MESSAGE = 'No se pudieron cargar los datos necesarios. Actualiza e intenta nuevamente.'
+const SAFE_SAVE_ERROR_MESSAGE = 'No se pudo guardar el registro. Actualiza e intenta nuevamente.'
+
 const SECTIONS = {
   principal: 'Principal',
   relaciones: 'Relaciones',
@@ -996,7 +999,7 @@ async function loadRows() {
     })
   } catch (err) {
     rows.value = []
-    error.value = err.response?.data?.detail || `No se pudo cargar ${meta.value.title.toLowerCase()}`
+    error.value = safeAdminErrorMessage(err, `No se pudo cargar ${meta.value.title.toLowerCase()}`)
   } finally {
     loading.value = false
   }
@@ -1139,7 +1142,7 @@ async function submitForm() {
     await Promise.all([loadRows(), loadReferences()])
     closeForm()
   } catch (err) {
-    formError.value = err.response?.data?.detail || 'No se pudo guardar el registro'
+    formError.value = safeAdminErrorMessage(err, SAFE_SAVE_ERROR_MESSAGE)
   } finally {
     submitting.value = false
   }
@@ -1167,7 +1170,7 @@ async function submitQuickAssignment() {
     resetQuickAssignment()
     await loadRows()
   } catch (err) {
-    error.value = err.response?.data?.detail || 'No se pudo crear la asignacion'
+    error.value = safeAdminErrorMessage(err, 'No se pudo crear la asignacion')
   } finally {
     submitting.value = false
   }
@@ -1196,7 +1199,7 @@ async function confirmDelete() {
     clearReferenceCacheFor(entity.value)
     await loadRows()
   } catch (err) {
-    error.value = err.response?.data?.detail || `No se pudo ${verb} el registro`
+    error.value = safeAdminErrorMessage(err, `No se pudo ${verb} el registro`)
   } finally {
     submitting.value = false
     cancelDelete()
@@ -1345,10 +1348,21 @@ async function updateRelationEntity(refEntity, id, payload) {
     await loadReferences()
     cancelRelationDraft()
   } catch (err) {
-    error.value = err.response?.data?.detail || 'No se pudo actualizar la vinculacion'
+    error.value = safeAdminErrorMessage(err, 'No se pudo actualizar la vinculacion')
   } finally {
     submitting.value = false
   }
+}
+
+function safeAdminErrorMessage(err, fallback) {
+  const detail = err?.response?.data?.detail
+  if (typeof detail !== 'string' || !detail.trim()) return fallback
+  if (err?.response?.status >= 500 || containsTechnicalError(detail)) return SAFE_LOAD_ERROR_MESSAGE
+  return detail
+}
+
+function containsTechnicalError(message) {
+  return /\b(SQL|SELECT|INSERT|UPDATE|DELETE|Traceback|OperationalError|ProgrammingError|SQLAlchemy|pymysql|MySQL|parameters?:|Background on this error)\b/i.test(message)
 }
 
 function fieldClass(field) {


### PR DESCRIPTION
## Resumen
- Fixes #44.
- Sanitiza errores no capturados de SQLAlchemy/MySQL en el backend: se loguea el detalle técnico en servidor y se responde JSON seguro con HTTP 503.
- Evita que el CRUD admin muestre SQL, tracebacks o detalles técnicos crudos en el modal de tipos de proceso y otros flujos admin.
- Mantiene el modal operable con mensaje amigable para reintentar.

## Causa técnica
El error del issue venía de una consulta a `personal.idPersonal` durante dependencias/autenticación admin. Cuando MySQL cortaba la conexión, el handler global devolvía `str(exc)`, que incluye SQL y parámetros. El frontend tomaba `response.data.detail` y lo mostraba tal cual.

## Tests
- `python -m pytest` -> 23 passed
- `npm run test` -> 36 passed
- `npm run build` -> OK; mantiene warning conocido de chunk > 500 kB
