### PR TITLE
Fix vehicle autocomplete in unit relations

### DIFF
--- a/frontend/src/views/admin/AdminCrudView.test.js
+++ b/frontend/src/views/admin/AdminCrudView.test.js
@@ -156,4 +156,61 @@ describe('AdminCrudView tipos de proceso', () => {
     await flushPromises()
     expect(wrapper.findAll('[role="option"]').map((option) => option.text())).toEqual(['Ana Alvarez - DNI 101'])
   })
+
+  it('uses a searchable sorted autocomplete when adding a vehicle to a business unit', async () => {
+    routeState.params.entity = 'unidades-negocio'
+    api.get.mockImplementation((url) => {
+      const dataByUrl = {
+        '/api/admin/unidades-negocio': [
+          { idUnidadNegocio: 1, nombre: 'COSECHA DELTA', prefijo: 'DELTA', activo: 1 },
+        ],
+        '/api/admin/personal': [],
+        '/api/admin/moviles': [
+          { idMovil: 12, patente: 'ZZZ999', detalle: 'Zorra Forestal', id_unidad_negocio: 2 },
+          { idMovil: 10, patente: 'AAA111', detalle: 'Carreton Principal', id_unidad_negocio: 2 },
+          { idMovil: 11, patente: 'BBB222', detalle: 'Ya vinculado', id_unidad_negocio: 1 },
+        ],
+        '/api/admin/tipos-proceso': [],
+      }
+      return Promise.resolve({ data: dataByUrl[url] || [] })
+    })
+
+    const wrapper = mount(AdminCrudView, {
+      global: {
+        directives: {
+          motionPanel: {},
+          motionPop: {},
+        },
+        stubs: {
+          AppIcon: true,
+        },
+      },
+    })
+    await flushPromises()
+
+    const relaciones = wrapper.findAll('button').find((button) => button.text().includes('Relaciones'))
+    expect(relaciones).toBeTruthy()
+    await relaciones.trigger('click')
+    await flushPromises()
+
+    const agregarMovil = wrapper.findAll('button[title="Agregar Moviles"]').at(0)
+    expect(agregarMovil).toBeTruthy()
+    await agregarMovil.trigger('click')
+    await flushPromises()
+
+    const input = wrapper.find('input[role="combobox"]')
+    expect(input.exists()).toBe(true)
+    expect(input.attributes('placeholder')).toBe('Buscar movil')
+
+    await input.trigger('focus')
+    await flushPromises()
+    expect(wrapper.findAll('[role="option"]').map((option) => option.text())).toEqual([
+      'AAA111 - Carreton Principal',
+      'ZZZ999 - Zorra Forestal',
+    ])
+
+    await input.setValue('carreton')
+    await flushPromises()
+    expect(wrapper.findAll('[role="option"]').map((option) => option.text())).toEqual(['AAA111 - Carreton Principal'])
+  })
 })

--- a/frontend/src/views/admin/AdminCrudView.vue
+++ b/frontend/src/views/admin/AdminCrudView.vue
@@ -174,16 +174,16 @@
                 </div>
                 <div v-if="isRelationAdding(row[meta.idKey], block.key)" class="mb-2 flex gap-2">
                   <AutocompleteField
-                    v-if="block.key === 'personal'"
+                    v-if="usesRelationAutocomplete(block.key)"
                     v-model="relationDraft.selectedId"
                     class="min-w-0 flex-1"
                     :items="relationAddOptions(row[meta.idKey], block.key)"
                     labelKey="label"
                     valueKey="id"
-                    placeholder="Buscar personal"
+                    :placeholder="relationAutocompletePlaceholder(block.key)"
                     selectedDisplay="input"
                     dropdownMode="inline"
-                    emptyMessage="Sin personal disponible"
+                    :emptyMessage="relationAutocompleteEmptyMessage(block.key)"
                   />
                   <select
                     v-else
@@ -351,16 +351,16 @@
                         </div>
                         <div v-if="isRelationAdding(row[meta.idKey], block.key)" class="mb-2 flex gap-2">
                           <AutocompleteField
-                            v-if="block.key === 'personal'"
+                            v-if="usesRelationAutocomplete(block.key)"
                             v-model="relationDraft.selectedId"
                             class="min-w-0 flex-1"
                             :items="relationAddOptions(row[meta.idKey], block.key)"
                             labelKey="label"
                             valueKey="id"
-                            placeholder="Buscar personal"
+                            :placeholder="relationAutocompletePlaceholder(block.key)"
                             selectedDisplay="input"
                             dropdownMode="inline"
-                            emptyMessage="Sin personal disponible"
+                            :emptyMessage="relationAutocompleteEmptyMessage(block.key)"
                           />
                           <select v-else v-model="relationDraft.selectedId" class="app-input min-w-0 flex-1 rounded-md border px-2 py-1.5 text-sm">
                             <option value="">Seleccionar</option>
@@ -1296,6 +1296,20 @@ function startRelationAdd(unidadId, type) {
   relationDraft.type = type
   relationDraft.selectedId = ''
   relationDraft.targetUnidadId = ''
+}
+
+function usesRelationAutocomplete(type) {
+  return ['personal', 'moviles'].includes(type)
+}
+
+function relationAutocompletePlaceholder(type) {
+  if (type === 'moviles') return 'Buscar movil'
+  return 'Buscar personal'
+}
+
+function relationAutocompleteEmptyMessage(type) {
+  if (type === 'moviles') return 'Sin moviles disponibles'
+  return 'Sin personal disponible'
 }
 
 async function startRelationRemove(unidadId, type, selectedId) {


### PR DESCRIPTION
## Qué cambia

- Reemplaza el selector largo de `Moviles` en las relaciones de `/admin/crud/unidades-negocio` por `AutocompleteField`.
- Mantiene el autocomplete ya agregado para `Personal` en #64.
- Permite buscar moviles por patente o descripcion visible.
- Conserva el orden estable de opciones por etiqueta visible.

## Por qué

El selector anterior mostraba una lista larga de unidades/equipos/vehiculos y obligaba a recorrer manualmente opciones similares. Esto resolvia mal el flujo de vinculacion reportado en #63.

Closes #63

## PR apilado

Este PR tiene base `fix/issue-64-personal-autocomplete` porque ese cambio ya fue deployado manualmente a produccion y aun no esta mergeado a `main`. Asi evitamos revertir el #64 al deployar el #63.

## Validacion

- `npm test -- AdminCrudView.test.js`
- `npm test`
- `npm run build`
