### PR TITLE
fix(ui): clasificar errores de login (sin red vs 401 vs 5xx) (issue #51)

### DIFF
--- a/docs/superpowers/plans/pr-51-body.md
+++ b/docs/superpowers/plans/pr-51-body.md
@@ -1,0 +1,61 @@
+## Objetivo
+
+Closes #51 (cierra también parcialmente el #24 — mensajes 5xx ya no leaken SQL/trazas)
+
+Cuando el operador intenta login y algo falla, la pantalla de Login debe decirle **claramente qué pasó**:
+- "Estás sin conexión" si está en el campo sin señal.
+- "DNI o contraseña incorrectos" si escribió mal la credencial.
+- "No se pudo conectar con el servidor" si el backend está caído (sin filtrar SQL ni stack traces).
+
+## Cambios
+
+- `frontend/src/stores/auth.js`
+  - Nuevo helper `classifyLoginError(err)` que centraliza el mapeo axios error → mensaje amigable para el operador.
+  - Constantes exportadas: `LOGIN_ERROR_NO_CONNECTION`, `LOGIN_ERROR_BAD_CREDENTIALS`, `LOGIN_ERROR_SERVER`.
+  - `classifyLoginError()` rechaza eco de `data.detail` si es muy largo (>120 chars) o si luce técnico (regex sobre `pymysql`/`sqlalchemy`/`INSERT`/`SELECT`/`column`/`table`/`traceback`/`password_hash`/etc.).
+  - `login()` ahora pasa `_suppressErrorToast: true` en el config para evitar el toast global duplicado.
+
+- `frontend/src/services/api.js`
+  - El interceptor de respuesta respeta el flag `_suppressErrorToast` (skipea todos los toasts).
+  - Cubre 401 para requests no-login con un toast claro "Sesión expirada".
+  - 5xx sigue usando `SERVER_ERROR_MESSAGE` (no leak), ahora también cuando es login (porque el flag lo silencia, pero por seguridad la rama 5xx del interceptor mantiene el genérico).
+
+- `frontend/src/views/LoginView.vue`
+  - Banner **amber persistente** "Estás sin conexión" arriba del formulario cuando `navigator.onLine === false`, escucha eventos online/offline.
+  - Bloque de error con icono/color/título **diferenciado por categoría**:
+    - `offline` → amber, icono offline, título "Sin conexión".
+    - `credentials` → rojo, icono error, título "Credenciales incorrectas".
+    - `server`/`other` → rojo, icono error, título "No se pudo validar el ingreso".
+  - El subtítulo muestra `authStore.error` (texto amigable, sin SQL).
+
+- Tests
+  - `frontend/src/stores/auth.test.js` (+10) — clasificador, login payload, fallback técnico.
+  - `frontend/src/services/api.test.js` reescrito (+6) — captura el handler del interceptor via mock de axios para testear 5xx, flag suppress, 401 cleanup, setUnauthorizedHandler.
+
+## Tests / Validaciones
+
+- [x] `git diff --check`
+- [x] `npx vitest run` — **64/64 tests** (48 anteriores + 16 nuevos)
+- [x] `npx vite build` — 9.59s, SW + manifest regenerados
+- [x] sin nuevas warnings de CRLF en el diff
+
+## Comportamiento por escenario
+
+| Dispositivo | Status / error | Resultado visible |
+|---|---|---|
+| **Offline** | `err.response` undefined | Banner persistente + toast "Sin conexión" |
+| Online, 401 | DNI mal | "Credenciales incorrectas" en rojo |
+| Online, 5xx | Backend SQL leak | "No se pudo validar el ingreso" + sub "No se pudo conectar con el servidor…" (sin SQL) |
+| Online, 400 corto | Backend dice "X inválido" | "No se pudo validar el ingreso" + sub "X inválido" (eco seguro) |
+| Online, 400 técnico | Backend dice "INSERT INTO…" | Mensaje genérico, no se echo el SQL |
+| Online, timeout | Sin response | "Sin conexión" (también mensaje amigable) |
+
+## Fuera de alcance
+
+- No se cambió el backend. El backend sigue mandando su `detail` técnico si quiere — el frontend ahora lo filtra para 5xx y para 4xx que luzca técnico.
+- No se tocó el manejo 5xx fuera del flujo login (banner global). Eso entra en #34 si querés endurecer.
+
+## Riesgos / pendientes
+
+- El regex `looksTechnical` puede tener falsos positivos si el backend alguna vez manda un detail de 4xx que casualmente matchea (ej. "trace" en una palabra normal en español). Aceptable por ahora, se puede refinar en un follow-up.
+- Si querés deshabilitar completamente la posibilidad de eco de 4xx detail, eso entra en hardening posterior. Hoy solo filtra técnicos.

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -33,6 +33,11 @@ api.interceptors.response.use(
     const status = error?.response?.status
     const requestUrl = error?.config?.url || ''
     const isAuthLogin = requestUrl.includes('/api/auth/login')
+    // Callers can opt-out from the global toast by passing
+    // `{ _suppressErrorToast: true }` on the request config (used by the
+    // login flow to render its own contextual message instead of a generic
+    // toast).
+    const suppressToast = error?.config?._suppressErrorToast === true
 
     if (status === 401 && !isAuthLogin) {
       localStorage.removeItem('token')
@@ -43,12 +48,17 @@ api.interceptors.response.use(
       }
     }
 
-    if (!error.response) {
-      useToastStore().error('Backend no disponible', 'No se pudo conectar con el servidor.')
-    } else if (status === 403) {
-      useToastStore().error('Acceso restringido', error.response?.data?.detail || 'No tenes permisos para esta accion.')
-    } else if (status >= 500) {
-      useToastStore().error('Error del servidor', SERVER_ERROR_MESSAGE)
+    if (!suppressToast) {
+      if (!error.response) {
+        useToastStore().error('Backend no disponible', 'No se pudo conectar con el servidor.')
+      } else if (status === 403) {
+        useToastStore().error('Acceso restringido', error.response?.data?.detail || 'No tenes permisos para esta accion.')
+      } else if (status >= 500) {
+        // 5xx never leaks backend detail to the UI; only the generic message.
+        useToastStore().error('Error del servidor', SERVER_ERROR_MESSAGE)
+      } else if (status === 401 && !isAuthLogin) {
+        useToastStore().error('Sesion expirada', 'Volvé a iniciar sesion para continuar.')
+      }
     }
 
     return Promise.reject(error)

--- a/frontend/src/services/api.test.js
+++ b/frontend/src/services/api.test.js
@@ -1,33 +1,195 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { SERVER_ERROR_MESSAGE, normalizeBaseURL } from './api'
+const toastError = vi.fn()
+const toastInfo = vi.fn()
+const toastSuccess = vi.fn()
+
+vi.mock('@/stores/toast', () => ({
+  useToastStore: () => ({
+    error: toastError,
+    info: toastInfo,
+    success: toastSuccess,
+  }),
+}))
+
+// Capture the response interceptor's error handler so tests can drive it
+// without spinning up a real HTTP request. Each test gets a fresh fn.
+const capturedHandlers = []
+
+vi.mock('axios', async () => {
+  const actual = await vi.importActual('axios')
+  return {
+    ...actual,
+    default: {
+      ...actual.default,
+      create: () => {
+        const requestUse = vi.fn()
+        const responseUse = vi.fn((ok, err) => {
+          if (typeof err === 'function') capturedHandlers.push(err)
+        })
+        return {
+          interceptors: {
+            request: { use: requestUse },
+            response: { use: responseUse },
+          },
+          defaults: { headers: { common: {} } },
+          post: vi.fn(),
+          get: vi.fn(),
+          put: vi.fn(),
+          delete: vi.fn(),
+          request: vi.fn(),
+        }
+      },
+    },
+  }
+})
+
+import axios from 'axios'
+
+let cachedApi
+let cachedHandler
+
+beforeAll(async () => {
+  cachedApi = await import('./api')
+  cachedHandler = capturedHandlers[capturedHandlers.length - 1]
+  expect(typeof cachedHandler).toBe('function')
+})
+
+async function loadApi() {
+  return cachedApi
+}
+
+async function getErrorHandler() {
+  return cachedHandler
+}
+
+beforeEach(() => {
+  toastError.mockReset()
+  toastInfo.mockReset()
+  toastSuccess.mockReset()
+  localStorage.clear()
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
 
 describe('normalizeBaseURL', () => {
-  it('uses relative URLs when no base URL is configured', () => {
+  it('uses relative URLs when no base URL is configured', async () => {
+    const { normalizeBaseURL } = await loadApi()
     expect(normalizeBaseURL()).toBe('')
     expect(normalizeBaseURL('')).toBe('')
   })
 
-  it('removes a trailing api segment from configured base URLs', () => {
+  it('removes a trailing api segment from configured base URLs', async () => {
+    const { normalizeBaseURL } = await loadApi()
     expect(normalizeBaseURL('/api')).toBe('')
     expect(normalizeBaseURL('/api/')).toBe('')
     expect(normalizeBaseURL('https://example.com/api')).toBe('https://example.com')
   })
 
-  it('keeps non-api base URLs unchanged', () => {
+  it('keeps non-api base URLs unchanged', async () => {
+    const { normalizeBaseURL } = await loadApi()
     expect(normalizeBaseURL('http://localhost:8000')).toBe('http://localhost:8000')
   })
 })
 
 describe('server error toast message', () => {
-  it('uses a generic message instead of backend details for 5xx errors', () => {
+  it('uses a generic message instead of backend details for 5xx errors', async () => {
+    const { SERVER_ERROR_MESSAGE } = await loadApi()
     const technicalDetail = `
       pymysql.err.OperationalError: (2013, 'Lost connection to MySQL server during query')
       SELECT id, dni, password_hash FROM usuarios WHERE dni = %s
     `
 
-    expect(SERVER_ERROR_MESSAGE).toBe('No se pudo conectar con el servidor. Intenta nuevamente en unos minutos.')
+    expect(SERVER_ERROR_MESSAGE).toBe(
+      'No se pudo conectar con el servidor. Intenta nuevamente en unos minutos.',
+    )
     expect(SERVER_ERROR_MESSAGE).not.toContain(technicalDetail)
-    expect(SERVER_ERROR_MESSAGE).not.toMatch(/pymysql|OperationalError|SELECT|usuarios|password_hash/i)
+    expect(SERVER_ERROR_MESSAGE).not.toMatch(
+      /pymysql|OperationalError|SELECT|usuarios|password_hash/i,
+    )
+  })
+})
+
+describe('api response interceptor', () => {
+  it('uses SERVER_ERROR_MESSAGE for 5xx and never echoes technical detail', async () => {
+    const handler = await getErrorHandler()
+    const error = {
+      response: {
+        status: 500,
+        data: {
+          detail:
+            "pymysql.err.OperationalError: (2013, 'Lost connection') SELECT * FROM usuarios",
+        },
+      },
+      config: { url: '/api/produccion' },
+    }
+    await expect(handler(error)).rejects.toBe(error)
+    expect(toastError).toHaveBeenCalledTimes(1)
+    const [, message] = toastError.mock.calls[0]
+    expect(message).not.toMatch(/pymysql|SELECT|usuarios|OperationalError/i)
+    expect(message).toBe(
+      'No se pudo conectar con el servidor. Intenta nuevamente en unos minutos.',
+    )
+  })
+
+  it('suppresses the toast when _suppressErrorToast is true on the request config', async () => {
+    const handler = await getErrorHandler()
+    const error = {
+      response: {
+        status: 500,
+        data: { detail: 'something technical that should NOT leak' },
+      },
+      config: { url: '/api/auth/login', _suppressErrorToast: true },
+    }
+    await expect(handler(error)).rejects.toBe(error)
+    expect(toastError).not.toHaveBeenCalled()
+  })
+
+  it('shows a "no response" toast when the request failed without a response', async () => {
+    const handler = await getErrorHandler()
+    const error = { message: 'Network Error', config: { url: '/api/x' } }
+    await expect(handler(error)).rejects.toBe(error)
+    expect(toastError).toHaveBeenCalledTimes(1)
+    expect(toastError.mock.calls[0][0]).toBe('Backend no disponible')
+  })
+
+  it('still cleans up auth state on 401 for non-login requests', async () => {
+    const handler = await getErrorHandler()
+    const error = {
+      response: { status: 401, data: { detail: 'expired' } },
+      config: { url: '/api/produccion' },
+    }
+    localStorage.setItem('token', 'old-token')
+    localStorage.setItem('user', JSON.stringify({ dni: 'X' }))
+    await expect(handler(error)).rejects.toBe(error)
+    expect(localStorage.getItem('token')).toBeNull()
+    expect(localStorage.getItem('user')).toBeNull()
+  })
+
+  it('runs setUnauthorizedHandler when handler is configured', async () => {
+    const { setUnauthorizedHandler } = await loadApi()
+    const cb = vi.fn()
+    setUnauthorizedHandler(cb)
+    const handler = await getErrorHandler()
+    const error = {
+      response: { status: 401, data: { detail: 'expired' } },
+      config: { url: '/api/produccion' },
+    }
+    await expect(handler(error)).rejects.toBe(error)
+    expect(cb).toHaveBeenCalledTimes(1)
+  })
+
+  it('does NOT clear auth on 401 when request is /api/auth/login', async () => {
+    const handler = await getErrorHandler()
+    const error = {
+      response: { status: 401, data: { detail: 'bad creds' } },
+      config: { url: '/api/auth/login' },
+    }
+    localStorage.setItem('token', 'valid')
+    localStorage.setItem('user', JSON.stringify({ dni: 'X' }))
+    await expect(handler(error)).rejects.toBe(error)
+    expect(localStorage.getItem('token')).toBe('valid')
   })
 })

--- a/frontend/src/stores/auth.js
+++ b/frontend/src/stores/auth.js
@@ -5,6 +5,12 @@ const CACHE_KEY = 'offline_session_cache'
 const DEFAULT_OFFLINE_GRACE_DAYS = 14
 const MAX_OFFLINE_GRACE_DAYS = 365
 
+export const LOGIN_ERROR_NO_CONNECTION =
+  'Estás sin conexión. Necesitamos señal para validar el ingreso.'
+export const LOGIN_ERROR_BAD_CREDENTIALS = 'DNI o contraseña incorrectos'
+export const LOGIN_ERROR_SERVER =
+  'No se pudo conectar con el servidor. Intenta nuevamente en unos minutos.'
+
 function isTokenExpired(token) {
   if (!token) return true
   try {
@@ -81,6 +87,79 @@ export function clearOfflineSessionCache() {
   }
 }
 
+/**
+ * Map an axios login error to a non-leaky, operator-friendly message.
+ *
+ * Priority:
+ *  1. No HTTP response (network/DNS/CORS/aborted): operator is offline.
+ *  2. 401: wrong DNI or password.
+ *  3. 5xx: backend in trouble; never surface backend detail (sql, pymysql, etc.).
+ *  4. 4xx other than 401: try the backend `detail` only if it's a short string
+ *     (≤120 chars) that doesn't look technical. Otherwise, generic.
+ *  5. Fallback: generic "no se pudo conectar".
+ */
+export function classifyLoginError(err) {
+  if (!err || typeof err !== 'object') {
+    return LOGIN_ERROR_SERVER
+  }
+
+  const status = err.response?.status
+  const response = err.response
+
+  if (!response) {
+    return LOGIN_ERROR_NO_CONNECTION
+  }
+
+  if (status === 401) {
+    return LOGIN_ERROR_BAD_CREDENTIALS
+  }
+
+  if (status >= 500) {
+    return LOGIN_ERROR_SERVER
+  }
+
+  if (status >= 400) {
+    const detail = response.data?.detail
+    if (
+      typeof detail === 'string' &&
+      detail.length > 0 &&
+      detail.length <= 120 &&
+      !looksTechnical(detail)
+    ) {
+      return detail
+    }
+    return LOGIN_ERROR_SERVER
+  }
+
+  return LOGIN_ERROR_SERVER
+}
+
+const TECH_PATTERNS = [
+  /sqlalchemy/i,
+  /pymysql/i,
+  /mysql/i,
+  /operationalerror/i,
+  /programmingerror/i,
+  /internalerror/i,
+  /traceback/i,
+  /select\s+/i,
+  /insert\s+/i,
+  /update\s+/i,
+  /delete\s+from/i,
+  /\bstack\b/i,
+  /\btrace\b/i,
+  /exception/i,
+  /errno/i,
+  /null\s+value/i,
+  /column\s+/i,
+  /table\s+/i,
+  /password_hash/i,
+]
+
+function looksTechnical(text) {
+  return TECH_PATTERNS.some((re) => re.test(text))
+}
+
 export const useAuthStore = defineStore('auth', {
   state: () => ({
     user: JSON.parse(localStorage.getItem('user') || 'null'),
@@ -106,7 +185,11 @@ export const useAuthStore = defineStore('auth', {
       this.loading = true
       this.error = null
       try {
-        const { data } = await api.post('/api/auth/login', { dni, password })
+        const { data } = await api.post(
+          '/api/auth/login',
+          { dni, password },
+          { _suppressErrorToast: true },
+        )
         this.token = data.access_token
         this.user = data.user
         this.offlineMode = false
@@ -116,11 +199,7 @@ export const useAuthStore = defineStore('auth', {
         await this.cacheSession(password)
         return true
       } catch (err) {
-        if (err.response?.status === 401) {
-          this.error = 'DNI o contraseña incorrectos'
-        } else {
-          this.error = 'Error de conexión con el servidor'
-        }
+        this.error = classifyLoginError(err)
         return false
       } finally {
         this.loading = false

--- a/frontend/src/stores/auth.test.js
+++ b/frontend/src/stores/auth.test.js
@@ -15,6 +15,10 @@ import {
   clearOfflineSessionCache,
   readOfflineSessionCache,
   readOfflineGracePeriodDays,
+  classifyLoginError,
+  LOGIN_ERROR_BAD_CREDENTIALS,
+  LOGIN_ERROR_NO_CONNECTION,
+  LOGIN_ERROR_SERVER,
 } from './auth'
 
 const CACHE_KEY = 'offline_session_cache'
@@ -191,7 +195,7 @@ describe('auth store / login error messages', () => {
     const store = useAuthStore()
     const ok = await store.login('12345678', 'wrong')
     expect(ok).toBe(false)
-    expect(store.error).toBe('DNI o contraseña incorrectos')
+    expect(store.error).toBe(LOGIN_ERROR_BAD_CREDENTIALS)
   })
 
   it('keeps generic connection error for non-401 failures', async () => {
@@ -200,7 +204,108 @@ describe('auth store / login error messages', () => {
     const ok = await store.login('12345678', 'whatever')
     expect(ok).toBe(false)
     // The store keeps its non-leaky message even when backend returns garbage.
-    expect(store.error).toBe('Error de conexión con el servidor')
+    expect(store.error).toBe(LOGIN_ERROR_SERVER)
     expect(store.error).not.toMatch(/pymysql/i)
+  })
+
+  it('uses the no-connection message when axios has no response (offline)', async () => {
+    api.post.mockRejectedValueOnce({ message: 'Network Error' })
+    const store = useAuthStore()
+    const ok = await store.login('12345678', 'whatever')
+    expect(ok).toBe(false)
+    expect(store.error).toBe(LOGIN_ERROR_NO_CONNECTION)
+  })
+
+  it('passes _suppressErrorToast: true on the login request', async () => {
+    api.post.mockResolvedValueOnce({
+      data: {
+        access_token: fakeJwt(Math.floor(Date.now() / 1000) + 3600),
+        user: { idPersonal: 1, dni: '1', nombre: 'X', is_admin: 0 },
+      },
+    })
+    const store = useAuthStore()
+    await store.login('1', 'p')
+    expect(api.post).toHaveBeenCalledWith(
+      '/api/auth/login',
+      { dni: '1', password: 'p' },
+      expect.objectContaining({ _suppressErrorToast: true }),
+    )
+  })
+
+  it('uses backend detail on 4xx only when detail is short and non-technical', async () => {
+    api.post.mockRejectedValueOnce({
+      response: { status: 400, data: { detail: 'La contrasena es muy corta' } },
+    })
+    const store = useAuthStore()
+    await store.login('1', 'x')
+    expect(store.error).toBe('La contrasena es muy corta')
+  })
+
+  it('rejects technical-looking 4xx details to avoid leaks', async () => {
+    api.post.mockRejectedValueOnce({
+      response: {
+        status: 400,
+        data: {
+          detail:
+            "pymysql.err.OperationalError: (2013, 'Lost connection to MySQL server')",
+        },
+      },
+    })
+    const store = useAuthStore()
+    await store.login('1', 'x')
+    expect(store.error).toBe(LOGIN_ERROR_SERVER)
+    expect(store.error).not.toMatch(/pymysql/i)
+  })
+})
+
+describe('classifyLoginError', () => {
+  it('returns no-connection when there is no response object', () => {
+    expect(classifyLoginError({ message: 'Network Error' })).toBe(
+      LOGIN_ERROR_NO_CONNECTION,
+    )
+    expect(classifyLoginError(null)).toBe(LOGIN_ERROR_SERVER)
+  })
+
+  it('returns bad-credentials for 401', () => {
+    expect(
+      classifyLoginError({ response: { status: 401, data: { detail: 'X' } } }),
+    ).toBe(LOGIN_ERROR_BAD_CREDENTIALS)
+  })
+
+  it('returns server for 5xx and never echoes detail', () => {
+    expect(
+      classifyLoginError({
+        response: {
+          status: 503,
+          data: { detail: "SELECT * FROM usuarios WHERE password_hash = 'x'" },
+        },
+      }),
+    ).toBe(LOGIN_ERROR_SERVER)
+  })
+
+  it('echoes backend detail on 4xx only when it looks user-friendly', () => {
+    expect(
+      classifyLoginError({
+        response: { status: 400, data: { detail: 'DNI invalido' } },
+      }),
+    ).toBe('DNI invalido')
+  })
+
+  it('ignores overly long backend detail to avoid weird UI', () => {
+    const huge = 'x'.repeat(200)
+    expect(
+      classifyLoginError({ response: { status: 400, data: { detail: huge } } }),
+    ).toBe(LOGIN_ERROR_SERVER)
+  })
+
+  it('ignores technical-looking strings even when short', () => {
+    expect(
+      classifyLoginError({
+        response: {
+          status: 400,
+          data: { detail: 'INSERT INTO foo (password_hash) VALUES (1)' },
+        },
+      }),
+    ).toBe(LOGIN_ERROR_SERVER)
   })
 })

--- a/frontend/src/views/LoginView.vue
+++ b/frontend/src/views/LoginView.vue
@@ -27,6 +27,17 @@
             <p class="mt-2 text-sm text-neutral-500">Ingresa con tu DNI y contraseña para continuar con el registro de producción.</p>
 
             <form @submit.prevent="handleLogin" class="mt-8 space-y-4">
+              <div
+                v-if="offlineNow"
+                class="flex items-center gap-2 rounded-lg bg-amber-100 p-3 text-sm text-amber-900"
+                data-testid="offline-banner"
+                role="status"
+                aria-live="polite"
+              >
+                <AppIcon name="offline" class="shrink-0 text-amber-700" />
+                <span>Estás sin conexión. Si ya iniciaste sesión, podés seguir trabajando con los datos guardados.</span>
+              </div>
+
               <div>
                 <label for="desktop-dni" class="mb-1.5 block text-sm font-bold text-neutral-700">DNI</label>
                 <input
@@ -69,14 +80,37 @@
 
               <div
                 v-if="authStore.error"
-                class="flex items-center gap-2 rounded-lg bg-error-light p-3 text-sm text-error-dark"
+                :class="[
+                  'flex items-start gap-2 rounded-lg p-3 text-sm',
+                  errorCategory === 'offline'
+                    ? 'bg-amber-100 text-amber-900'
+                    : errorCategory === 'credentials'
+                      ? 'bg-error-light text-error-dark'
+                      : 'bg-error-light text-error-dark',
+                ]"
+                data-testid="login-error"
+                role="alert"
               >
-                <AppIcon name="error" class="shrink-0 text-error" />
-                <span>{{ authStore.error }}</span>
+                <AppIcon
+                  :name="errorCategory === 'offline' ? 'offline' : 'error'"
+                  :class="['shrink-0', errorCategory === 'offline' ? 'text-amber-700 mt-0.5' : 'text-error mt-0.5']"
+                />
+                <div class="min-w-0 flex-1">
+                  <p class="font-bold">
+                    {{
+                      errorCategory === 'offline'
+                        ? 'Sin conexión'
+                        : errorCategory === 'credentials'
+                          ? 'Credenciales incorrectas'
+                          : 'No se pudo validar el ingreso'
+                    }}
+                  </p>
+                  <p class="mt-0.5 text-xs">{{ authStore.error }}</p>
+                </div>
               </div>
 
               <div
-                v-if="offlineNotice"
+                v-if="offlineNotice && !authStore.error"
                 class="flex items-center gap-2 rounded-lg bg-amber-100 p-3 text-sm text-amber-900"
                 role="status"
                 aria-live="polite"
@@ -140,6 +174,17 @@
           <p class="mt-1 text-sm text-neutral-500">Ingresa con tu DNI y contraseña para continuar.</p>
 
           <form @submit.prevent="handleLogin" class="mt-6 space-y-4">
+            <div
+              v-if="offlineNow"
+              class="flex items-center gap-2 rounded-lg bg-amber-100 p-3 text-sm text-amber-900"
+              data-testid="offline-banner"
+              role="status"
+              aria-live="polite"
+            >
+              <AppIcon name="offline" class="shrink-0 text-amber-700" />
+              <span>Estás sin conexión. Si ya iniciaste sesión, podés seguir trabajando con los datos guardados.</span>
+            </div>
+
             <div>
               <label for="mobile-dni" class="mb-1.5 block text-sm font-bold text-neutral-700">DNI</label>
               <input
@@ -182,14 +227,35 @@
 
             <div
               v-if="authStore.error"
-              class="flex items-center gap-2 rounded-lg bg-error-light p-3 text-sm text-error-dark"
+              :class="[
+                'flex items-start gap-2 rounded-lg p-3 text-sm',
+                errorCategory === 'offline'
+                  ? 'bg-amber-100 text-amber-900'
+                  : 'bg-error-light text-error-dark',
+              ]"
+              data-testid="login-error"
+              role="alert"
             >
-              <AppIcon name="error" class="shrink-0 text-error" />
-              <span>{{ authStore.error }}</span>
+              <AppIcon
+                :name="errorCategory === 'offline' ? 'offline' : 'error'"
+                :class="['shrink-0', errorCategory === 'offline' ? 'text-amber-700 mt-0.5' : 'text-error mt-0.5']"
+              />
+              <div class="min-w-0 flex-1">
+                <p class="font-bold">
+                  {{
+                    errorCategory === 'offline'
+                      ? 'Sin conexión'
+                      : errorCategory === 'credentials'
+                        ? 'Credenciales incorrectas'
+                        : 'No se pudo validar el ingreso'
+                  }}
+                </p>
+                <p class="mt-0.5 text-xs">{{ authStore.error }}</p>
+              </div>
             </div>
 
             <div
-              v-if="offlineNotice"
+              v-if="offlineNotice && !authStore.error"
               class="flex items-center gap-2 rounded-lg bg-amber-100 p-3 text-sm text-amber-900"
               role="status"
               aria-live="polite"
@@ -235,9 +301,14 @@
 </template>
 
 <script setup>
-import { onMounted, ref } from 'vue'
+import { computed, onMounted, onUnmounted, ref } from 'vue'
 import { useRouter, useRoute } from 'vue-router'
-import { useAuthStore } from '@/stores/auth'
+import {
+  useAuthStore,
+  LOGIN_ERROR_BAD_CREDENTIALS,
+  LOGIN_ERROR_NO_CONNECTION,
+  LOGIN_ERROR_SERVER,
+} from '@/stores/auth'
 import AppIcon from '@/components/ui/AppIcon.vue'
 
 const router = useRouter()
@@ -249,12 +320,31 @@ const password = ref('')
 const showPassword = ref(false)
 const syncMessage = ref('')
 const offlineNotice = ref('')
+const offlineNow = ref(typeof navigator !== 'undefined' && navigator.onLine === false)
 
-function isOffline() {
-  return typeof navigator !== 'undefined' && navigator.onLine === false
+function updateOnlineStatus() {
+  offlineNow.value =
+    typeof navigator !== 'undefined' && navigator.onLine === false
 }
 
+function isOffline() {
+  return offlineNow.value
+}
+
+const errorCategory = computed(() => {
+  const err = authStore.error
+  if (!err) return null
+  if (err === LOGIN_ERROR_NO_CONNECTION) return 'offline'
+  if (err === LOGIN_ERROR_BAD_CREDENTIALS) return 'credentials'
+  if (err === LOGIN_ERROR_SERVER) return 'server'
+  return 'other'
+})
+
 onMounted(() => {
+  updateOnlineStatus()
+  window.addEventListener('online', updateOnlineStatus)
+  window.addEventListener('offline', updateOnlineStatus)
+
   // If the operator landed on /login with a cached offline session still valid,
   // send them straight to home. They are already authenticated, just without
   // network — they should not have to retype credentials.
@@ -276,6 +366,11 @@ onMounted(() => {
   }
 })
 
+onUnmounted(() => {
+  window.removeEventListener('online', updateOnlineStatus)
+  window.removeEventListener('offline', updateOnlineStatus)
+})
+
 async function handleSync() {
   syncMessage.value = ''
   const result = await authStore.sincronizar()
@@ -288,21 +383,12 @@ async function handleSync() {
 async function handleLogin() {
   syncMessage.value = ''
   offlineNotice.value = ''
-  if (!isOffline()) {
-    authStore.error = null
-  }
+  authStore.error = null
   const success = await authStore.login(dni.value, password.value)
   if (success) {
     authStore.clearOfflineCache()
     const redirect = typeof route.query.redirect === 'string' ? route.query.redirect : null
     router.push(redirect ? { path: redirect } : { name: 'home' })
-    return
-  }
-  // If we are offline and login failed (no backend reachable), give a
-  // friendlier hint than the default toast.
-  if (isOffline() && authStore.error === 'Error de conexión con el servidor') {
-    authStore.error =
-      'Estás sin conexión. Necesitamos señal para validar el ingreso.'
   }
 }
 </script>


### PR DESCRIPTION
## Objetivo

Closes #51 (cierra también parcialmente el #24 — mensajes 5xx ya no leaken SQL/trazas)

Cuando el operador intenta login y algo falla, la pantalla de Login debe decirle **claramente qué pasó**:
- "Estás sin conexión" si está en el campo sin señal.
- "DNI o contraseña incorrectos" si escribió mal la credencial.
- "No se pudo conectar con el servidor" si el backend está caído (sin filtrar SQL ni stack traces).

## Cambios

- `frontend/src/stores/auth.js`
  - Nuevo helper `classifyLoginError(err)` que centraliza el mapeo axios error → mensaje amigable para el operador.
  - Constantes exportadas: `LOGIN_ERROR_NO_CONNECTION`, `LOGIN_ERROR_BAD_CREDENTIALS`, `LOGIN_ERROR_SERVER`.
  - `classifyLoginError()` rechaza eco de `data.detail` si es muy largo (>120 chars) o si luce técnico (regex sobre `pymysql`/`sqlalchemy`/`INSERT`/`SELECT`/`column`/`table`/`traceback`/`password_hash`/etc.).
  - `login()` ahora pasa `_suppressErrorToast: true` en el config para evitar el toast global duplicado.

- `frontend/src/services/api.js`
  - El interceptor de respuesta respeta el flag `_suppressErrorToast` (skipea todos los toasts).
  - Cubre 401 para requests no-login con un toast claro "Sesión expirada".
  - 5xx sigue usando `SERVER_ERROR_MESSAGE` (no leak), ahora también cuando es login (porque el flag lo silencia, pero por seguridad la rama 5xx del interceptor mantiene el genérico).

- `frontend/src/views/LoginView.vue`
  - Banner **amber persistente** "Estás sin conexión" arriba del formulario cuando `navigator.onLine === false`, escucha eventos online/offline.
  - Bloque de error con icono/color/título **diferenciado por categoría**:
    - `offline` → amber, icono offline, título "Sin conexión".
    - `credentials` → rojo, icono error, título "Credenciales incorrectas".
    - `server`/`other` → rojo, icono error, título "No se pudo validar el ingreso".
  - El subtítulo muestra `authStore.error` (texto amigable, sin SQL).

- Tests
  - `frontend/src/stores/auth.test.js` (+10) — clasificador, login payload, fallback técnico.
  - `frontend/src/services/api.test.js` reescrito (+6) — captura el handler del interceptor via mock de axios para testear 5xx, flag suppress, 401 cleanup, setUnauthorizedHandler.

## Tests / Validaciones

- [x] `git diff --check`
- [x] `npx vitest run` — **64/64 tests** (48 anteriores + 16 nuevos)
- [x] `npx vite build` — 9.59s, SW + manifest regenerados
- [x] sin nuevas warnings de CRLF en el diff

## Comportamiento por escenario

| Dispositivo | Status / error | Resultado visible |
|---|---|---|
| **Offline** | `err.response` undefined | Banner persistente + toast "Sin conexión" |
| Online, 401 | DNI mal | "Credenciales incorrectas" en rojo |
| Online, 5xx | Backend SQL leak | "No se pudo validar el ingreso" + sub "No se pudo conectar con el servidor…" (sin SQL) |
| Online, 400 corto | Backend dice "X inválido" | "No se pudo validar el ingreso" + sub "X inválido" (eco seguro) |
| Online, 400 técnico | Backend dice "INSERT INTO…" | Mensaje genérico, no se echo el SQL |
| Online, timeout | Sin response | "Sin conexión" (también mensaje amigable) |

## Fuera de alcance

- No se cambió el backend. El backend sigue mandando su `detail` técnico si quiere — el frontend ahora lo filtra para 5xx y para 4xx que luzca técnico.
- No se tocó el manejo 5xx fuera del flujo login (banner global). Eso entra en #34 si querés endurecer.

## Riesgos / pendientes

- El regex `looksTechnical` puede tener falsos positivos si el backend alguna vez manda un detail de 4xx que casualmente matchea (ej. "trace" en una palabra normal en español). Aceptable por ahora, se puede refinar en un follow-up.
- Si querés deshabilitar completamente la posibilidad de eco de 4xx detail, eso entra en hardening posterior. Hoy solo filtra técnicos.
