### PR TITLE
[codex] Ampliar nombre de equipo en carga de produccion

### DIFF
--- a/backend/app/models/produccion.py
+++ b/backend/app/models/produccion.py
@@ -9,7 +9,7 @@ class TableroProduccion(Base):
     UN = Column(String(50), nullable=False, default="")
     operacion = Column(String(50), nullable=False, default="")
     fecha = Column(Date, nullable=True)
-    equipo = Column(String(50), nullable=False, default="")
+    equipo = Column(String(100), nullable=False, default="")
     operador = Column(String(50), nullable=False, default="")
     hr_inicio = Column(Numeric(12, 2), nullable=False, default=0)
     hr_fin = Column(Numeric(12, 2), nullable=False, default=0)

--- a/backend/tests/test_produccion_equipo_length.py
+++ b/backend/tests/test_produccion_equipo_length.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+
+from app.models.produccion import TableroProduccion
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_tablero_produccion_equipo_allows_long_machine_names():
+    assert TableroProduccion.__table__.c.equipo.type.length == 100
+
+
+def test_schema_documents_equipo_length_migration():
+    migrations = (REPO_ROOT / "migrations.sql").read_text(encoding="utf-8")
+    base_schema = (REPO_ROOT / "fg_structure.sql").read_text(encoding="utf-8")
+
+    assert "MODIFY COLUMN equipo VARCHAR(100) NOT NULL DEFAULT ''" in migrations
+    assert "`equipo` varchar(100) NOT NULL DEFAULT ''" in base_schema

--- a/fg_structure.sql
+++ b/fg_structure.sql
@@ -3103,7 +3103,7 @@ CREATE TABLE `tablero_produccion` (
   `UN` varchar(50) NOT NULL DEFAULT '',
   `operacion` varchar(50) NOT NULL DEFAULT '',
   `fecha` date DEFAULT NULL,
-  `equipo` varchar(50) NOT NULL DEFAULT '',
+  `equipo` varchar(100) NOT NULL DEFAULT '',
   `operador` varchar(50) NOT NULL DEFAULT '',
   `hr_inicio` decimal(12,2) NOT NULL DEFAULT 0.00,
   `hr_fin` decimal(12,2) NOT NULL DEFAULT 0.00,

--- a/migrations.sql
+++ b/migrations.sql
@@ -308,6 +308,10 @@ ALTER TABLE tablero_produccion
   ADD COLUMN IF NOT EXISTS pies_12  DECIMAL(12,2) NOT NULL DEFAULT 0,
   ADD COLUMN IF NOT EXISTS pies_10  DECIMAL(12,2) NOT NULL DEFAULT 0,
   ADD COLUMN IF NOT EXISTS pulpable DECIMAL(12,2) NOT NULL DEFAULT 0;
+
+-- Migración 2026-07-02: permitir nombres visibles de equipo mas largos
+ALTER TABLE tablero_produccion
+  MODIFY COLUMN equipo VARCHAR(100) NOT NULL DEFAULT '';
 INSERT IGNORE INTO tipo_proceso_kpi (tipo_proceso_id, kpi_id, orden, es_principal) VALUES
   (11, 1,  1, 1),
   (11, 10, 2, 0),


### PR DESCRIPTION
## Qué cambia

- Amplía `tablero_produccion.equipo` de 50 a 100 caracteres en el modelo SQLAlchemy.
- Actualiza el esquema base `fg_structure.sql` y agrega migración para producción.
- Agrega una prueba de contrato para evitar volver al límite de 50 caracteres.

## Causa raíz

La carga de producción manda el texto visible del equipo (`detalle - patente`) junto con `cod_equipo`. Si ese texto supera 50 caracteres, MySQL rechaza el INSERT con `DataError 1406` y la producción no queda guardada.

## Validación

- `python -m pytest backend\tests -q` -> 25 passed
- `git diff --check HEAD~1..HEAD` -> sin errores

Fixes #46
