### PR TITLE
Add admin CRUD for actas

### DIFF
--- a/backend/app/api/routes/admin_catalogs.py
+++ b/backend/app/api/routes/admin_catalogs.py
@@ -2,6 +2,7 @@ from fastapi import APIRouter, status
 
 from app.api.routes import admin_legacy
 from app.schemas.admin import (
+    ActaAdminResponse,
     DeleteResponse,
     LugarCargaResponse,
     MovilResponse,
@@ -45,3 +46,8 @@ router.add_api_route("/rodales", admin_legacy.list_rodales, methods=["GET"], res
 router.add_api_route("/rodales", admin_legacy.create_rodal, methods=["POST"], response_model=RodalResponse, status_code=status.HTTP_201_CREATED)
 router.add_api_route("/rodales/{idRodal}", admin_legacy.update_rodal, methods=["PUT"], response_model=RodalResponse)
 router.add_api_route("/rodales/{idRodal}", admin_legacy.delete_rodal, methods=["DELETE"], response_model=DeleteResponse)
+
+router.add_api_route("/actas", admin_legacy.list_actas_admin, methods=["GET"], response_model=list[ActaAdminResponse])
+router.add_api_route("/actas", admin_legacy.create_acta, methods=["POST"], response_model=ActaAdminResponse, status_code=status.HTTP_201_CREATED)
+router.add_api_route("/actas/{acta_id}", admin_legacy.update_acta, methods=["PUT"], response_model=ActaAdminResponse)
+router.add_api_route("/actas/{acta_id}", admin_legacy.delete_acta, methods=["DELETE"], response_model=DeleteResponse)

--- a/backend/app/api/routes/admin_legacy.py
+++ b/backend/app/api/routes/admin_legacy.py
@@ -15,9 +15,12 @@ from app.models.personal_unidad_negocio import PersonalUnidadNegocio
 from app.models.produccion import TableroProduccion
 from app.models.tipo_proceso import TipoDeProceso, UnidadNegocioTipoProceso
 from app.models.tipo_movil import TipoMovil
-from app.models.ubicacion import Predio, Rodal
+from app.models.ubicacion import Acta, Predio, Rodal
 from app.models.unidad_negocio import UnidadNegocio
 from app.schemas.admin import (
+    ActaAdminResponse,
+    ActaCreate,
+    ActaUpdate,
     AdminDashboardEvolutionItem,
     AdminDashboardOverviewResponse,
     AdminDashboardRankingItem,
@@ -325,6 +328,19 @@ def _to_rodal_response(row: Rodal) -> RodalResponse:
         tarifa=float(row.Tarifa or 0),
         extraccion=float(row.Extraccion or 0),
         carga=float(row.Carga or 0),
+    )
+
+
+def _to_acta_admin_response(row: Acta) -> ActaAdminResponse:
+    return ActaAdminResponse(
+        id=row.id,
+        numero=row.numero or "",
+        rodal_id=int(row.rodal_id or 0),
+        vam=float(row.vam or 0),
+        tarifa=float(row.tarifa or 0),
+        extraccion=float(row.extraccion or 0),
+        carga=float(row.carga or 0),
+        periodo=row.periodo,
     )
 
 
@@ -1520,6 +1536,96 @@ async def delete_rodal(
     row = db.query(Rodal).filter(Rodal.idRodal == idRodal).first()
     if not row:
         raise HTTPException(status_code=404, detail="Rodal no encontrado")
+
+    db.delete(row)
+    db.commit()
+    return DeleteResponse()
+
+
+@router.get("/actas", response_model=list[ActaAdminResponse])
+async def list_actas_admin(
+    skip: int = 0,
+    limit: int = 50,
+    buscar: str | None = None,
+    db: Session = Depends(get_db),
+    _: Personal = Depends(get_current_admin),
+):
+    query = db.query(Acta)
+    if buscar:
+        query = query.filter(Acta.numero.ilike(f"%{buscar.strip()}%"))
+    rows = query.order_by(Acta.numero).offset(skip).limit(limit).all()
+    return [_to_acta_admin_response(r) for r in rows]
+
+
+@router.post("/actas", response_model=ActaAdminResponse, status_code=status.HTTP_201_CREATED)
+async def create_acta(
+    payload: ActaCreate,
+    db: Session = Depends(get_db),
+    _: Personal = Depends(get_current_admin),
+):
+    numero = payload.numero.strip()
+    if not numero:
+        raise HTTPException(status_code=400, detail="Numero es obligatorio")
+
+    row = Acta(
+        numero=numero,
+        rodal_id=payload.rodal_id,
+        vam=payload.vam,
+        tarifa=payload.tarifa,
+        extraccion=payload.extraccion,
+        carga=payload.carga,
+        periodo=payload.periodo,
+    )
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return _to_acta_admin_response(row)
+
+
+@router.put("/actas/{acta_id}", response_model=ActaAdminResponse)
+async def update_acta(
+    acta_id: int,
+    payload: ActaUpdate,
+    db: Session = Depends(get_db),
+    _: Personal = Depends(get_current_admin),
+):
+    row = db.query(Acta).filter(Acta.id == acta_id).first()
+    if not row:
+        raise HTTPException(status_code=404, detail="Acta no encontrada")
+
+    data = payload.model_dump(exclude_unset=True)
+    if "numero" in data:
+        numero = (data.pop("numero") or "").strip()
+        if not numero:
+            raise HTTPException(status_code=400, detail="Numero es obligatorio")
+        row.numero = numero
+    if "rodal_id" in data:
+        row.rodal_id = data.pop("rodal_id")
+    if "vam" in data:
+        row.vam = data.pop("vam")
+    if "tarifa" in data:
+        row.tarifa = data.pop("tarifa")
+    if "extraccion" in data:
+        row.extraccion = data.pop("extraccion")
+    if "carga" in data:
+        row.carga = data.pop("carga")
+    if "periodo" in data:
+        row.periodo = data.pop("periodo")
+
+    db.commit()
+    db.refresh(row)
+    return _to_acta_admin_response(row)
+
+
+@router.delete("/actas/{acta_id}", response_model=DeleteResponse)
+async def delete_acta(
+    acta_id: int,
+    db: Session = Depends(get_db),
+    _: Personal = Depends(get_current_admin),
+):
+    row = db.query(Acta).filter(Acta.id == acta_id).first()
+    if not row:
+        raise HTTPException(status_code=404, detail="Acta no encontrada")
 
     db.delete(row)
     db.commit()

--- a/backend/app/api/routes/produccion.py
+++ b/backend/app/api/routes/produccion.py
@@ -441,7 +441,16 @@ async def list_moviles(
 async def list_actas(db: Session = Depends(get_db)):
     if not _table_exists(db, "actas"):
         return []
-    return db.query(Acta).order_by(Acta.numero).all()
+    rows = db.query(Acta).order_by(Acta.numero).all()
+    seen_numeros: set[str] = set()
+    unique_rows = []
+    for row in rows:
+        numero = str(row.numero or "").strip()
+        if numero in seen_numeros:
+            continue
+        seen_numeros.add(numero)
+        unique_rows.append(row)
+    return unique_rows
 
 
 # ─── Predios ───

--- a/backend/app/schemas/admin.py
+++ b/backend/app/schemas/admin.py
@@ -338,6 +338,37 @@ class RodalResponse(BaseModel):
     carga: float
 
 
+class ActaCreate(BaseModel):
+    numero: str = Field(min_length=1)
+    rodal_id: int
+    vam: float = 0
+    tarifa: float = 0
+    extraccion: float = 0
+    carga: float = 0
+    periodo: str | None = None
+
+
+class ActaUpdate(BaseModel):
+    numero: str | None = None
+    rodal_id: int | None = None
+    vam: float | None = None
+    tarifa: float | None = None
+    extraccion: float | None = None
+    carga: float | None = None
+    periodo: str | None = None
+
+
+class ActaAdminResponse(BaseModel):
+    id: int
+    numero: str
+    rodal_id: int
+    vam: float
+    tarifa: float
+    extraccion: float
+    carga: float
+    periodo: str | None = None
+
+
 class AsignacionOperativaCreate(BaseModel):
     idMovil: int
     idChofer: int

--- a/backend/tests/test_deploy_scripts_contract.py
+++ b/backend/tests/test_deploy_scripts_contract.py
@@ -77,3 +77,26 @@ def test_production_deploy_package_applies_idempotent_db_migrations():
     missing += [fragment for fragment in deploy_fragments if fragment not in deploy_script]
     missing += [fragment for fragment in migration_fragments if fragment not in migration]
     assert missing == []
+
+
+def test_admin_actas_crud_contract_is_registered():
+    schemas = read("backend/app/schemas/admin.py")
+    admin_routes = read("backend/app/api/routes/admin_legacy.py")
+    catalog_routes = read("backend/app/api/routes/admin_catalogs.py")
+
+    required_fragments = [
+        "class ActaCreate",
+        "class ActaUpdate",
+        "class ActaAdminResponse",
+        "def list_actas_admin",
+        "def create_acta",
+        "def update_acta",
+        "def delete_acta",
+        '"/actas"',
+        '"/actas/{acta_id}"',
+        "ActaAdminResponse",
+    ]
+
+    combined = "\n".join([schemas, admin_routes, catalog_routes])
+    missing = [fragment for fragment in required_fragments if fragment not in combined]
+    assert missing == []

--- a/backend/tests/test_produccion_operadores.py
+++ b/backend/tests/test_produccion_operadores.py
@@ -1,3 +1,4 @@
+import asyncio
 from types import SimpleNamespace
 
 from app.api.routes import produccion
@@ -10,6 +11,9 @@ class FakeQuery:
 
     def filter(self, *_args, **_kwargs):
         self.filter_calls += 1
+        return self
+
+    def order_by(self, *_args, **_kwargs):
         return self
 
     def all(self):
@@ -41,3 +45,16 @@ def test_personal_unidad_ids_map_batches_relation_lookup(monkeypatch):
         3: [9],
     }
     assert db.query_obj.filter_calls == 1
+
+
+def test_list_actas_returns_one_option_per_numero(monkeypatch):
+    monkeypatch.setattr(produccion, "_table_exists", lambda _db, _table_name: True)
+    db = FakeDb([
+        SimpleNamespace(id=1, numero="7900001144", rodal_id=12),
+        SimpleNamespace(id=2, numero="7900001144", rodal_id=13),
+        SimpleNamespace(id=3, numero="7900000611", rodal_id=10),
+    ])
+
+    result = asyncio.run(produccion.list_actas(db=db))
+
+    assert [row.numero for row in result] == ["7900001144", "7900000611"]

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -325,6 +325,7 @@ const navSections = computed(() => {
         { key: 'lugares', label: 'Lugares de Carga', icon: 'location', to: { name: 'admin-crud', params: { entity: 'lugares-carga' } } },
         { key: 'predios', label: 'Predios', icon: 'field', to: { name: 'admin-crud', params: { entity: 'predios' } } },
         { key: 'rodales', label: 'Rodales', icon: 'plot', to: { name: 'admin-crud', params: { entity: 'rodales' } } },
+        { key: 'actas', label: 'Actas', icon: 'records', to: { name: 'admin-crud', params: { entity: 'actas' } } },
         { key: 'acceso', label: 'Configuración de Acceso', icon: 'settings', to: { name: 'admin-configuracion' } },
       ],
     })

--- a/frontend/src/config/adminEntityConfig.js
+++ b/frontend/src/config/adminEntityConfig.js
@@ -7,5 +7,6 @@ export const ADMIN_ENTITY_CONFIG = {
   'lugares-carga': { endpoint: '/api/admin/lugares-carga', idKey: 'idLugarCarga', label: 'Lugares de Carga' },
   predios: { endpoint: '/api/admin/predios', idKey: 'idPredio', label: 'Predios' },
   rodales: { endpoint: '/api/admin/rodales', idKey: 'idRodal', label: 'Rodales' },
+  actas: { endpoint: '/api/admin/actas', idKey: 'id', label: 'Actas' },
   asignaciones: { endpoint: '/api/admin/asignaciones', idKey: 'idAsignacion', label: 'Asignaciones Operativas' },
 }

--- a/frontend/src/views/admin/AdminCrudView.test.js
+++ b/frontend/src/views/admin/AdminCrudView.test.js
@@ -213,4 +213,49 @@ describe('AdminCrudView tipos de proceso', () => {
     await flushPromises()
     expect(wrapper.findAll('[role="option"]').map((option) => option.text())).toEqual(['AAA111 - Carreton Principal'])
   })
+
+  it('shows an admin CRUD form for actas used by the production combo', async () => {
+    routeState.params.entity = 'actas'
+    api.get.mockImplementation((url) => {
+      const dataByUrl = {
+        '/api/admin/actas': [
+          { id: 3, numero: '7900000099', rodal_id: 12, periodo: '202607', vam: 1, tarifa: 2, extraccion: 3, carga: 4 },
+        ],
+        '/api/admin/rodales': [
+          { idRodal: 12, rodal: 'Rodal 12', idPredio: 5, vam: 1, tarifa: 2, extraccion: 3, carga: 4 },
+        ],
+      }
+      return Promise.resolve({ data: dataByUrl[url] || [] })
+    })
+
+    const wrapper = mount(AdminCrudView, {
+      global: {
+        directives: {
+          motionPanel: {},
+          motionPop: {},
+        },
+        stubs: {
+          AppIcon: true,
+        },
+      },
+    })
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('Actas')
+    expect(wrapper.text()).toContain('7900000099')
+
+    const nuevo = wrapper.findAll('button').find((button) => button.text().includes('Nuevo'))
+    expect(nuevo).toBeTruthy()
+    await nuevo.trigger('click')
+    await flushPromises()
+
+    const labels = wrapper.findAll('label').map((label) => label.text())
+    expect(labels).toContain('Número')
+    expect(labels).toContain('Rodal')
+    expect(labels).toContain('Periodo')
+    expect(labels).toContain('VAM')
+    expect(labels).toContain('Tarifa')
+    expect(labels).toContain('Extracción')
+    expect(labels).toContain('Carga')
+  })
 })

--- a/frontend/src/views/admin/AdminCrudView.vue
+++ b/frontend/src/views/admin/AdminCrudView.vue
@@ -812,6 +812,31 @@ const ENTITY_DEFINITIONS = {
       { key: 'carga', label: 'Carga', type: 'number', default: 0, section: 'tecnico' },
     ],
   },
+  actas: {
+    title: 'Actas',
+    singular: 'acta',
+    description: 'Catálogo de actas disponibles para la carga de producción.',
+    formHint: 'Estas actas alimentan el combo Acta de la carga de producción.',
+    idKey: 'id',
+    deleteVerb: 'Eliminar',
+    extraReferences: ['rodales'],
+    columns: [
+      { key: 'id', label: 'ID' },
+      { key: 'numero', label: 'Número' },
+      { key: 'rodal_id', label: 'Rodal', type: 'lookup', optionsEntity: 'rodales', optionValue: 'idRodal', optionLabel: 'rodal' },
+      { key: 'periodo', label: 'Periodo' },
+      { key: 'vam', label: 'VAM' },
+    ],
+    fields: [
+      { key: 'numero', label: 'Número', type: 'text', required: true, section: 'principal' },
+      { key: 'rodal_id', label: 'Rodal', type: 'autocomplete', optionsEntity: 'rodales', optionValue: 'idRodal', optionLabel: 'rodal', section: 'principal' },
+      { key: 'periodo', label: 'Periodo', type: 'text', nullable: true, section: 'principal' },
+      { key: 'vam', label: 'VAM', type: 'number', default: 0, section: 'principal' },
+      { key: 'tarifa', label: 'Tarifa', type: 'number', default: 0, section: 'principal' },
+      { key: 'extraccion', label: 'Extracción', type: 'number', default: 0, section: 'principal' },
+      { key: 'carga', label: 'Carga', type: 'number', default: 0, section: 'principal' },
+    ],
+  },
   asignaciones: {
     title: 'Asignaciones Operativas',
     singular: 'asignacion operativa',
@@ -1233,7 +1258,7 @@ async function confirmDelete() {
 
 function clearReferenceCacheFor(changedEntity) {
   referenceCache.delete(changedEntity)
-  for (const key of ['personal', 'moviles', 'tipos-proceso', 'unidades-negocio', 'predios']) {
+  for (const key of ['personal', 'moviles', 'tipos-proceso', 'unidades-negocio', 'predios', 'rodales', 'actas']) {
     if (changedEntity === key) referenceCache.delete(key)
   }
 }
@@ -1498,6 +1523,8 @@ function optionFieldForEntity(refEntity) {
     'tipos-movil': { optionsEntity: 'tipos-movil', optionLabel: 'detalle' },
     'unidades-negocio': { optionsEntity: 'unidades-negocio', optionLabel: 'nombre' },
     predios: { optionsEntity: 'predios', optionLabel: 'nombre' },
+    rodales: { optionsEntity: 'rodales', optionLabel: 'rodal' },
+    actas: { optionsEntity: 'actas', optionLabel: 'numero' },
   }
   return map[refEntity] || { optionsEntity: refEntity, optionLabel: 'nombre' }
 }
@@ -1516,7 +1543,7 @@ function formatCellValue(row, column) {
 }
 
 function mobilePrimaryLabel(row) {
-  const preferred = ['nombre', 'detalle', 'patente', 'rodal', 'descripcion']
+  const preferred = ['nombre', 'detalle', 'patente', 'rodal', 'numero', 'descripcion']
   const key = preferred.find((item) => row[item])
   if (key) return row[key]
   const firstColumn = mobileColumns.value[0]


### PR DESCRIPTION
## Summary
- Adds an admin CRUD for the existing `actas` table, using the same generic admin style as Predios/Rodales.
- Exposes `/api/admin/actas` with list/create/update/delete routes and schemas.
- Adds the Actas catalog item to the admin sidebar and covers it with backend/frontend contract tests.
- Deduplicates `/api/produccion/actas` by `numero` so the production Acta combo shows each acta number only once.

## Impact
Admins can maintain the Acta catalog used by production, and operators no longer see duplicate Acta options when registering production.

## Stack note
This PR is stacked on `fix/issue-65-personal-multiple-units` because production work for the previous issue is still in that branch stack.

## Validation
- `python -m pytest backend/tests/test_produccion_operadores.py -q`
- `python -m pytest backend/tests -q`
- `python -m pytest backend/tests/test_deploy_scripts_contract.py`
- `npm test -- AdminCrudView.test.js`
- `python -m pytest backend/tests`
- `npm test`
- `npm run build`
- deploy package builder: backend 28 passed, frontend 101 passed, Vite build OK