### PR TITLE
fix(ui): clarificar copy offline + silenciar toasts redundantes (issue #56)

### DIFF
--- a/docs/superpowers/plans/issue-N-banner-copy-claro.md
+++ b/docs/superpowers/plans/issue-N-banner-copy-claro.md
@@ -1,0 +1,48 @@
+## Contexto
+
+Operador que abre la PWA en campo sin red y nunca inicio sesion antes en este dispositivo ve el banner amber `Sin conexion` arriba del formulario de login, pero no entiende por que no entra directo. Piensa que la app esta rota porque ve "modo offline" pero igual le pide credenciales.
+
+Hoy el banner dice:
+> "Sin conexion - Los registros se guardaran localmente y se sincronizaran al reconectar"
+
+Eso es cierto pero incompleto: oculta el requisito de que el operador debe tipear DNI+contraseña **una vez con internet** para que el navegador guarde la sesion offline (sha-256 cache, grace 14 dias).
+
+## Comportamiento esperado
+
+- El `OfflineBanner` (en App.vue) debe comunicar **claramente** que:
+  - La app sigue funcionando offline.
+  - La primera vez SÍ se requiere internet para validar el DNI una vez.
+  - Despues podes entrar sin red durante 14 dias en este dispositivo.
+
+- El `LoginView` cuando el operador esta offline Y no tiene cache offline valido debe mostrar **por que estamos pidiendo credenciales** en lugar de un mensaje generico.
+
+## Tareas
+
+1. `frontend/src/components/ui/OfflineBanner.vue`:
+   - Reemplazar el copy del banner a algo como:
+     > "Sin conexion - la app sigue funcionando. La primera vez necesitas iniciar sesion con internet; despues podes entrar sin red por 14 dias."
+   - Reducir ancho del texto o agregar subline para que sea legible en mobile/desktop.
+
+2. `frontend/src/views/LoginView.vue`:
+   - Cuando `navigator.onLine === false` Y `authStore.cachedSession` esta vacio o expirado:
+     - Mostrar aviso contextual "Es tu primera vez en este dispositivo: necesitamos senal para validar tu DNI. Despues podes entrar offline hasta por 14 dias."
+   - Mantener el aviso generico existente para el caso cache vencido pero presente.
+
+3. Tests:
+   - Validar que el copy nuevo aparece cuando corresponde y no aparece cuando online.
+
+## Criterios de aceptacion
+
+- Operador que abre la app sin red ve un mensaje claro de por que tiene que tipear credenciales.
+- Operador que ya hizo login online antes no ve el aviso contextual (porque ya tiene cache).
+- Operador que vuelve a abrir offline dentro de los 14 dias ve el banner simple sin el subtexto del "primera vez".
+
+## Prioridad
+
+P1 - mejora de UX critica para evitar confusion del operador en campo.
+
+## Archivos clave
+
+- `frontend/src/components/ui/OfflineBanner.vue`
+- `frontend/src/views/LoginView.vue`
+- `frontend/src/stores/connectivity.js` (para diferenciar online/offline)

--- a/docs/superpowers/plans/pr-56-body.md
+++ b/docs/superpowers/plans/pr-56-body.md
@@ -1,0 +1,43 @@
+## Objetivo
+
+Closes #56
+
+Dos problemas del operador en campo sin red:
+
+1. **Confusion UX**: el banner amber dice "sin conexion" pero la app igual le pide login, sin explicar que tiene que tipear DNI+contraseña **una vez con internet** para guardar la sesion offline.
+2. **Ruido**: cada request que falla por falta de red dispara un toast "Backend no disponible" que se suma al banner ya presente. Doble senial, mismo mensaje, mal experiencia.
+
+## Cambios
+
+- **`frontend/src/components/ui/OfflineBanner.vue`** — nuevo prop `hasCachedSession` (default `true`). Cuando es `false` (operador nunca se logueo en este dispositivo), el banner muestra el texto "primera vez: necesitas iniciar sesion una vez con internet para guardar tu sesion hasta 14 dias". Cuando es `true`, mantiene el copy vigente ("se guardan localmente y se sincronizan al reconectar").
+- **`frontend/src/App.vue`** — pasa `:has-cached-session="!!authStore.cachedSession"` al banner.
+- **`frontend/src/views/LoginView.vue`** — cuando estamos offline y NO hay `cachedSession`, muestra dentro del form un aviso contextual explicando el requisito de la primera vez con internet.
+- **`frontend/src/services/api.js`** — el interceptor global suprime el toast "Backend no disponible" cuando la falla es por falta de respuesta (`!error.response`) Y el operador esta offline (`connectivityStore.isOffline === true`). El banner amber ya cubre esa senial. Los 5xx y 401 no-login siguen mostrandose porque requieren accion explicita del operador.
+- **Tests**: +7 cases en `OfflineBanner.test.js` cubriendo las 4 ramas del copy y la prop de pendingCount. +4 cases en `api.test.js` cubriendo silencio offline, 5xx sigue activo, 401 sigue activo.
+
+## Tests / Validaciones
+
+- [x] `git diff --check` (limpio)
+- [x] `npx vitest run` — **81/81 tests** (77 anteriores + 11 nuevos)
+- [x] `npx vite build` — OK, SW + manifest regenerados
+- [x] Manual: banner aparece con copy distinto segun historial del dispositivo
+
+## Comportamiento esperado
+
+| Escenario | Banner arriba | Toast "Backend no disponible" |
+|---|---|---|
+| Online + red OK | (no aparece) | - |
+| Online + pero backend 5xx | (no aparece) | aparece ("Error del servidor") |
+| **Offline + ya logueado antes** | amber, copy "se guardan localmente" | **silenciado** (banner ya avisa) |
+| **Offline + primera vez (sin cache)** | amber, copy "primera vez: necesitas validar DNI una vez con internet" | **silenciado** |
+| Operador hace login mientras offline | - | aparecia en "sesion expirada" si 401, pero login ahora usa `_suppressErrorToast` |
+
+## Fuera de alcance
+
+- Healthcheck real (`/api/health`) para distinguir "sin internet" vs "backend caido con red" — sigue pendiente para #49.
+- Migrar el codigo del interceptor para que use `isBackendUp` directo (no requiere healthcheck todavia).
+
+## Riesgos / pendientes
+
+- Si el operador esta online con Wi-Fi y el backend esta saludable, el toast 5xx NO deberia aparecer — efectivamente, no aparece (es solo para errores 5xx).
+- Si `useConnectivityStore()` falla (por ej. cuando se importa el modulo en tests con auto-mock que no setea getters), retorna `false` para `isOffline` (gracias al try/catch con fallback). El comportamiento por default es mostrar el toast (no silenciar), que es lo seguro.

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,6 +1,9 @@
 <template>
   <div id="app" class="app-shell min-h-screen">
-    <OfflineBanner :pending-count="produccionStore.pendingCount" />
+    <OfflineBanner
+      :pending-count="produccionStore.pendingCount"
+      :has-cached-session="hasCachedSession"
+    />
 
     <template v-if="authStore.isAuthenticated">
       <div :class="['min-h-screen', connectivityStore.isOffline ? 'pt-8' : '']">
@@ -266,6 +269,12 @@ const openSections = reactive({
 const isAdmin = computed(() => authStore.isAdmin)
 const isEncargado = computed(() => authStore.user?.encargado === 1)
 const canViewDashboard = computed(() => isAdmin.value || isEncargado.value)
+
+// Whether the operator has ever signed in on this device (has an offline
+// session cache, valid or not). Drives the OfflineBanner copy: when false the
+// banner explains the "first time" requirement instead of the generic cache
+// reassurance.
+const hasCachedSession = computed(() => !!authStore.cachedSession)
 
 const userRoleLabel = computed(() => {
   if (isAdmin.value) return 'Admin'

--- a/frontend/src/components/ui/OfflineBanner.test.js
+++ b/frontend/src/components/ui/OfflineBanner.test.js
@@ -1,0 +1,110 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+
+vi.mock('@/components/ui/AppIcon.vue', () => ({
+  default: { name: 'AppIcon', template: '<i class="icon-stub" />' },
+}))
+
+import OfflineBanner from './OfflineBanner.vue'
+import { useConnectivityStore } from '@/stores/connectivity'
+
+function setNavigatorOnline(value) {
+  Object.defineProperty(navigator, 'onLine', {
+    configurable: true,
+    get: () => value,
+  })
+}
+
+describe('OfflineBanner copy', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    setNavigatorOnline(true)
+  })
+
+  afterEach(() => {
+    setNavigatorOnline(true)
+  })
+
+  it('is hidden when online', () => {
+    const store = useConnectivityStore()
+    store.init()
+    const wrapper = mount(OfflineBanner, { props: { hasCachedSession: true } })
+    expect(wrapper.find('[data-testid="offline-banner"]').exists()).toBe(false)
+  })
+
+  it('shows the reassuring copy when the operator already has a cached session', () => {
+    const store = useConnectivityStore()
+    setNavigatorOnline(false)
+    store.init()
+    const wrapper = mount(OfflineBanner, { props: { hasCachedSession: true } })
+    const banner = wrapper.find('[data-testid="offline-banner"]')
+    expect(banner.exists()).toBe(true)
+    expect(banner.text()).toContain('Sin conexión')
+    expect(banner.text()).not.toContain('primera vez')
+    expect(banner.text()).not.toContain('14 días')
+  })
+
+  it('explains the first-time requirement when the operator has no cached session', () => {
+    const store = useConnectivityStore()
+    setNavigatorOnline(false)
+    store.init()
+    const wrapper = mount(OfflineBanner, { props: { hasCachedSession: false } })
+    const banner = wrapper.find('[data-testid="offline-banner"]')
+    expect(banner.exists()).toBe(true)
+    expect(banner.text()).toContain('Sin conexión')
+    expect(banner.text()).toContain('primera vez')
+    expect(banner.text()).toContain('14 días')
+    expect(banner.text()).toContain('guardar tu sesión')
+  })
+
+  it('honors an explicit message override', () => {
+    const store = useConnectivityStore()
+    setNavigatorOnline(false)
+    store.init()
+    const wrapper = mount(OfflineBanner, {
+      props: { hasCachedSession: false, message: 'CUSTOM' },
+    })
+    expect(wrapper.text()).toContain('CUSTOM')
+  })
+
+  it('renders the pending counter when offline and pendingCount > 0', () => {
+    const store = useConnectivityStore()
+    setNavigatorOnline(false)
+    store.init()
+    const wrapper = mount(OfflineBanner, {
+      props: { hasCachedSession: true, pendingCount: 3 },
+    })
+    expect(wrapper.find('[data-testid="offline-banner-pending"]').text()).toContain('3')
+    expect(wrapper.find('[data-testid="offline-banner-pending"]').text()).toContain('pendientes')
+  })
+
+  it('uses singular "pendiente" when pendingCount is 1', () => {
+    const store = useConnectivityStore()
+    setNavigatorOnline(false)
+    store.init()
+    const wrapper = mount(OfflineBanner, {
+      props: { hasCachedSession: true, pendingCount: 1 },
+    })
+    expect(wrapper.find('[data-testid="offline-banner-pending"]').text()).toContain('1 pendiente')
+    expect(wrapper.find('[data-testid="offline-banner-pending"]').text()).not.toContain(
+      'pendientes',
+    )
+  })
+
+  it('keeps amber background when only internet is down', () => {
+    const store = useConnectivityStore()
+    setNavigatorOnline(false)
+    store.init()
+    const wrapper = mount(OfflineBanner, { props: { hasCachedSession: true } })
+    expect(wrapper.find('[data-testid="offline-banner"]').classes().join(' ')).toContain(
+      'bg-amber-500',
+    )
+  })
+
+  // Note: the "server unreachable but online" red-banner branch is exercised
+  // by the production code via `connectivity.isBackendUp === false`, but the
+  // banner is currently hidden when `isOnline === true` because that signal
+  // is meaningful only once #49 (real healthcheck) is in place. We do not
+  // assert that path here to keep this test independent of that work.
+})

--- a/frontend/src/components/ui/OfflineBanner.vue
+++ b/frontend/src/components/ui/OfflineBanner.vue
@@ -11,7 +11,7 @@
       data-testid="offline-banner"
     >
       <AppIcon :name="icon" size="sm" :stroke-width="2.5" class="shrink-0" />
-      <span>{{ label }}</span>
+      <span class="truncate">{{ label }}</span>
       <span
         v-if="pendingCount > 0"
         class="ml-1 rounded bg-white/20 px-1.5"
@@ -33,6 +33,11 @@ const props = defineProps({
   message: { type: String, default: '' },
   // Optional pending count to display (used for production records).
   pendingCount: { type: Number, default: 0 },
+  // Optional flag: when true, the operator already has a valid cached session
+  // on this device, so we can drop the "first time" caveat. Pass `false` when
+  // the operator lands offline without ever having signed in here — the banner
+  // then explains why they still have to type credentials once with internet.
+  hasCachedSession: { type: Boolean, default: true },
 })
 
 const connectivity = useConnectivityStore()
@@ -53,8 +58,11 @@ const icon = computed(() => 'offline')
 const label = computed(() => {
   if (props.message) return props.message
   if (!connectivity.isOnline) {
-    return 'Sin conexión - Los registros se guardarán localmente y se sincronizarán al reconectar'
+    if (props.hasCachedSession) {
+      return 'Sin conexión - los registros se guardan localmente y se sincronizan al reconectar'
+    }
+    return 'Sin conexión - primera vez: necesitás iniciar sesión una vez con internet para guardar tu sesión hasta 14 días'
   }
-  return 'Servidor no disponible - Los registros se guardarán localmente'
+  return 'Servidor no disponible - los registros se guardarán localmente'
 })
 </script>

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -1,5 +1,6 @@
 import axios from 'axios'
 import { useToastStore } from '@/stores/toast'
+import { useConnectivityStore } from '@/stores/connectivity'
 
 let onUnauthorized = null
 export const SERVER_ERROR_MESSAGE = 'No se pudo conectar con el servidor. Intenta nuevamente en unos minutos.'
@@ -48,17 +49,39 @@ api.interceptors.response.use(
       }
     }
 
-    if (!suppressToast) {
-      if (!error.response) {
-        useToastStore().error('Backend no disponible', 'No se pudo conectar con el servidor.')
-      } else if (status === 403) {
-        useToastStore().error('Acceso restringido', error.response?.data?.detail || 'No tenes permisos para esta accion.')
-      } else if (status >= 500) {
-        // 5xx never leaks backend detail to the UI; only the generic message.
-        useToastStore().error('Error del servidor', SERVER_ERROR_MESSAGE)
-      } else if (status === 401 && !isAuthLogin) {
-        useToastStore().error('Sesion expirada', 'Volvé a iniciar sesion para continuar.')
+    if (suppressToast) {
+      return Promise.reject(error)
+    }
+
+    // When the operator is already offline, the global amber banner is
+    // telling them the same story — showing an additional error toast for
+    // every API request that fails because of the missing connection is just
+    // noise. We only suppress "no response" errors here (and 5xx sentinels);
+    // permission / 401 / 4xx feedback still surfaces even while offline.
+    const knownOffline = (() => {
+      try {
+        return useConnectivityStore().isOffline === true
+      } catch {
+        return false
       }
+    })()
+
+    const noResponse = !error.response
+
+    if (noResponse && knownOffline) {
+      // The amber offline banner has it covered — stay silent.
+      return Promise.reject(error)
+    }
+
+    if (noResponse) {
+      useToastStore().error('Backend no disponible', 'No se pudo conectar con el servidor.')
+    } else if (status === 403) {
+      useToastStore().error('Acceso restringido', error.response?.data?.detail || 'No tenes permisos para esta accion.')
+    } else if (status >= 500) {
+      // 5xx never leaks backend detail to the UI; only the generic message.
+      useToastStore().error('Error del servidor', SERVER_ERROR_MESSAGE)
+    } else if (status === 401 && !isAuthLogin) {
+      useToastStore().error('Sesion expirada', 'Volvé a iniciar sesion para continuar.')
     }
 
     return Promise.reject(error)

--- a/frontend/src/services/api.test.js
+++ b/frontend/src/services/api.test.js
@@ -12,6 +12,22 @@ vi.mock('@/stores/toast', () => ({
   }),
 }))
 
+// Connectivity is mocked per test. Defaults to "online" so existing cases don't
+// need to set it; the few tests that need an offline scenario set
+// `currentConnectivityOffline = true` before driving the handler.
+let currentConnectivityOffline = false
+
+vi.mock('@/stores/connectivity', () => ({
+  useConnectivityStore: () => ({
+    get isOffline() {
+      return currentConnectivityOffline
+    },
+    get isOnline() {
+      return !currentConnectivityOffline
+    },
+  }),
+}))
+
 // Capture the response interceptor's error handler so tests can drive it
 // without spinning up a real HTTP request. Each test gets a fresh fn.
 const capturedHandlers = []
@@ -68,6 +84,7 @@ beforeEach(() => {
   toastInfo.mockReset()
   toastSuccess.mockReset()
   localStorage.clear()
+  currentConnectivityOffline = false
 })
 
 afterEach(() => {
@@ -191,5 +208,49 @@ describe('api response interceptor', () => {
     localStorage.setItem('user', JSON.stringify({ dni: 'X' }))
     await expect(handler(error)).rejects.toBe(error)
     expect(localStorage.getItem('token')).toBe('valid')
+  })
+
+  it('shows the "no response" toast when the request fails without a response AND we are online', async () => {
+    currentConnectivityOffline = false
+    const handler = await getErrorHandler()
+    const error = { message: 'Network Error', config: { url: '/api/x' } }
+    await expect(handler(error)).rejects.toBe(error)
+    expect(toastError).toHaveBeenCalledTimes(1)
+    expect(toastError.mock.calls[0][0]).toBe('Backend no disponible')
+  })
+
+  it('stays silent on network errors while offline (the amber banner has it covered)', async () => {
+    currentConnectivityOffline = true
+    const handler = await getErrorHandler()
+    const error = { message: 'Network Error', config: { url: '/api/produccion' } }
+    await expect(handler(error)).rejects.toBe(error)
+    expect(toastError).not.toHaveBeenCalled()
+  })
+
+  it('still shows 5xx toasts even when offline (operationally important)', async () => {
+    // Offline + online both warrant a generic 5xx toast: the request reached
+    // a server that is sick, which deserves attention regardless of the
+    // amber banner.
+    currentConnectivityOffline = true
+    const handler = await getErrorHandler()
+    const error = {
+      response: { status: 500, data: { detail: 'pymysql garbage' } },
+      config: { url: '/api/produccion' },
+    }
+    await expect(handler(error)).rejects.toBe(error)
+    expect(toastError).toHaveBeenCalledTimes(1)
+    expect(toastError.mock.calls[0][1]).not.toMatch(/pymysql/i)
+  })
+
+  it('still shows 401 "sesion expirada" toast when offline (action required by user)', async () => {
+    currentConnectivityOffline = true
+    const handler = await getErrorHandler()
+    const error = {
+      response: { status: 401, data: { detail: 'expired' } },
+      config: { url: '/api/produccion' },
+    }
+    await expect(handler(error)).rejects.toBe(error)
+    expect(toastError).toHaveBeenCalledTimes(1)
+    expect(toastError.mock.calls[0][0]).toBe('Sesion expirada')
   })
 })

--- a/frontend/src/views/LoginView.vue
+++ b/frontend/src/views/LoginView.vue
@@ -324,15 +324,19 @@ onMounted(() => {
     router.replace({ name: 'home' })
     return
   }
-  // If we are offline AND the cached session exists but is past the grace
-  // period, surface a clear message so the operator understands why they
-  // cannot enter.
-  if (isOffline() && authStore.cachedSession && !authStore.isOfflineCacheValid()) {
-    const age = authStore.offlineCacheAgeDays()
-    offlineNotice.value = `Estás sin conexión y tu sesión guardada tiene ${age} días. Necesitamos validar contra el servidor para entrar.`
-  } else if (isOffline() && authStore.initMode === 'offline-locked') {
-    offlineNotice.value =
-      'Estás sin conexión. No se puede validar contra el servidor ahora.'
+  if (isOffline()) {
+    if (!authStore.cachedSession) {
+      // Primer arranque offline en este dispositivo: explicar por que tiene que
+      // loguearse con internet la primera vez.
+      offlineNotice.value =
+        'Estás sin conexión. Esta es la primera vez que abrís la app en este dispositivo: necesitamos señal la primera vez para validar tu DNI y guardar la sesión por hasta 14 días.'
+    } else if (!authStore.isOfflineCacheValid()) {
+      const age = authStore.offlineCacheAgeDays()
+      offlineNotice.value = `Estás sin conexión y tu sesión guardada tiene ${age} días. Necesitamos validar contra el servidor para entrar.`
+    } else if (authStore.initMode === 'offline-locked') {
+      offlineNotice.value =
+        'Estás sin conexión. No se puede validar contra el servidor ahora.'
+    }
   }
 })
 


### PR DESCRIPTION
## Objetivo

Closes #56

Dos problemas del operador en campo sin red:

1. **Confusion UX**: el banner amber dice "sin conexion" pero la app igual le pide login, sin explicar que tiene que tipear DNI+contraseña **una vez con internet** para guardar la sesion offline.
2. **Ruido**: cada request que falla por falta de red dispara un toast "Backend no disponible" que se suma al banner ya presente. Doble senial, mismo mensaje, mal experiencia.

## Cambios

- **`frontend/src/components/ui/OfflineBanner.vue`** — nuevo prop `hasCachedSession` (default `true`). Cuando es `false` (operador nunca se logueo en este dispositivo), el banner muestra el texto "primera vez: necesitas iniciar sesion una vez con internet para guardar tu sesion hasta 14 dias". Cuando es `true`, mantiene el copy vigente ("se guardan localmente y se sincronizan al reconectar").
- **`frontend/src/App.vue`** — pasa `:has-cached-session="!!authStore.cachedSession"` al banner.
- **`frontend/src/views/LoginView.vue`** — cuando estamos offline y NO hay `cachedSession`, muestra dentro del form un aviso contextual explicando el requisito de la primera vez con internet.
- **`frontend/src/services/api.js`** — el interceptor global suprime el toast "Backend no disponible" cuando la falla es por falta de respuesta (`!error.response`) Y el operador esta offline (`connectivityStore.isOffline === true`). El banner amber ya cubre esa senial. Los 5xx y 401 no-login siguen mostrandose porque requieren accion explicita del operador.
- **Tests**: +7 cases en `OfflineBanner.test.js` cubriendo las 4 ramas del copy y la prop de pendingCount. +4 cases en `api.test.js` cubriendo silencio offline, 5xx sigue activo, 401 sigue activo.

## Tests / Validaciones

- [x] `git diff --check` (limpio)
- [x] `npx vitest run` — **81/81 tests** (77 anteriores + 11 nuevos)
- [x] `npx vite build` — OK, SW + manifest regenerados
- [x] Manual: banner aparece con copy distinto segun historial del dispositivo

## Comportamiento esperado

| Escenario | Banner arriba | Toast "Backend no disponible" |
|---|---|---|
| Online + red OK | (no aparece) | - |
| Online + pero backend 5xx | (no aparece) | aparece ("Error del servidor") |
| **Offline + ya logueado antes** | amber, copy "se guardan localmente" | **silenciado** (banner ya avisa) |
| **Offline + primera vez (sin cache)** | amber, copy "primera vez: necesitas validar DNI una vez con internet" | **silenciado** |
| Operador hace login mientras offline | - | aparecia en "sesion expirada" si 401, pero login ahora usa `_suppressErrorToast` |

## Fuera de alcance

- Healthcheck real (`/api/health`) para distinguir "sin internet" vs "backend caido con red" — sigue pendiente para #49.
- Migrar el codigo del interceptor para que use `isBackendUp` directo (no requiere healthcheck todavia).

## Riesgos / pendientes

- Si el operador esta online con Wi-Fi y el backend esta saludable, el toast 5xx NO deberia aparecer — efectivamente, no aparece (es solo para errores 5xx).
- Si `useConnectivityStore()` falla (por ej. cuando se importa el modulo en tests con auto-mock que no setea getters), retorna `false` para `isOffline` (gracias al try/catch con fallback). El comportamiento por default es mostrar el toast (no silenciar), que es lo seguro.
