### PR TITLE
Corregir combustible de producción registrado como ingreso

### DIFF
--- a/backend/app/api/routes/produccion.py
+++ b/backend/app/api/routes/produccion.py
@@ -608,6 +608,7 @@ async def create_produccion(
             Litros=data.combustible,
             UnidadNegocio=data.cod_un or 1,
             personal=data.cod_operador or 1,
+            tipo_mov="E",
             idtabla=str(new_id),
             tabla="tablero_produccion",
             _usuario="web",

--- a/backend/tests/test_produccion_combustible.py
+++ b/backend/tests/test_produccion_combustible.py
@@ -1,0 +1,55 @@
+import asyncio
+from datetime import date
+from types import SimpleNamespace
+
+from app.api.routes import produccion
+from app.models.carga_comb import CargaComb
+from app.schemas.produccion import TableroProduccionCreate
+
+
+class FakeMaxQuery:
+    def scalar(self):
+        return 0
+
+
+class FakeDb:
+    def __init__(self):
+        self.added = []
+
+    def query(self, *_args, **_kwargs):
+        return FakeMaxQuery()
+
+    def add(self, row):
+        self.added.append(row)
+
+    def flush(self):
+        pass
+
+    def commit(self):
+        pass
+
+    def refresh(self, _row):
+        pass
+
+
+def test_create_produccion_records_combustible_as_egreso(monkeypatch):
+    monkeypatch.setattr(produccion, "_validate_restricted_payload", lambda *_args: None)
+    db = FakeDb()
+    payload = TableroProduccionCreate(
+        fecha=date(2026, 7, 15),
+        cod_equipo=10,
+        cod_operador=20,
+        cod_un=30,
+        combustible=150,
+    )
+
+    asyncio.run(
+        produccion.create_produccion(
+            data=payload,
+            db=db,
+            user=SimpleNamespace(),
+        )
+    )
+
+    carga = next(row for row in db.added if isinstance(row, CargaComb))
+    assert carga.tipo_mov == "E"


### PR DESCRIPTION
## Objetivo

Corregir el movimiento generado al informar combustible dentro de un parte de producción.

## Causa raíz

La creación de `cargacomb` desde el formulario de producción no asignaba `tipo_mov`. La base completaba el valor vacío y el sistema legado lo mostraba como ingreso, mientras que los consumos deben persistirse con `tipo_mov = "E"`.

## Cambios

- Asigna explícitamente `tipo_mov="E"` al combustible creado con el parte de producción.
- Agrega una prueba de regresión que ejecuta el endpoint y verifica el movimiento generado.

## Tests / Validaciones

- [x] Test de regresión observado en rojo antes del cambio (`None != "E"`).
- [x] `python -m pytest backend/tests -q` — 29 tests aprobados.
- [x] `python -m compileall -q backend/app`.
- [x] `git diff --cached --check`.

## Fuera de alcance

- No se modificaron registros históricos.
- No se modificó la pantalla independiente de carga de combustible, que ya grababa egresos correctamente.
- No se realizó despliegue ni se tocaron bases reales.

## Riesgos / pendientes

Los registros históricos que quedaron con `tipo_mov` vacío no se corrigen automáticamente; cualquier saneamiento requiere una tarea separada y validación previa de datos.