### PR TITLE
Fix multiple business units for personal

### DIFF
--- a/backend/tests/test_deploy_scripts_contract.py
+++ b/backend/tests/test_deploy_scripts_contract.py
@@ -49,3 +49,31 @@ def test_windows_package_script_builds_manifested_package_without_env_files():
 
     missing = [fragment for fragment in required_fragments if fragment not in script]
     assert missing == []
+
+
+def test_production_deploy_package_applies_idempotent_db_migrations():
+    package_script = read("scripts/build_deploy_package.ps1")
+    deploy_script = read("deploy_produccion_fg.sh")
+    migration = read("db_migrations/20260708_personal_unidad_negocio.sql")
+
+    package_fragments = [
+        "db_migrations",
+        "20260708_personal_unidad_negocio.sql",
+    ]
+    deploy_fragments = [
+        "Aplicando migraciones DB",
+        "DATABASE_URL",
+        "mysql --defaults-extra-file",
+        'for migration in "$migrations_dir"/*.sql',
+    ]
+    migration_fragments = [
+        "CREATE TABLE IF NOT EXISTS personal_unidad_negocio",
+        "INSERT IGNORE INTO personal_unidad_negocio",
+        "REFERENCES personal",
+        "REFERENCES unidadnegocio",
+    ]
+
+    missing = [fragment for fragment in package_fragments if fragment not in package_script]
+    missing += [fragment for fragment in deploy_fragments if fragment not in deploy_script]
+    missing += [fragment for fragment in migration_fragments if fragment not in migration]
+    assert missing == []

--- a/db_migrations/20260708_personal_unidad_negocio.sql
+++ b/db_migrations/20260708_personal_unidad_negocio.sql
@@ -1,0 +1,17 @@
+-- Issue #65: allow one person to belong to multiple business units.
+-- Idempotent and backward compatible with personal.unidad_negocio.
+
+CREATE TABLE IF NOT EXISTS personal_unidad_negocio (
+  idPersonal INT(10) UNSIGNED NOT NULL,
+  idUnidadNegocio INT(10) UNSIGNED NOT NULL,
+  PRIMARY KEY (idPersonal, idUnidadNegocio),
+  CONSTRAINT FK_pun_personal FOREIGN KEY (idPersonal)
+    REFERENCES personal (idPersonal) ON UPDATE CASCADE ON DELETE CASCADE,
+  CONSTRAINT FK_pun_unidad FOREIGN KEY (idUnidadNegocio)
+    REFERENCES unidadnegocio (idUnidadNegocio) ON UPDATE CASCADE ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+INSERT IGNORE INTO personal_unidad_negocio (idPersonal, idUnidadNegocio)
+SELECT idPersonal, unidad_negocio
+FROM personal
+WHERE unidad_negocio IS NOT NULL AND unidad_negocio > 0;

--- a/deploy_produccion_fg.sh
+++ b/deploy_produccion_fg.sh
@@ -49,6 +49,63 @@ cleanup() {
 }
 trap cleanup EXIT
 
+apply_db_migrations() {
+  local migrations_dir="$tmp_dir/db_migrations"
+  if [[ ! -d "$migrations_dir" ]] || ! compgen -G "$migrations_dir/*.sql" >/dev/null; then
+    return
+  fi
+
+  if ! command -v mysql >/dev/null 2>&1; then
+    echo "ERROR: mysql CLI no disponible; no puedo aplicar migraciones DB." >&2
+    exit 1
+  fi
+  if ! command -v python3 >/dev/null 2>&1; then
+    echo "ERROR: python3 no disponible; no puedo leer DATABASE_URL para migraciones DB." >&2
+    exit 1
+  fi
+
+  echo "==> Aplicando migraciones DB"
+  local mysql_defaults
+  mysql_defaults="$(mktemp)"
+  if ! python3 - "$APP_DIR/backend/.env" >"$mysql_defaults" <<'PY'
+import sys
+from pathlib import Path
+from urllib.parse import urlparse, unquote
+
+values = {}
+for raw in Path(sys.argv[1]).read_text().splitlines():
+    line = raw.strip()
+    if not line or line.startswith("#") or "=" not in line:
+        continue
+    key, value = line.split("=", 1)
+    values[key.strip()] = value.strip().strip("\"'")
+
+url = urlparse(values["DATABASE_URL"])
+print("[client]")
+print(f"host={url.hostname}")
+if url.port:
+    print(f"port={url.port}")
+print(f"user={unquote(url.username or '')}")
+print(f"password={unquote(url.password or '')}")
+print(f"database={url.path.lstrip('/')}")
+PY
+  then
+    rm -f "$mysql_defaults"
+    echo "ERROR: no pude preparar credenciales mysql desde DATABASE_URL." >&2
+    exit 1
+  fi
+  chmod 600 "$mysql_defaults"
+  for migration in "$migrations_dir"/*.sql; do
+    echo "==> DB migration: $(basename "$migration")"
+    if ! mysql --defaults-extra-file="$mysql_defaults" < "$migration"; then
+      rm -f "$mysql_defaults"
+      echo "ERROR: fallo migracion DB: $(basename "$migration")" >&2
+      exit 1
+    fi
+  done
+  rm -f "$mysql_defaults"
+}
+
 restore_backup() {
   if [[ "$rollback_needed" -ne 1 || ! -f "$backup_file" ]]; then
     return
@@ -116,6 +173,8 @@ tar -C "$APP_DIR" \
   backend/app backend/requirements.txt frontend restart.sh
 
 rollback_needed=1
+
+apply_db_migrations
 
 echo "==> Actualizando backend"
 rm -rf "$APP_DIR/backend/app"

--- a/scripts/build_deploy_package.ps1
+++ b/scripts/build_deploy_package.ps1
@@ -85,6 +85,7 @@ New-Item -ItemType Directory -Force -Path (Join-Path $Stage "backend") | Out-Nul
 New-Item -ItemType Directory -Force -Path (Join-Path $Stage "frontend") | Out-Null
 New-Item -ItemType Directory -Force -Path (Join-Path $Stage "backend/app") | Out-Null
 New-Item -ItemType Directory -Force -Path (Join-Path $Stage "frontend/dist") | Out-Null
+New-Item -ItemType Directory -Force -Path (Join-Path $Stage "db_migrations") | Out-Null
 
 Run-Step "Copiando backend/app" {
     Copy-Item -Recurse -Force "backend/app/*" (Join-Path $Stage "backend/app")
@@ -97,6 +98,10 @@ Run-Step "Copiando frontend/dist" {
 
 Run-Step "Copiando deploy script" {
     Copy-Item -Force "deploy_produccion_fg.sh" (Join-Path $Stage "deploy_produccion_fg.sh")
+}
+
+Run-Step "Copiando migraciones DB" {
+    Copy-Item -Force "db_migrations/20260708_personal_unidad_negocio.sql" (Join-Path $Stage "db_migrations/20260708_personal_unidad_negocio.sql")
 }
 
 $Manifest = @(
@@ -129,7 +134,7 @@ Run-Step "Generando paquete" {
     }
     Push-Location $Stage
     try {
-        tar -czf $PackagePath backend frontend deploy_produccion_fg.sh RELEASE_MANIFEST.txt
+        tar -czf $PackagePath backend frontend db_migrations deploy_produccion_fg.sh RELEASE_MANIFEST.txt
     } finally {
         Pop-Location
     }


### PR DESCRIPTION
## Qué cambia

- Agrega una migracion idempotente para crear `personal_unidad_negocio` y backfillear desde `personal.unidad_negocio`.
- Incluye `db_migrations/` dentro del paquete de deploy.
- Hace que `deploy_produccion_fg.sh` aplique migraciones SQL del paquete usando `DATABASE_URL` desde `backend/.env` sin imprimir credenciales.

## Por qué

En produccion falta la tabla `personal_unidad_negocio`. Cuando esa tabla no existe, el backend cae al campo historico `personal.unidad_negocio`, por eso la pantalla permite marcar varias unidades pero al guardar/recargar queda una sola.

Closes #65

## PR apilado

Base: `fix/issue-63-relations-autocomplete`, porque produccion ya esta en ese commit y aun no esta mergeado a `main`. El paquete de deploy de esta rama conserva #64 y #63.

## Validacion

- `python -m pytest backend/tests/test_deploy_scripts_contract.py`
- `python -m pytest backend/tests`
- `npm test`
- `npm run build`
- Verificacion remota previa: en produccion existe `unidadnegocio_tipo_proceso`, no existe `personal_unidad_negocio`.
