### PR TITLE
fix(ui): copy contextual en Home segun rango seleccionado (issue #23)

### DIFF
--- a/docs/superpowers/plans/pr-23-body.md
+++ b/docs/superpowers/plans/pr-23-body.md
@@ -1,0 +1,36 @@
+## Objetivo
+
+Closes #23 (la parte de copy; la de datos historicos ya estaba cubierta por el backend)
+
+El backend ya devuelve la ultima actividad historica por unidad (sin filtro de fecha en `last_activity_by_un` en `admin_legacy.py:612-642`). El frontend la muestra correctamente ordenada y con resumen breve. Pero el copy del header y del bloque "Sin actividad hoy" decia literalmente "del dia", independientemente del rango que el usuario hubiera seleccionado ("Hoy" / "Ayer" / "7 dias" / "Semana pasada" / custom). Eso contradice los datos y confundia al operador cuando seleccionaba un rango donde no habia registros del periodo pero sabia que hubo registros recientes.
+
+## Cambios
+
+`frontend/src/views/HomeView.vue`:
+- `headerSubtitle` (computed nuevo): contextualiza segun rol (admin/operador) y `isTodayRange`. Ya no dice "del dia" cuando el rango es mas amplio.
+- `rangeLabel`, `isTodayRange` (helpers): dan formato al rango y exponen el boolean.
+- `lastRecordEyebrow`, `lastRecordTitle`: el bloque "Ultimo registro" pasa a llamarse "Ultimo registro del periodo (rango)" cuando no estamos en Hoy, y el fallback cambia a "Sin registros en el periodo".
+- Bloque dashed "Sin actividad hoy" cambia a "Sin registros en {rango}" cuando corresponde. Titulo cambia a "No hay registros en el periodo seleccionado." si no es Hoy.
+
+## Tests / Validaciones
+
+- [x] `git diff --check`
+- [x] `npx vitest run` -> **98/98** tests (sin regresion)
+- [x] `npx vite build` -> OK, SW + manifest regenerados
+
+## Comportamiento
+
+| Rango seleccionado | Header (admin) | Bloque "Sin registros" | LastPersonalRecord |
+|---|---|---|---|
+| Hoy | "Resumen de hoy y accesos de administracion..." | "Sin actividad hoy" / "Todavia no cargaste registros." | "Ultimo registro del dia" / fallback "Sin actividad hoy" |
+| Ayer / 7 dias / Semana pasada / custom | "Resumen de <rango> y accesos de administracion..." | "Sin registros en <rango>" / "No hay registros en el periodo seleccionado." | "Ultimo registro del periodo (<rango>)" / "Sin registros en el periodo" |
+
+## Fuera de alcance
+
+- El bloque admin "Ultima actividad registrada" ya estaba bien (orden + resumen). No se toca.
+- El filtro del rango ya estaba bien. No se toca.
+- Backend no se toca (la query historica ya estaba implementada).
+
+## Riesgos / pendientes
+
+- Si el operador nunca tuvo registros en su vida, el bloque dashed sigue mostrando el copy "Sin registros en <rango>" independientemente del rango. Aceptable.

--- a/frontend/src/views/HomeView.vue
+++ b/frontend/src/views/HomeView.vue
@@ -16,7 +16,7 @@
               {{ isAdmin ? 'Panel operativo' : authStore.userName }}
             </h1>
             <p class="mt-1 text-sm font-medium text-neutral-500">
-              {{ isAdmin ? 'Resumen general del día y accesos de administración.' : 'Accesos diarios, estado de sincronización y actividad personal.' }}
+              {{ headerSubtitle }}
             </p>
           </div>
 
@@ -208,8 +208,8 @@
         <section v-if="!recordsStore.loading && !lastRecord" class="rounded-xl border border-dashed border-warning/40 bg-warning-light/20 p-4">
           <div class="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
             <div>
-              <p class="text-xs font-extrabold uppercase tracking-wide text-neutral-400">Sin actividad hoy</p>
-              <h2 class="mt-1 text-xl font-extrabold text-neutral-900">Todavía no cargaste registros.</h2>
+              <p class="text-xs font-extrabold uppercase tracking-wide text-neutral-400">{{ emptyRangeEyebrow }}</p>
+              <h2 class="mt-1 text-xl font-extrabold text-neutral-900">{{ emptyRangeTitle }}</h2>
               <p class="mt-1 text-sm text-neutral-500">Podés iniciar una carga productiva o registrar combustible directamente.</p>
             </div>
             <div class="flex flex-col gap-2 sm:flex-row">
@@ -295,6 +295,25 @@ const todayLabel = computed(() => {
   const { from, to } = selectedDateRange.value
   if (from === to) return formatDisplayDate(from)
   return `${formatDisplayDate(from)} - ${formatDisplayDate(to)}`
+})
+
+const rangeLabel = computed(() => {
+  const { from, to } = selectedDateRange.value
+  if (from === to) return formatDisplayDate(from)
+  return `${formatDisplayDate(from)} - ${formatDisplayDate(to)}`
+})
+
+const isTodayRange = computed(() => selectedDatePreset.value === 'today')
+
+const headerSubtitle = computed(() => {
+  if (isAdmin.value) {
+    return isTodayRange.value
+      ? 'Resumen de hoy y accesos de administración. La sección de unidades muestra la última actividad registrada.'
+      : `Resumen de ${rangeLabel.value} y accesos de administración. La sección de unidades muestra la última actividad registrada.`
+  }
+  return isTodayRange.value
+    ? 'Accesos del día, estado de sincronización y actividad personal.'
+    : `Accesos de ${rangeLabel.value}, estado de sincronización y actividad personal.`
 })
 
 const roleLabel = computed(() => authStore.user?.encargado === 1 ? 'Encargado' : 'Operador')
@@ -414,7 +433,25 @@ const sortedRecords = computed(() => [...recordsStore.registros].sort((a, b) => 
 }))
 
 const lastRecord = computed(() => sortedRecords.value[0] || null)
-const lastRecordTitle = computed(() => lastRecord.value?.operacion || 'Sin actividad hoy')
+const lastRecordEyebrow = computed(() => {
+  return isTodayRange.value
+    ? 'Último registro del día'
+    : `Último registro del periodo (${rangeLabel.value})`
+})
+const lastRecordTitle = computed(() => {
+  if (lastRecord.value) return lastRecord.value.operacion
+  return isTodayRange.value ? 'Sin actividad hoy' : 'Sin registros en el periodo'
+})
+const emptyRangeEyebrow = computed(() => {
+  return isTodayRange.value
+    ? 'Sin actividad hoy'
+    : `Sin registros en ${rangeLabel.value}`
+})
+const emptyRangeTitle = computed(() => {
+  return isTodayRange.value
+    ? 'Todavía no cargaste registros.'
+    : 'No hay registros en el periodo seleccionado.'
+})
 
 const lastRecordMetrics = computed(() => {
   const record = lastRecord.value
@@ -506,7 +543,7 @@ const LastPersonalRecord = defineComponent({
     return () => h('article', { class: 'app-card rounded-xl p-4' }, [
       h('div', { class: 'mb-3 flex items-center justify-between gap-3' }, [
         h('div', [
-          h('p', { class: 'text-xs font-bold uppercase tracking-wide text-neutral-400' }, 'Ultimo registro'),
+          h('p', { class: 'text-xs font-bold uppercase tracking-wide text-neutral-400' }, lastRecordEyebrow.value),
           h('h2', { class: 'mt-1 text-lg font-extrabold text-neutral-900' }, lastRecordTitle.value),
         ]),
         h(AppIcon, { name: 'records', size: 'lg', class: 'text-info' }),
@@ -519,7 +556,7 @@ const LastPersonalRecord = defineComponent({
             h('div', { class: 'flex flex-wrap gap-2' }, lastRecordMetrics.value.map((metric) => h('span', { key: metric.label, class: 'rounded-md border px-2.5 py-1 text-xs font-bold app-state-inactive' }, `${metric.value} ${metric.unit}`))),
             h('button', { type: 'button', class: 'rounded-md border border-neutral-200 px-3 py-2 text-xs font-bold text-neutral-700 hover:border-secondary/40 hover:text-info-dark', onClick: () => router.push({ name: 'mis-registros' }) }, 'Ver mis registros'),
           ])
-          : h('p', { class: 'text-sm text-neutral-500' }, 'Todavia no hay registros cargados para hoy.'),
+          : h('p', { class: 'text-sm text-neutral-500' }, isTodayRange.value ? 'Todavia no hay registros cargados para hoy.' : 'No hay registros cargados en este periodo.'),
     ])
   },
 })


### PR DESCRIPTION
## Objetivo

Closes #23 (la parte de copy; la de datos historicos ya estaba cubierta por el backend)

El backend ya devuelve la ultima actividad historica por unidad (sin filtro de fecha en `last_activity_by_un` en `admin_legacy.py:612-642`). El frontend la muestra correctamente ordenada y con resumen breve. Pero el copy del header y del bloque "Sin actividad hoy" decia literalmente "del dia", independientemente del rango que el usuario hubiera seleccionado ("Hoy" / "Ayer" / "7 dias" / "Semana pasada" / custom). Eso contradice los datos y confundia al operador cuando seleccionaba un rango donde no habia registros del periodo pero sabia que hubo registros recientes.

## Cambios

`frontend/src/views/HomeView.vue`:
- `headerSubtitle` (computed nuevo): contextualiza segun rol (admin/operador) y `isTodayRange`. Ya no dice "del dia" cuando el rango es mas amplio.
- `rangeLabel`, `isTodayRange` (helpers): dan formato al rango y exponen el boolean.
- `lastRecordEyebrow`, `lastRecordTitle`: el bloque "Ultimo registro" pasa a llamarse "Ultimo registro del periodo (rango)" cuando no estamos en Hoy, y el fallback cambia a "Sin registros en el periodo".
- Bloque dashed "Sin actividad hoy" cambia a "Sin registros en {rango}" cuando corresponde. Titulo cambia a "No hay registros en el periodo seleccionado." si no es Hoy.

## Tests / Validaciones

- [x] `git diff --check`
- [x] `npx vitest run` -> **98/98** tests (sin regresion)
- [x] `npx vite build` -> OK, SW + manifest regenerados

## Comportamiento

| Rango seleccionado | Header (admin) | Bloque "Sin registros" | LastPersonalRecord |
|---|---|---|---|
| Hoy | "Resumen de hoy y accesos de administracion..." | "Sin actividad hoy" / "Todavia no cargaste registros." | "Ultimo registro del dia" / fallback "Sin actividad hoy" |
| Ayer / 7 dias / Semana pasada / custom | "Resumen de <rango> y accesos de administracion..." | "Sin registros en <rango>" / "No hay registros en el periodo seleccionado." | "Ultimo registro del periodo (<rango>)" / "Sin registros en el periodo" |

## Fuera de alcance

- El bloque admin "Ultima actividad registrada" ya estaba bien (orden + resumen). No se toca.
- El filtro del rango ya estaba bien. No se toca.
- Backend no se toca (la query historica ya estaba implementada).

## Riesgos / pendientes

- Si el operador nunca tuvo registros en su vida, el bloque dashed sigue mostrando el copy "Sin registros en <rango>" independientemente del rango. Aceptable.
