### PR TITLE
Fix personal autocomplete in unit relations

### DIFF
--- a/frontend/src/views/admin/AdminCrudView.test.js
+++ b/frontend/src/views/admin/AdminCrudView.test.js
@@ -2,8 +2,12 @@ import { flushPromises, mount } from '@vue/test-utils'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createPinia, setActivePinia } from 'pinia'
 
+const routeState = vi.hoisted(() => ({
+  params: { entity: 'tipos-proceso' },
+}))
+
 vi.mock('vue-router', () => ({
-  useRoute: () => ({ params: { entity: 'tipos-proceso' } }),
+  useRoute: () => routeState,
   useRouter: () => ({ replace: vi.fn() }),
 }))
 
@@ -22,6 +26,7 @@ import AdminCrudView from './AdminCrudView.vue'
 describe('AdminCrudView tipos de proceso', () => {
   beforeEach(() => {
     setActivePinia(createPinia())
+    routeState.params.entity = 'tipos-proceso'
     vi.clearAllMocks()
     api.get.mockResolvedValue({ data: [] })
     api.post.mockResolvedValue({ data: {} })
@@ -94,5 +99,61 @@ describe('AdminCrudView tipos de proceso', () => {
     expect(wrapper.text()).not.toContain('SELECT personal')
     expect(wrapper.text()).not.toContain('OperationalError')
     expect(wrapper.text()).not.toContain('Lost connection')
+  })
+
+  it('uses a searchable sorted autocomplete when adding personal to a business unit', async () => {
+    routeState.params.entity = 'unidades-negocio'
+    api.get.mockImplementation((url) => {
+      const dataByUrl = {
+        '/api/admin/unidades-negocio': [
+          { idUnidadNegocio: 1, nombre: 'COSECHA DELTA', prefijo: 'DELTA', activo: 1 },
+          { idUnidadNegocio: 2, nombre: 'TALLER', prefijo: 'TAL', activo: 1 },
+        ],
+        '/api/admin/personal': [
+          { idPersonal: 8, nombre: 'Zulu Operador', dni: '303', unidad_ids: [] },
+          { idPersonal: 7, nombre: 'Ana Alvarez', dni: '101', unidad_ids: [] },
+          { idPersonal: 9, nombre: 'Marcado Actual', dni: '909', unidad_ids: [1] },
+        ],
+        '/api/admin/moviles': [],
+        '/api/admin/tipos-proceso': [],
+      }
+      return Promise.resolve({ data: dataByUrl[url] || [] })
+    })
+
+    const wrapper = mount(AdminCrudView, {
+      global: {
+        directives: {
+          motionPanel: {},
+          motionPop: {},
+        },
+        stubs: {
+          AppIcon: true,
+        },
+      },
+    })
+    await flushPromises()
+
+    const relaciones = wrapper.findAll('button').find((button) => button.text().includes('Relaciones'))
+    expect(relaciones).toBeTruthy()
+    await relaciones.trigger('click')
+    await flushPromises()
+
+    const agregarPersonal = wrapper.findAll('button[title="Agregar Personal"]').at(0)
+    expect(agregarPersonal).toBeTruthy()
+    await agregarPersonal.trigger('click')
+    await flushPromises()
+
+    const input = wrapper.find('input[role="combobox"]')
+    expect(input.exists()).toBe(true)
+    expect(input.attributes('placeholder')).toBe('Buscar personal')
+
+    await input.trigger('focus')
+    await flushPromises()
+    const optionLabels = wrapper.findAll('[role="option"]').map((option) => option.text())
+    expect(optionLabels.slice(0, 2)).toEqual(['Ana Alvarez - DNI 101', 'Zulu Operador - DNI 303'])
+
+    await input.setValue('101')
+    await flushPromises()
+    expect(wrapper.findAll('[role="option"]').map((option) => option.text())).toEqual(['Ana Alvarez - DNI 101'])
   })
 })

--- a/frontend/src/views/admin/AdminCrudView.vue
+++ b/frontend/src/views/admin/AdminCrudView.vue
@@ -173,7 +173,20 @@
                   </div>
                 </div>
                 <div v-if="isRelationAdding(row[meta.idKey], block.key)" class="mb-2 flex gap-2">
+                  <AutocompleteField
+                    v-if="block.key === 'personal'"
+                    v-model="relationDraft.selectedId"
+                    class="min-w-0 flex-1"
+                    :items="relationAddOptions(row[meta.idKey], block.key)"
+                    labelKey="label"
+                    valueKey="id"
+                    placeholder="Buscar personal"
+                    selectedDisplay="input"
+                    dropdownMode="inline"
+                    emptyMessage="Sin personal disponible"
+                  />
                   <select
+                    v-else
                     v-model="relationDraft.selectedId"
                     class="app-input min-w-0 flex-1 rounded-md border px-2 py-1.5 text-sm"
                   >
@@ -337,7 +350,19 @@
                           </div>
                         </div>
                         <div v-if="isRelationAdding(row[meta.idKey], block.key)" class="mb-2 flex gap-2">
-                          <select v-model="relationDraft.selectedId" class="app-input min-w-0 flex-1 rounded-md border px-2 py-1.5 text-sm">
+                          <AutocompleteField
+                            v-if="block.key === 'personal'"
+                            v-model="relationDraft.selectedId"
+                            class="min-w-0 flex-1"
+                            :items="relationAddOptions(row[meta.idKey], block.key)"
+                            labelKey="label"
+                            valueKey="id"
+                            placeholder="Buscar personal"
+                            selectedDisplay="input"
+                            dropdownMode="inline"
+                            emptyMessage="Sin personal disponible"
+                          />
+                          <select v-else v-model="relationDraft.selectedId" class="app-input min-w-0 flex-1 rounded-md border px-2 py-1.5 text-sm">
                             <option value="">Seleccionar</option>
                             <option v-for="option in relationAddOptions(row[meta.idKey], block.key)" :key="option.id" :value="option.id">
                               {{ option.label }}
@@ -1240,12 +1265,15 @@ function unidadRelations(unidadId) {
   const personal = (referenceData.personal || [])
     .filter((item) => Array.isArray(item.unidad_ids) && item.unidad_ids.map(Number).includes(id))
     .map((item) => ({ id: item.idPersonal, label: item.nombre }))
+    .sort(compareRelationLabels)
   const moviles = (referenceData.moviles || [])
     .filter((item) => Number(item.id_unidad_negocio) === id)
     .map((item) => ({ id: item.idMovil, label: formatOptionLabel(item, { optionsEntity: 'moviles', optionLabel: 'detalle' }) }))
+    .sort(compareRelationLabels)
   const procesos = (referenceData['tipos-proceso'] || [])
     .filter((item) => Array.isArray(item.unidad_ids) && item.unidad_ids.map(Number).includes(id))
     .map((item) => ({ id: item.id, label: item.nombre }))
+    .sort(compareRelationLabels)
 
   return [
     { key: 'personal', title: 'Personal', items: personal, manageable: true },
@@ -1289,15 +1317,24 @@ function relationAddOptions(unidadId, type) {
     return (referenceData.personal || [])
       .filter((item) => !Array.isArray(item.unidad_ids) || !item.unidad_ids.map(Number).includes(id))
       .map((item) => ({ id: item.idPersonal, label: formatOptionLabel(item, { optionsEntity: 'personal', optionLabel: 'nombre' }) }))
+      .sort(compareRelationLabels)
   }
 
   if (type === 'moviles') {
     return (referenceData.moviles || [])
       .filter((item) => Number(item.id_unidad_negocio) !== id)
       .map((item) => ({ id: item.idMovil, label: formatOptionLabel(item, { optionsEntity: 'moviles', optionLabel: 'detalle' }) }))
+      .sort(compareRelationLabels)
   }
 
   return []
+}
+
+function compareRelationLabels(left, right) {
+  return String(left?.label || '').localeCompare(String(right?.label || ''), 'es', {
+    sensitivity: 'base',
+    numeric: true,
+  })
 }
 
 function relationMoveOptions(unidadId) {


### PR DESCRIPTION
## Qué cambia

- Reemplaza el selector largo de `Personal` en las relaciones de `/admin/crud/unidades-negocio` por `AutocompleteField`.
- Ordena de forma estable las opciones y los listados de relaciones por la etiqueta visible.
- Permite buscar personal por nombre o DNI visible al agregarlo a una unidad de negocio.

## Por qué

El selector anterior obligaba a recorrer una lista larga y desordenada para vincular personal desde una unidad de negocio. Esto hacía lenta la operación y aumentaba el riesgo de seleccionar una persona incorrecta.

Closes #64

## Validación

- `npm test -- AdminCrudView.test.js`
- `npm test`
- `npm run build`
