### PR TITLE
Agregar deploy seguro desde GitHub main

### DIFF
--- a/backend/tests/test_deploy_main_fasa195.py
+++ b/backend/tests/test_deploy_main_fasa195.py
@@ -32,6 +32,7 @@ class DeployHarness:
         *arguments: str,
         git_status: str = "",
         merge_base_exit: int = 0,
+        target_commit: str = "target-commit",
     ) -> subprocess.CompletedProcess[str]:
         env = os.environ.copy()
         env.update(
@@ -44,6 +45,8 @@ class DeployHarness:
                 "CALL_LOG": str(self.call_log),
                 "FAKE_GIT_STATUS": git_status,
                 "FAKE_MERGE_BASE_EXIT": str(merge_base_exit),
+                "FAKE_TARGET_COMMIT": target_commit,
+                "FAKE_STATE_DIR": str(self.root),
             }
         )
         script = REPO_ROOT / "scripts/deploy_main_fasa195.sh"
@@ -102,11 +105,18 @@ printf 'flock %s\\n' "$*" >>"$CALL_LOG"
 printf 'git %s\\n' "$*" >>"$CALL_LOG"
 case "$*" in
   "status --porcelain") printf '%s' "${FAKE_GIT_STATUS:-}" ;;
-  "rev-parse origin/main") printf '%s\\n' target-commit ;;
-  "rev-parse HEAD") printf '%s\\n' current-commit ;;
+  "rev-parse origin/main") printf '%s\\n' "${FAKE_TARGET_COMMIT:-target-commit}" ;;
+  "rev-parse HEAD")
+    if [[ -f "$FAKE_STATE_DIR/merged" ]]; then
+      printf '%s\\n' "${FAKE_TARGET_COMMIT:-target-commit}"
+    else
+      printf '%s\\n' current-commit
+    fi
+    ;;
   "rev-parse main") printf '%s\\n' current-main ;;
   "merge-base --is-ancestor"*) exit "${FAKE_MERGE_BASE_EXIT:-0}" ;;
   "show-ref --verify --quiet refs/heads/main") exit 0 ;;
+  "merge --ff-only origin/main") touch "$FAKE_STATE_DIR/merged" ;;
 esac
 """,
     )
@@ -116,6 +126,7 @@ esac
 printf 'docker %s\\n' "$*" >>"$CALL_LOG"
 case "$*" in
   "compose config --services") printf '%s\\n' indufor produccion_fg ;;
+  "inspect -f {{.State.Health.Status}}"*) printf '%s\\n' healthy ;;
 esac
 """,
     )
@@ -147,3 +158,36 @@ def test_check_is_read_only(deploy_harness: DeployHarness):
     assert "git merge --ff-only" not in deploy_harness.calls
     assert "docker compose build" not in deploy_harness.calls
     assert "docker compose up" not in deploy_harness.calls
+
+
+def test_deploy_builds_commit_image_and_updates_services_in_order(
+    deploy_harness: DeployHarness,
+):
+    result = deploy_harness.run("--deploy", "--yes", target_commit="abc123")
+
+    assert result.returncode == 0, result.stderr
+    calls = deploy_harness.calls.splitlines()
+    assert "git switch main" in calls
+    assert "git merge --ff-only origin/main" in calls
+    assert "docker build --tag registro_produccion:abc123 ." in calls
+    indufor_call = next(
+        index
+        for index, call in enumerate(calls)
+        if "up -d --no-build --force-recreate indufor" in call
+    )
+    produccion_call = next(
+        index
+        for index, call in enumerate(calls)
+        if "up -d --no-build --force-recreate produccion_fg" in call
+    )
+    assert indufor_call < produccion_call
+    assert any("http://127.0.0.1:18004/health" in call for call in calls)
+    assert any("http://127.0.0.1:18005/health" in call for call in calls)
+
+
+def test_deploy_requires_yes_when_not_interactive(deploy_harness: DeployHarness):
+    result = deploy_harness.run("--deploy")
+
+    assert result.returncode != 0
+    assert "interactive terminal or --yes" in result.stderr
+    assert "docker build" not in deploy_harness.calls

--- a/backend/tests/test_deploy_main_fasa195.py
+++ b/backend/tests/test_deploy_main_fasa195.py
@@ -43,6 +43,8 @@ class DeployHarness:
         merge_base_exit: int = 0,
         target_commit: str = "target-commit",
         fail_health: str = "",
+        fail_rollback_service: str = "",
+        extra_env: dict[str, str] | None = None,
     ) -> subprocess.CompletedProcess[str]:
         env = os.environ.copy()
         env.update(
@@ -58,8 +60,11 @@ class DeployHarness:
                 "FAKE_TARGET_COMMIT": target_commit,
                 "FAKE_STATE_DIR": str(self.root),
                 "FAKE_FAIL_HEALTH": fail_health,
+                "FAKE_FAIL_ROLLBACK_SERVICE": fail_rollback_service,
             }
         )
+        if extra_env:
+            env.update(extra_env)
         script = REPO_ROOT / "scripts/deploy_main_fasa195.sh"
         return subprocess.run(
             [
@@ -138,6 +143,18 @@ esac
 printf 'docker %s\\n' "$*" >>"$CALL_LOG"
 case "$*" in
   "compose config --services") printf '%s\\n' indufor produccion_fg ;;
+  "compose -f docker-compose.yml -f "*" config --images")
+    override_file="$5"
+    awk '/image:/ {print $2}' "$override_file"
+    ;;
+  "compose -f docker-compose.yml -f "*" up -d --no-build --force-recreate "*)
+    service="${*: -1}"
+    if [[ -n "${FAKE_FAIL_ROLLBACK_SERVICE:-}" &&
+          "$service" == "$FAKE_FAIL_ROLLBACK_SERVICE" &&
+          -f "$FAKE_STATE_DIR/health-fail-count" ]]; then
+      exit 1
+    fi
+    ;;
   "inspect -f {{.Image}} registro_produccion_indufor")
     printf '%s\\n' old-indufor-image
     ;;
@@ -263,3 +280,43 @@ def test_manifest_records_previous_and_target_state(deploy_harness: DeployHarnes
     assert manifest["target_commit"] == "abc123"
     assert manifest["previous_indufor_image"] == "old-indufor-image"
     assert manifest["previous_produccion_fg_image"] == "old-produccion-image"
+
+
+def test_failed_rollback_is_reported_truthfully(deploy_harness: DeployHarness):
+    result = deploy_harness.run(
+        "--deploy",
+        "--yes",
+        fail_health="registro_produccion_indufor",
+        fail_rollback_service="indufor",
+    )
+
+    assert result.returncode != 0
+    assert "rollback failed" in result.stderr
+    assert deploy_harness.latest_manifest()["status"] == "rollback_failed"
+
+
+def test_origin_main_cannot_be_overridden_from_environment(
+    deploy_harness: DeployHarness,
+):
+    result = deploy_harness.run(
+        "--check",
+        extra_env={"REMOTE": "attacker", "BRANCH": "unsafe"},
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "git fetch --prune origin" in deploy_harness.calls
+    assert "git rev-parse origin/main" in deploy_harness.calls
+    assert "attacker" not in deploy_harness.calls
+    assert "unsafe" not in deploy_harness.calls
+
+
+def test_success_output_contains_live_evidence(deploy_harness: DeployHarness):
+    result = deploy_harness.run("--deploy", "--yes", target_commit="abc123")
+
+    assert result.returncode == 0, result.stderr
+    assert "indufor_image=" in result.stdout
+    assert "produccion_fg_image=" in result.stdout
+    assert "indufor_health_url=http://127.0.0.1:18004/health" in result.stdout
+    assert (
+        "produccion_fg_health_url=http://127.0.0.1:18005/health" in result.stdout
+    )

--- a/backend/tests/test_deploy_main_fasa195.py
+++ b/backend/tests/test_deploy_main_fasa195.py
@@ -27,12 +27,22 @@ class DeployHarness:
     def calls(self) -> str:
         return self.call_log.read_text(encoding="utf-8") if self.call_log.exists() else ""
 
+    def latest_manifest(self) -> dict[str, str]:
+        manifests = sorted((self.root / "backups").glob("deploy_*.env"))
+        assert manifests
+        return dict(
+            line.split("=", 1)
+            for line in manifests[-1].read_text(encoding="utf-8").splitlines()
+            if "=" in line
+        )
+
     def run(
         self,
         *arguments: str,
         git_status: str = "",
         merge_base_exit: int = 0,
         target_commit: str = "target-commit",
+        fail_health: str = "",
     ) -> subprocess.CompletedProcess[str]:
         env = os.environ.copy()
         env.update(
@@ -47,6 +57,7 @@ class DeployHarness:
                 "FAKE_MERGE_BASE_EXIT": str(merge_base_exit),
                 "FAKE_TARGET_COMMIT": target_commit,
                 "FAKE_STATE_DIR": str(self.root),
+                "FAKE_FAIL_HEALTH": fail_health,
             }
         )
         script = REPO_ROOT / "scripts/deploy_main_fasa195.sh"
@@ -114,6 +125,7 @@ case "$*" in
     fi
     ;;
   "rev-parse main") printf '%s\\n' current-main ;;
+  "branch --show-current") printf '%s\\n' old-branch ;;
   "merge-base --is-ancestor"*) exit "${FAKE_MERGE_BASE_EXIT:-0}" ;;
   "show-ref --verify --quiet refs/heads/main") exit 0 ;;
   "merge --ff-only origin/main") touch "$FAKE_STATE_DIR/merged" ;;
@@ -126,7 +138,29 @@ esac
 printf 'docker %s\\n' "$*" >>"$CALL_LOG"
 case "$*" in
   "compose config --services") printf '%s\\n' indufor produccion_fg ;;
-  "inspect -f {{.State.Health.Status}}"*) printf '%s\\n' healthy ;;
+  "inspect -f {{.Image}} registro_produccion_indufor")
+    printf '%s\\n' old-indufor-image
+    ;;
+  "inspect -f {{.Image}} registro_produccion_produccion_fg")
+    printf '%s\\n' old-produccion-image
+    ;;
+  "inspect -f {{.State.Health.Status}}"*)
+    container="${*: -1}"
+    if [[ -n "${FAKE_FAIL_HEALTH:-}" && "$container" == "$FAKE_FAIL_HEALTH" ]]; then
+      count_file="$FAKE_STATE_DIR/health-fail-count"
+      count=0
+      [[ -f "$count_file" ]] && count="$(cat "$count_file")"
+      count=$((count + 1))
+      printf '%s' "$count" >"$count_file"
+      if [[ "$count" -le 30 ]]; then
+        printf '%s\\n' unhealthy
+      else
+        printf '%s\\n' healthy
+      fi
+    else
+      printf '%s\\n' healthy
+    fi
+    ;;
 esac
 """,
     )
@@ -191,3 +225,41 @@ def test_deploy_requires_yes_when_not_interactive(deploy_harness: DeployHarness)
     assert result.returncode != 0
     assert "interactive terminal or --yes" in result.stderr
     assert "docker build" not in deploy_harness.calls
+
+
+def test_indufor_failure_restores_only_indufor(deploy_harness: DeployHarness):
+    result = deploy_harness.run(
+        "--deploy", "--yes", fail_health="registro_produccion_indufor"
+    )
+
+    assert result.returncode != 0
+    assert "rollback_service indufor old-indufor-image" in result.stdout
+    assert "rollback_service produccion_fg" not in result.stdout
+    assert not any(
+        "up -d --no-build --force-recreate produccion_fg" in call
+        for call in deploy_harness.calls.splitlines()
+    )
+
+
+def test_produccion_failure_restores_both_services(deploy_harness: DeployHarness):
+    result = deploy_harness.run(
+        "--deploy",
+        "--yes",
+        fail_health="registro_produccion_produccion_fg",
+    )
+
+    assert result.returncode != 0
+    assert "rollback_service produccion_fg old-produccion-image" in result.stdout
+    assert "rollback_service indufor old-indufor-image" in result.stdout
+    assert deploy_harness.calls.count("http://127.0.0.1:18004/health") >= 2
+    assert "http://127.0.0.1:18005/health" in deploy_harness.calls
+
+
+def test_manifest_records_previous_and_target_state(deploy_harness: DeployHarness):
+    result = deploy_harness.run("--deploy", "--yes", target_commit="abc123")
+
+    assert result.returncode == 0, result.stderr
+    manifest = deploy_harness.latest_manifest()
+    assert manifest["target_commit"] == "abc123"
+    assert manifest["previous_indufor_image"] == "old-indufor-image"
+    assert manifest["previous_produccion_fg_image"] == "old-produccion-image"

--- a/backend/tests/test_deploy_main_fasa195.py
+++ b/backend/tests/test_deploy_main_fasa195.py
@@ -44,6 +44,7 @@ class DeployHarness:
         target_commit: str = "target-commit",
         fail_health: str = "",
         fail_rollback_service: str = "",
+        fail_update_service: str = "",
         extra_env: dict[str, str] | None = None,
     ) -> subprocess.CompletedProcess[str]:
         env = os.environ.copy()
@@ -61,6 +62,7 @@ class DeployHarness:
                 "FAKE_STATE_DIR": str(self.root),
                 "FAKE_FAIL_HEALTH": fail_health,
                 "FAKE_FAIL_ROLLBACK_SERVICE": fail_rollback_service,
+                "FAKE_FAIL_UPDATE_SERVICE": fail_update_service,
             }
         )
         if extra_env:
@@ -149,11 +151,19 @@ case "$*" in
     ;;
   "compose -f docker-compose.yml -f "*" up -d --no-build --force-recreate "*)
     service="${*: -1}"
+    update_fail_marker="$FAKE_STATE_DIR/update-failed-$service"
+    if [[ -n "${FAKE_FAIL_UPDATE_SERVICE:-}" &&
+          "$service" == "$FAKE_FAIL_UPDATE_SERVICE" &&
+          ! -f "$update_fail_marker" ]]; then
+      touch "$update_fail_marker"
+      exit 1
+    fi
     if [[ -n "${FAKE_FAIL_ROLLBACK_SERVICE:-}" &&
           "$service" == "$FAKE_FAIL_ROLLBACK_SERVICE" &&
           -f "$FAKE_STATE_DIR/health-fail-count" ]]; then
       exit 1
     fi
+    exit 0
     ;;
   "inspect -f {{.Image}} registro_produccion_indufor")
     printf '%s\\n' old-indufor-image
@@ -293,6 +303,20 @@ def test_failed_rollback_is_reported_truthfully(deploy_harness: DeployHarness):
     assert result.returncode != 0
     assert "rollback failed" in result.stderr
     assert deploy_harness.latest_manifest()["status"] == "rollback_failed"
+
+
+def test_partial_compose_failure_restores_attempted_service(
+    deploy_harness: DeployHarness,
+):
+    result = deploy_harness.run(
+        "--deploy",
+        "--yes",
+        fail_update_service="indufor",
+    )
+
+    assert result.returncode != 0
+    assert "rollback_service indufor old-indufor-image" in result.stdout
+    assert deploy_harness.latest_manifest()["status"] == "rolled_back", result.stderr
 
 
 def test_origin_main_cannot_be_overridden_from_environment(

--- a/backend/tests/test_deploy_main_fasa195.py
+++ b/backend/tests/test_deploy_main_fasa195.py
@@ -1,0 +1,149 @@
+import os
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+BASH = Path(r"C:\Program Files\Git\bin\bash.exe")
+
+
+def bash_path(path: Path) -> str:
+    resolved = path.resolve()
+    return f"/{resolved.drive[0].lower()}{resolved.as_posix()[2:]}"
+
+
+@dataclass
+class DeployHarness:
+    root: Path
+
+    @property
+    def call_log(self) -> Path:
+        return self.root / "calls.log"
+
+    @property
+    def calls(self) -> str:
+        return self.call_log.read_text(encoding="utf-8") if self.call_log.exists() else ""
+
+    def run(
+        self,
+        *arguments: str,
+        git_status: str = "",
+        merge_base_exit: int = 0,
+    ) -> subprocess.CompletedProcess[str]:
+        env = os.environ.copy()
+        env.update(
+            {
+                "EXPECTED_HOSTNAME": "test-host",
+                "APP_DIR": str(self.root / "app"),
+                "ENV_DIR": str(self.root / "env"),
+                "BACKUP_DIR": str(self.root / "backups"),
+                "LOCK_FILE": str(self.root / "deploy.lock"),
+                "CALL_LOG": str(self.call_log),
+                "FAKE_GIT_STATUS": git_status,
+                "FAKE_MERGE_BASE_EXIT": str(merge_base_exit),
+            }
+        )
+        script = REPO_ROOT / "scripts/deploy_main_fasa195.sh"
+        return subprocess.run(
+            [
+                str(BASH),
+                "-c",
+                'export PATH="$1:$PATH"; shift; exec "$@"',
+                "deploy-test",
+                bash_path(self.root / "fake-bin"),
+                bash_path(script),
+                *arguments,
+            ],
+            cwd=self.root / "app",
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+
+def write_fake(path: Path, body: str) -> None:
+    path.write_text(f"#!/usr/bin/env bash\nset -eu\n{body}\n", encoding="utf-8", newline="\n")
+    path.chmod(0o755)
+
+
+@pytest.fixture
+def deploy_harness(tmp_path: Path) -> DeployHarness:
+    app_dir = tmp_path / "app"
+    env_dir = tmp_path / "env"
+    fake_bin = tmp_path / "fake-bin"
+    app_dir.mkdir()
+    (app_dir / ".git").mkdir()
+    env_dir.mkdir()
+    fake_bin.mkdir()
+    (env_dir / "indufor.env").write_text("APP_INSTANCE=indufor\n", encoding="utf-8")
+    (env_dir / "produccion_fg.env").write_text(
+        "APP_INSTANCE=produccion_fg\n", encoding="utf-8"
+    )
+
+    write_fake(
+        fake_bin / "hostname",
+        """
+printf '%s\\n' test-host
+""",
+    )
+    write_fake(
+        fake_bin / "flock",
+        """
+printf 'flock %s\\n' "$*" >>"$CALL_LOG"
+""",
+    )
+    write_fake(
+        fake_bin / "git",
+        """
+printf 'git %s\\n' "$*" >>"$CALL_LOG"
+case "$*" in
+  "status --porcelain") printf '%s' "${FAKE_GIT_STATUS:-}" ;;
+  "rev-parse origin/main") printf '%s\\n' target-commit ;;
+  "rev-parse HEAD") printf '%s\\n' current-commit ;;
+  "rev-parse main") printf '%s\\n' current-main ;;
+  "merge-base --is-ancestor"*) exit "${FAKE_MERGE_BASE_EXIT:-0}" ;;
+  "show-ref --verify --quiet refs/heads/main") exit 0 ;;
+esac
+""",
+    )
+    write_fake(
+        fake_bin / "docker",
+        """
+printf 'docker %s\\n' "$*" >>"$CALL_LOG"
+case "$*" in
+  "compose config --services") printf '%s\\n' indufor produccion_fg ;;
+esac
+""",
+    )
+    write_fake(fake_bin / "curl", """printf 'curl %s\\n' "$*" >>"$CALL_LOG" """)
+    write_fake(fake_bin / "sleep", """:""")
+
+    return DeployHarness(tmp_path)
+
+
+def test_check_rejects_dirty_checkout(deploy_harness: DeployHarness):
+    result = deploy_harness.run("--check", git_status=" M backend/app/main.py")
+
+    assert result.returncode != 0
+    assert "checkout is not clean" in result.stderr
+    assert "docker compose up" not in deploy_harness.calls
+
+
+def test_check_rejects_non_fast_forward_main(deploy_harness: DeployHarness):
+    result = deploy_harness.run("--check", merge_base_exit=1)
+
+    assert result.returncode != 0
+    assert "not a fast-forward" in result.stderr
+
+
+def test_check_is_read_only(deploy_harness: DeployHarness):
+    result = deploy_harness.run("--check")
+
+    assert result.returncode == 0
+    assert "git merge --ff-only" not in deploy_harness.calls
+    assert "docker compose build" not in deploy_harness.calls
+    assert "docker compose up" not in deploy_harness.calls

--- a/backend/tests/test_deploy_scripts_contract.py
+++ b/backend/tests/test_deploy_scripts_contract.py
@@ -57,8 +57,8 @@ def test_github_main_docker_deploy_has_safe_contract():
     required_fragments = [
         'EXPECTED_HOSTNAME="${EXPECTED_HOSTNAME:-fg-ubuntu}"',
         'APP_DIR="${APP_DIR:-/srv/apps/registro_produccion}"',
-        'REMOTE="${REMOTE:-origin}"',
-        'BRANCH="${BRANCH:-main}"',
+        'REMOTE="origin"',
+        'BRANCH="main"',
         "--check",
         "--deploy",
         "--yes",
@@ -76,6 +76,8 @@ def test_github_main_docker_deploy_has_safe_contract():
         "http://127.0.0.1:18005/health",
         ".deploy-backups",
         "rollback",
+        "trap handle_signal INT TERM",
+        "rollback_failed",
     ]
 
     missing = [fragment for fragment in required_fragments if fragment not in script]

--- a/backend/tests/test_deploy_scripts_contract.py
+++ b/backend/tests/test_deploy_scripts_contract.py
@@ -51,6 +51,37 @@ def test_windows_package_script_builds_manifested_package_without_env_files():
     assert missing == []
 
 
+def test_github_main_docker_deploy_has_safe_contract():
+    script = read("scripts/deploy_main_fasa195.sh")
+
+    required_fragments = [
+        'EXPECTED_HOSTNAME="${EXPECTED_HOSTNAME:-fg-ubuntu}"',
+        'APP_DIR="${APP_DIR:-/srv/apps/registro_produccion}"',
+        'REMOTE="${REMOTE:-origin}"',
+        'BRANCH="${BRANCH:-main}"',
+        "--check",
+        "--deploy",
+        "--yes",
+        "flock",
+        "git status --porcelain",
+        "git fetch --prune",
+        "git merge-base --is-ancestor",
+        "git merge --ff-only",
+        "registro_produccion:${target_commit}",
+        "docker compose config",
+        "python -m compileall",
+        "import app.main",
+        "indufor produccion_fg",
+        "http://127.0.0.1:18004/health",
+        "http://127.0.0.1:18005/health",
+        ".deploy-backups",
+        "rollback",
+    ]
+
+    missing = [fragment for fragment in required_fragments if fragment not in script]
+    assert missing == []
+
+
 def test_production_deploy_package_applies_idempotent_db_migrations():
     package_script = read("scripts/build_deploy_package.ps1")
     deploy_script = read("deploy_produccion_fg.sh")

--- a/backend/tests/test_deploy_scripts_contract.py
+++ b/backend/tests/test_deploy_scripts_contract.py
@@ -82,6 +82,24 @@ def test_github_main_docker_deploy_has_safe_contract():
     assert missing == []
 
 
+def test_github_main_runbook_documents_safe_operator_flow():
+    runbook = read("docs/DEPLOY_GITHUB_MAIN_RUNBOOK.md")
+    required = [
+        "--check",
+        "--deploy",
+        "--yes",
+        "indufor",
+        "produccion_fg",
+        "indufor_demo",
+        "Nginx",
+        ".env",
+        "rollback",
+    ]
+
+    missing = [fragment for fragment in required if fragment not in runbook]
+    assert missing == []
+
+
 def test_production_deploy_package_applies_idempotent_db_migrations():
     package_script = read("scripts/build_deploy_package.ps1")
     deploy_script = read("deploy_produccion_fg.sh")

--- a/docs/DEPLOY_GITHUB_MAIN_RUNBOOK.md
+++ b/docs/DEPLOY_GITHUB_MAIN_RUNBOOK.md
@@ -3,7 +3,8 @@
 ## Alcance
 
 `scripts/deploy_main_fasa195.sh` actualiza exclusivamente los servicios Docker
-`indufor` y `produccion_fg` en `fasa_195`.
+`indufor` y `produccion_fg` en `fasa_195`. La fuente está fijada dentro del
+script en `origin/main`; variables de entorno no pueden cambiar la rama.
 
 El script:
 
@@ -95,6 +96,8 @@ El rollback es automático:
   revisiones diferentes;
 - restaura el checkout anterior y vuelve a comprobar los healthchecks.
 
-El manifiesto se conserva con `status=rolled_back`. Si el rollback automático
-también falla, no improvisar cambios sobre Nginx, `.env` o la base: inspeccionar
-el manifiesto y los IDs de imagen antes de intervenir manualmente.
+El manifiesto se conserva con `status=rolled_back`. Si cualquier recreación,
+healthcheck o restauración Git del rollback falla, queda
+`status=rollback_failed` y el script lo informa como error. En ese caso no
+improvisar cambios sobre Nginx, `.env` o la base: inspeccionar el manifiesto y
+los IDs de imagen antes de intervenir manualmente.

--- a/docs/DEPLOY_GITHUB_MAIN_RUNBOOK.md
+++ b/docs/DEPLOY_GITHUB_MAIN_RUNBOOK.md
@@ -1,0 +1,100 @@
+# Deploy desde GitHub main
+
+## Alcance
+
+`scripts/deploy_main_fasa195.sh` actualiza exclusivamente los servicios Docker
+`indufor` y `produccion_fg` en `fasa_195`.
+
+El script:
+
+- obtiene el código desde `origin/main`;
+- construye una imagen inmutable etiquetada con el commit;
+- actualiza primero `indufor` y después `produccion_fg`;
+- comprueba el healthcheck Docker y el endpoint HTTP de cada instancia;
+- ejecuta rollback automático si una instancia no queda saludable.
+
+No modifica Nginx, archivos `.env`, bases de datos ni `indufor_demo`. Tampoco
+elimina imágenes Docker anteriores.
+
+## Requisitos
+
+- Hostname `fg-ubuntu`.
+- Checkout limpio en `/srv/apps/registro_produccion`.
+- Acceso de lectura a GitHub mediante el remoto `origin`.
+- Acceso del usuario a Docker.
+- Env files existentes:
+  - `/srv/env/registro_produccion/indufor.env`
+  - `/srv/env/registro_produccion/produccion_fg.env`
+
+El contenido de los env files nunca se imprime.
+
+## Preflight
+
+El preflight actualiza referencias remotas, pero no cambia rama, imágenes ni
+contenedores:
+
+```bash
+cd /srv/apps/registro_produccion
+bash scripts/deploy_main_fasa195.sh --check
+```
+
+El comando aborta ante archivos locales, divergencia Git, configuración Compose
+inválida, servicios ausentes o env files faltantes.
+
+## Deploy interactivo
+
+```bash
+cd /srv/apps/registro_produccion
+bash scripts/deploy_main_fasa195.sh --deploy
+```
+
+Escribir `DEPLOY` cuando el script lo solicite.
+
+## Deploy no interactivo aprobado
+
+```bash
+cd /srv/apps/registro_produccion
+bash scripts/deploy_main_fasa195.sh --deploy --yes
+```
+
+`--yes` sólo debe usarse después de revisar un `--check` exitoso.
+
+## Evidencia
+
+Los manifiestos quedan en:
+
+```text
+~/.deploy-backups/registro_produccion/
+```
+
+Cada manifiesto registra commit y rama anteriores, imagen anterior de cada
+instancia, commit objetivo y estado final. No contiene secretos.
+
+Verificación manual:
+
+```bash
+git status -sb
+git rev-parse HEAD
+docker compose ps
+docker inspect \
+  -f '{{.Name}} {{.Image}} {{.State.Health.Status}}' \
+  registro_produccion_indufor \
+  registro_produccion_produccion_fg
+curl -fsS http://127.0.0.1:18004/health
+curl -fsS http://127.0.0.1:18005/health
+```
+
+## Rollback
+
+El rollback es automático:
+
+- si falla la construcción, no reemplaza contenedores;
+- si falla `indufor`, restaura solamente `indufor` y no actualiza
+  `produccion_fg`;
+- si falla `produccion_fg`, restaura ambas instancias para que no queden en
+  revisiones diferentes;
+- restaura el checkout anterior y vuelve a comprobar los healthchecks.
+
+El manifiesto se conserva con `status=rolled_back`. Si el rollback automático
+también falla, no improvisar cambios sobre Nginx, `.env` o la base: inspeccionar
+el manifiesto y los IDs de imagen antes de intervenir manualmente.

--- a/docs/superpowers/plans/2026-07-18-deploy-github-main.md
+++ b/docs/superpowers/plans/2026-07-18-deploy-github-main.md
@@ -1,0 +1,606 @@
+# GitHub Main Docker Deploy Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Crear y ejecutar un deploy seguro desde `origin/main` que actualice `indufor` y `produccion_fg` en `fasa_195`, con preflight, imagen inmutable, healthchecks y rollback.
+
+**Architecture:** Un script Bash servidor controla el checkout Git y construye una imagen etiquetada por commit. Un override Compose temporal selecciona esa imagen para actualizar secuencialmente las dos instancias, mientras un manifiesto conserva el estado anterior para rollback. Las pruebas Python verifican el contrato estático y un harness Bash simula Git, Docker y curl para probar preflight, orden y rollback sin tocar infraestructura real.
+
+**Tech Stack:** Bash 5, Git, Docker Compose v2, Python 3.12, pytest.
+
+---
+
+### Task 1: Contrato estático del script
+
+**Files:**
+- Modify: `backend/tests/test_deploy_scripts_contract.py`
+- Create: `scripts/deploy_main_fasa195.sh`
+
+- [ ] **Step 1: Escribir la prueba estática fallida**
+
+Agregar a `backend/tests/test_deploy_scripts_contract.py`:
+
+```python
+def test_github_main_docker_deploy_has_safe_contract():
+    script = read("scripts/deploy_main_fasa195.sh")
+
+    required_fragments = [
+        'EXPECTED_HOSTNAME="${EXPECTED_HOSTNAME:-fg-ubuntu}"',
+        'APP_DIR="${APP_DIR:-/srv/apps/registro_produccion}"',
+        'REMOTE="${REMOTE:-origin}"',
+        'BRANCH="${BRANCH:-main}"',
+        "--check",
+        "--deploy",
+        "--yes",
+        "flock",
+        "git status --porcelain",
+        "git fetch --prune",
+        "git merge-base --is-ancestor",
+        "git merge --ff-only",
+        "registro_produccion:${target_commit}",
+        "docker compose config",
+        "python -m compileall",
+        "import app.main",
+        "indufor produccion_fg",
+        "http://127.0.0.1:18004/health",
+        "http://127.0.0.1:18005/health",
+        ".deploy-backups",
+        "rollback",
+    ]
+
+    missing = [fragment for fragment in required_fragments if fragment not in script]
+    assert missing == []
+```
+
+- [ ] **Step 2: Ejecutar la prueba y comprobar RED**
+
+Run:
+
+```powershell
+& 'C:\Users\Ventas\AppData\Local\hermes\hermes-agent\venv\Scripts\python.exe' -m pytest backend/tests/test_deploy_scripts_contract.py::test_github_main_docker_deploy_has_safe_contract -q
+```
+
+Expected: `FAIL` porque `scripts/deploy_main_fasa195.sh` todavía no existe.
+
+- [ ] **Step 3: Crear la estructura mínima del script**
+
+Crear `scripts/deploy_main_fasa195.sh` con:
+
+```bash
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+EXPECTED_HOSTNAME="${EXPECTED_HOSTNAME:-fg-ubuntu}"
+APP_DIR="${APP_DIR:-/srv/apps/registro_produccion}"
+REMOTE="${REMOTE:-origin}"
+BRANCH="${BRANCH:-main}"
+BACKUP_DIR="${BACKUP_DIR:-$APP_DIR/.deploy-backups}"
+LOCK_FILE="${LOCK_FILE:-$APP_DIR/.deploy-main.lock}"
+SERVICES=(indufor produccion_fg)
+HEALTH_INDUFOR="${HEALTH_INDUFOR:-http://127.0.0.1:18004/health}"
+HEALTH_PRODUCCION_FG="${HEALTH_PRODUCCION_FG:-http://127.0.0.1:18005/health}"
+
+usage() {
+  printf '%s\n' \
+    "Usage: $0 --check" \
+    "       $0 --deploy [--yes]"
+}
+
+mode=""
+assume_yes=false
+for argument in "$@"; do
+  case "$argument" in
+    --check|--deploy) mode="$argument" ;;
+    --yes) assume_yes=true ;;
+    -h|--help) usage; exit 0 ;;
+    *) printf 'ERROR: unknown argument: %s\n' "$argument" >&2; exit 2 ;;
+  esac
+done
+[[ -n "$mode" ]] || { usage >&2; exit 2; }
+
+rollback() {
+  printf 'ERROR: rollback requested before implementation\n' >&2
+  return 1
+}
+
+printf '%s\n' \
+  "git status --porcelain" \
+  "git fetch --prune" \
+  "git merge-base --is-ancestor" \
+  "git merge --ff-only" \
+  'registro_produccion:${target_commit}' \
+  "docker compose config" \
+  "python -m compileall" \
+  "import app.main" \
+  "indufor produccion_fg" \
+  "$HEALTH_INDUFOR" \
+  "$HEALTH_PRODUCCION_FG" \
+  "$BACKUP_DIR"
+command -v flock >/dev/null
+```
+
+- [ ] **Step 4: Ejecutar prueba estática y sintaxis**
+
+Run:
+
+```powershell
+& 'C:\Users\Ventas\AppData\Local\hermes\hermes-agent\venv\Scripts\python.exe' -m pytest backend/tests/test_deploy_scripts_contract.py::test_github_main_docker_deploy_has_safe_contract -q
+bash -n scripts/deploy_main_fasa195.sh
+```
+
+Expected: test `PASS`; `bash -n` exit code `0`.
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add backend/tests/test_deploy_scripts_contract.py scripts/deploy_main_fasa195.sh
+git commit -m "test: define safe GitHub deploy contract"
+```
+
+### Task 2: Harness de preflight y checkout fast-forward
+
+**Files:**
+- Create: `backend/tests/test_deploy_main_fasa195.py`
+- Modify: `scripts/deploy_main_fasa195.sh`
+
+- [ ] **Step 1: Escribir pruebas fallidas de preflight**
+
+Crear un harness que copie el script a un directorio temporal, anteponga
+ejecutables fake a `PATH` y registre invocaciones en `CALL_LOG`. Agregar:
+
+```python
+def test_check_rejects_dirty_checkout(deploy_harness):
+    result = deploy_harness.run("--check", git_status=" M backend/app/main.py")
+    assert result.returncode != 0
+    assert "checkout is not clean" in result.stderr
+    assert "docker compose up" not in deploy_harness.calls
+
+
+def test_check_rejects_non_fast_forward_main(deploy_harness):
+    result = deploy_harness.run("--check", merge_base_exit=1)
+    assert result.returncode != 0
+    assert "not a fast-forward" in result.stderr
+
+
+def test_check_is_read_only(deploy_harness):
+    result = deploy_harness.run("--check")
+    assert result.returncode == 0
+    assert "git merge --ff-only" not in deploy_harness.calls
+    assert "docker compose build" not in deploy_harness.calls
+    assert "docker compose up" not in deploy_harness.calls
+```
+
+El fixture debe crear fakes deterministas para `hostname`, `git`, `docker`,
+`curl`, `flock` y `sleep`; nunca debe invocar herramientas reales.
+
+- [ ] **Step 2: Ejecutar y comprobar RED**
+
+```powershell
+& 'C:\Users\Ventas\AppData\Local\hermes\hermes-agent\venv\Scripts\python.exe' -m pytest backend/tests/test_deploy_main_fasa195.py -q
+```
+
+Expected: fallos por ausencia de preflight real.
+
+- [ ] **Step 3: Implementar preflight**
+
+Reemplazar la estructura provisional por funciones:
+
+```bash
+log() { printf '==> %s\n' "$*"; }
+fail() { printf 'ERROR: %s\n' "$*" >&2; exit 1; }
+require_command() { command -v "$1" >/dev/null 2>&1 || fail "missing command: $1"; }
+
+preflight() {
+  [[ "$(hostname)" == "$EXPECTED_HOSTNAME" ]] ||
+    fail "hostname must be $EXPECTED_HOSTNAME"
+  for command_name in git docker curl flock; do
+    require_command "$command_name"
+  done
+  [[ -d "$APP_DIR/.git" ]] || fail "application checkout not found: $APP_DIR"
+  cd "$APP_DIR"
+  [[ -z "$(git status --porcelain)" ]] || fail "checkout is not clean"
+  [[ -f /srv/env/registro_produccion/indufor.env ]] ||
+    fail "missing indufor env file"
+  [[ -f /srv/env/registro_produccion/produccion_fg.env ]] ||
+    fail "missing produccion_fg env file"
+  git fetch --prune "$REMOTE"
+  target_commit="$(git rev-parse "$REMOTE/$BRANCH")"
+  current_commit="$(git rev-parse HEAD)"
+  git merge-base --is-ancestor "$current_commit" "$target_commit" ||
+    fail "current commit is not a fast-forward of $REMOTE/$BRANCH"
+  if git show-ref --verify --quiet "refs/heads/$BRANCH"; then
+    local_main="$(git rev-parse "$BRANCH")"
+    git merge-base --is-ancestor "$local_main" "$target_commit" ||
+      fail "local $BRANCH is not a fast-forward of $REMOTE/$BRANCH"
+  fi
+  docker compose config >/dev/null
+  available_services="$(docker compose config --services)"
+  for service in "${SERVICES[@]}"; do
+    grep -Fxq "$service" <<<"$available_services" ||
+      fail "missing compose service: $service"
+  done
+}
+```
+
+Adquirir el lock con descriptor:
+
+```bash
+exec 9>"$LOCK_FILE"
+flock -n 9 || fail "another deploy is running"
+```
+
+En `--check`, terminar después de `preflight` mostrando commit actual y commit
+objetivo, sin cambiar el checkout.
+
+- [ ] **Step 4: Ejecutar pruebas de preflight**
+
+```powershell
+& 'C:\Users\Ventas\AppData\Local\hermes\hermes-agent\venv\Scripts\python.exe' -m pytest backend/tests/test_deploy_main_fasa195.py -q
+```
+
+Expected: `3 passed`.
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add backend/tests/test_deploy_main_fasa195.py scripts/deploy_main_fasa195.sh
+git commit -m "feat: add guarded deploy preflight"
+```
+
+### Task 3: Imagen inmutable y actualización secuencial
+
+**Files:**
+- Modify: `backend/tests/test_deploy_main_fasa195.py`
+- Modify: `scripts/deploy_main_fasa195.sh`
+
+- [ ] **Step 1: Escribir pruebas fallidas de despliegue**
+
+Agregar:
+
+```python
+def test_deploy_builds_commit_image_and_updates_services_in_order(deploy_harness):
+    result = deploy_harness.run("--deploy", "--yes", target_commit="abc123")
+    assert result.returncode == 0
+    calls = deploy_harness.calls.splitlines()
+    assert "git switch main" in calls
+    assert "git merge --ff-only origin/main" in calls
+    assert "docker build --tag registro_produccion:abc123 ." in calls
+    assert calls.index("compose_up indufor abc123") < calls.index(
+        "compose_up produccion_fg abc123"
+    )
+    assert "curl http://127.0.0.1:18004/health" in calls
+    assert "curl http://127.0.0.1:18005/health" in calls
+
+
+def test_deploy_requires_confirmation_without_yes(deploy_harness):
+    result = deploy_harness.run("--deploy", stdin="NO\n")
+    assert result.returncode != 0
+    assert "deployment cancelled" in result.stderr
+```
+
+- [ ] **Step 2: Ejecutar y comprobar RED**
+
+```powershell
+& 'C:\Users\Ventas\AppData\Local\hermes\hermes-agent\venv\Scripts\python.exe' -m pytest backend/tests/test_deploy_main_fasa195.py -q
+```
+
+Expected: fallos porque no existen build, confirmación ni actualización.
+
+- [ ] **Step 3: Implementar build y despliegue**
+
+Agregar confirmación y funciones:
+
+```bash
+confirm_deploy() {
+  [[ "$assume_yes" == true ]] && return
+  [[ -t 0 ]] || fail "--deploy requires an interactive terminal or --yes"
+  read -r -p "Type DEPLOY to continue: " answer
+  [[ "$answer" == DEPLOY ]] || fail "deployment cancelled"
+}
+
+write_override() {
+  override_file="$(mktemp)"
+  cat >"$override_file" <<YAML
+services:
+  indufor:
+    image: registro_produccion:${target_commit}
+  produccion_fg:
+    image: registro_produccion:${target_commit}
+YAML
+}
+
+compose_target() {
+  docker compose -f docker-compose.yml -f "$override_file" "$@"
+}
+
+wait_healthy() {
+  local container="$1"
+  local health_url="$2"
+  for _ in {1..30}; do
+    if [[ "$(docker inspect -f '{{.State.Health.Status}}' "$container")" == healthy ]]; then
+      curl -fsS "$health_url" >/dev/null
+      return
+    fi
+    sleep 2
+  done
+  return 1
+}
+```
+
+El flujo principal debe ejecutar:
+
+```bash
+git switch "$BRANCH"
+git merge --ff-only "$REMOTE/$BRANCH"
+target_commit="$(git rev-parse HEAD)"
+target_image="registro_produccion:${target_commit}"
+docker build --tag "$target_image" .
+docker run --rm "$target_image" python -m compileall -q /app
+docker run --rm "$target_image" python -c "import app.main"
+write_override
+compose_target up -d --no-build --force-recreate indufor
+wait_healthy registro_produccion_indufor "$HEALTH_INDUFOR"
+compose_target up -d --no-build --force-recreate produccion_fg
+wait_healthy registro_produccion_produccion_fg "$HEALTH_PRODUCCION_FG"
+docker tag "$target_image" registro_produccion:latest
+```
+
+- [ ] **Step 4: Ejecutar pruebas**
+
+```powershell
+& 'C:\Users\Ventas\AppData\Local\hermes\hermes-agent\venv\Scripts\python.exe' -m pytest backend/tests/test_deploy_main_fasa195.py -q
+bash -n scripts/deploy_main_fasa195.sh
+```
+
+Expected: pruebas `PASS`; sintaxis exit code `0`.
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add backend/tests/test_deploy_main_fasa195.py scripts/deploy_main_fasa195.sh
+git commit -m "feat: deploy immutable image sequentially"
+```
+
+### Task 4: Manifiesto y rollback
+
+**Files:**
+- Modify: `backend/tests/test_deploy_main_fasa195.py`
+- Modify: `scripts/deploy_main_fasa195.sh`
+
+- [ ] **Step 1: Escribir pruebas fallidas de rollback**
+
+Agregar:
+
+```python
+def test_indufor_failure_restores_only_indufor(deploy_harness):
+    result = deploy_harness.run(
+        "--deploy", "--yes", fail_health="registro_produccion_indufor"
+    )
+    assert result.returncode != 0
+    assert "rollback_service indufor old-indufor-image" in deploy_harness.calls
+    assert "compose_up produccion_fg" not in deploy_harness.calls
+
+
+def test_produccion_failure_restores_both_services(deploy_harness):
+    result = deploy_harness.run(
+        "--deploy", "--yes", fail_health="registro_produccion_produccion_fg"
+    )
+    assert result.returncode != 0
+    assert "rollback_service produccion_fg old-produccion-image" in deploy_harness.calls
+    assert "rollback_service indufor old-indufor-image" in deploy_harness.calls
+    assert "curl http://127.0.0.1:18004/health" in deploy_harness.calls
+    assert "curl http://127.0.0.1:18005/health" in deploy_harness.calls
+
+
+def test_manifest_records_previous_and_target_state(deploy_harness):
+    result = deploy_harness.run("--deploy", "--yes", target_commit="abc123")
+    assert result.returncode == 0
+    manifest = deploy_harness.latest_manifest()
+    assert manifest["target_commit"] == "abc123"
+    assert manifest["previous_indufor_image"] == "old-indufor-image"
+    assert manifest["previous_produccion_fg_image"] == "old-produccion-image"
+```
+
+- [ ] **Step 2: Ejecutar y comprobar RED**
+
+```powershell
+& 'C:\Users\Ventas\AppData\Local\hermes\hermes-agent\venv\Scripts\python.exe' -m pytest backend/tests/test_deploy_main_fasa195.py -q
+```
+
+Expected: fallos por falta de manifiesto y rollback.
+
+- [ ] **Step 3: Implementar captura y restauración**
+
+Capturar imágenes y escribir el manifiesto sin secretos:
+
+```bash
+previous_branch="$(git branch --show-current)"
+previous_commit="$(git rev-parse HEAD)"
+previous_indufor_image="$(docker inspect -f '{{.Image}}' registro_produccion_indufor)"
+previous_produccion_image="$(docker inspect -f '{{.Image}}' registro_produccion_produccion_fg)"
+timestamp="$(date -u +%Y%m%dT%H%M%SZ)"
+mkdir -p "$BACKUP_DIR"
+manifest="$BACKUP_DIR/deploy_${timestamp}_${target_commit}.env"
+printf '%s\n' \
+  "previous_branch=$previous_branch" \
+  "previous_commit=$previous_commit" \
+  "previous_indufor_image=$previous_indufor_image" \
+  "previous_produccion_fg_image=$previous_produccion_image" \
+  "target_commit=$target_commit" >"$manifest"
+```
+
+`rollback_service` debe crear un override temporal con el ID de imagen anterior,
+recrear sólo el servicio solicitado y esperar su healthcheck. Un trap `ERR`
+debe consultar marcadores `indufor_updated` y `produccion_updated`: si falló la
+segunda instancia restaura ambas; si falló la primera restaura sólo `indufor`.
+Después restaura la rama y el commit mediante:
+
+```bash
+git switch "$previous_branch"
+git reset --keep "$previous_commit"
+```
+
+El trap debe deshabilitarse durante el propio rollback para evitar recursión.
+
+- [ ] **Step 4: Ejecutar suite del nuevo script**
+
+```powershell
+& 'C:\Users\Ventas\AppData\Local\hermes\hermes-agent\venv\Scripts\python.exe' -m pytest backend/tests/test_deploy_main_fasa195.py backend/tests/test_deploy_scripts_contract.py -q
+bash -n scripts/deploy_main_fasa195.sh
+```
+
+Expected: todas las pruebas `PASS`; sintaxis exit code `0`.
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add backend/tests/test_deploy_main_fasa195.py scripts/deploy_main_fasa195.sh
+git commit -m "feat: rollback failed Docker deployments"
+```
+
+### Task 5: Documentación y validación local completa
+
+**Files:**
+- Create: `docs/DEPLOY_GITHUB_MAIN_RUNBOOK.md`
+- Modify: `backend/tests/test_deploy_scripts_contract.py`
+
+- [ ] **Step 1: Escribir contrato documental fallido**
+
+Agregar:
+
+```python
+def test_github_main_runbook_documents_safe_operator_flow():
+    runbook = read("docs/DEPLOY_GITHUB_MAIN_RUNBOOK.md")
+    required = [
+        "--check",
+        "--deploy",
+        "--yes",
+        "indufor",
+        "produccion_fg",
+        "indufor_demo",
+        "Nginx",
+        ".env",
+        "rollback",
+    ]
+    assert [fragment for fragment in required if fragment not in runbook] == []
+```
+
+- [ ] **Step 2: Ejecutar y comprobar RED**
+
+```powershell
+& 'C:\Users\Ventas\AppData\Local\hermes\hermes-agent\venv\Scripts\python.exe' -m pytest backend/tests/test_deploy_scripts_contract.py::test_github_main_runbook_documents_safe_operator_flow -q
+```
+
+Expected: `FAIL` porque el runbook no existe.
+
+- [ ] **Step 3: Crear runbook**
+
+Documentar:
+
+```markdown
+# Deploy desde GitHub main
+
+## Alcance
+
+Actualiza exclusivamente los servicios Docker `indufor` y `produccion_fg`.
+No modifica Nginx, archivos `.env`, bases de datos ni `indufor_demo`.
+
+## Preflight
+
+`bash scripts/deploy_main_fasa195.sh --check`
+
+## Deploy interactivo
+
+`bash scripts/deploy_main_fasa195.sh --deploy`
+
+## Deploy no interactivo aprobado
+
+`bash scripts/deploy_main_fasa195.sh --deploy --yes`
+
+## Evidencia y rollback
+
+Los manifiestos quedan en `.deploy-backups/`. Ante un healthcheck fallido el
+script ejecuta rollback automático y vuelve a comprobar ambas instancias.
+```
+
+- [ ] **Step 4: Ejecutar validación completa**
+
+```powershell
+& 'C:\Users\Ventas\AppData\Local\hermes\hermes-agent\venv\Scripts\python.exe' -m pytest backend/tests/test_deploy_main_fasa195.py backend/tests/test_deploy_scripts_contract.py backend/tests/test_demo_deploy_contract.py -q
+bash -n scripts/deploy_main_fasa195.sh
+git diff --check origin/main...HEAD
+git status -sb
+```
+
+Expected: todas las pruebas `PASS`; Bash exit code `0`; diff check limpio; sólo
+archivos de alcance presentes.
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add docs/DEPLOY_GITHUB_MAIN_RUNBOOK.md backend/tests/test_deploy_scripts_contract.py
+git commit -m "docs: add GitHub main deploy runbook"
+```
+
+### Task 6: Publicar rama y ejecutar en fasa_195
+
+**Files:**
+- Remote checkout: `/srv/apps/registro_produccion`
+- Remote evidence: `/srv/apps/registro_produccion/.deploy-backups/`
+
+- [ ] **Step 1: Repetir verificación antes de publicar**
+
+```powershell
+& 'C:\Users\Ventas\AppData\Local\hermes\hermes-agent\venv\Scripts\python.exe' -m pytest backend/tests/test_deploy_main_fasa195.py backend/tests/test_deploy_scripts_contract.py backend/tests/test_demo_deploy_contract.py -q
+bash -n scripts/deploy_main_fasa195.sh
+git diff --check origin/main...HEAD
+```
+
+Expected: todo `PASS`.
+
+- [ ] **Step 2: Integrar el script en main**
+
+Publicar la rama, abrir PR draft, revisar el diff completo y, si las validaciones
+remotas obligatorias pasan, pasar a ready y mergear. No desplegar una rama de
+feature: el servidor debe recibir el script desde `origin/main`.
+
+- [ ] **Step 3: Confirmar main remoto**
+
+```powershell
+git fetch --prune origin
+git rev-parse origin/main
+```
+
+Expected: commit de merge que contiene `scripts/deploy_main_fasa195.sh`.
+
+- [ ] **Step 4: Ejecutar preflight remoto**
+
+```powershell
+ssh fasa_195 "cd /srv/apps/registro_produccion && git fetch --prune origin && git switch main && git merge --ff-only origin/main && bash scripts/deploy_main_fasa195.sh --check"
+```
+
+Expected: checkout limpio, Compose válido, ambos env files presentes y
+fast-forward confirmado.
+
+- [ ] **Step 5: Ejecutar deploy remoto**
+
+```powershell
+ssh fasa_195 "cd /srv/apps/registro_produccion && bash scripts/deploy_main_fasa195.sh --deploy --yes"
+```
+
+Expected: build exitoso; `indufor` y `produccion_fg` actualizados
+secuencialmente y saludables.
+
+- [ ] **Step 6: Verificar evidencia viva**
+
+```powershell
+ssh fasa_195 "cd /srv/apps/registro_produccion && git status -sb && git rev-parse HEAD && docker compose ps && docker inspect -f '{{.Name}} {{.Image}} {{.State.Health.Status}}' registro_produccion_indufor registro_produccion_produccion_fg && curl -fsS http://127.0.0.1:18004/health && curl -fsS http://127.0.0.1:18005/health"
+```
+
+Expected: servidor en `main`, HEAD igual a `origin/main`, ambos contenedores con
+la misma imagen del commit y estado `healthy`, ambos endpoints HTTP exitosos.
+
+- [ ] **Step 7: Reporte final**
+
+Informar commit/PR/merge, manifiesto remoto, imagen desplegada, estado de ambas
+instancias, healthchecks, límites preservados y estado final del checkout.

--- a/docs/superpowers/specs/2026-07-18-deploy-github-main-design.md
+++ b/docs/superpowers/specs/2026-07-18-deploy-github-main-design.md
@@ -69,7 +69,7 @@ tiempo.
 ## Rollback
 
 Antes de publicar, el script guardará un manifiesto bajo
-`/srv/apps/registro_produccion/.deploy-backups/` con:
+`~/.deploy-backups/registro_produccion/` con:
 
 - commit anterior;
 - rama anterior;
@@ -93,8 +93,9 @@ files, pero utilizará una sobreescritura temporal de imagen para seleccionar la
 etiqueta inmutable del commit. No editará el Compose ni los env files en el
 servidor.
 
-El lock, el override temporal y el manifiesto se limpiarán mediante traps. Los
-errores incluirán la fase que falló sin mostrar secretos.
+El lock bajo `/tmp` y el override temporal se limpiarán mediante traps. El
+manifiesto se conservará como evidencia. Los errores incluirán la fase que
+falló sin mostrar secretos.
 
 ## Pruebas y aceptación
 

--- a/docs/superpowers/specs/2026-07-18-deploy-github-main-design.md
+++ b/docs/superpowers/specs/2026-07-18-deploy-github-main-design.md
@@ -1,0 +1,132 @@
+# Deploy desde GitHub main para produccion_fg e indufor
+
+## Objetivo
+
+Agregar un script Bash ejecutable en `fasa_195` que actualice
+`/srv/apps/registro_produccion` desde `origin/main`, reconstruya el backend
+Docker y publique la misma revisión en `indufor` y `produccion_fg`.
+
+El despliegue no debe modificar Nginx, archivos `.env`, bases de datos ni el
+servicio `indufor_demo`.
+
+## Interfaz
+
+El script será `scripts/deploy_main_fasa195.sh` y se ejecutará desde cualquier
+directorio:
+
+```bash
+bash /srv/apps/registro_produccion/scripts/deploy_main_fasa195.sh --check
+bash /srv/apps/registro_produccion/scripts/deploy_main_fasa195.sh --deploy
+```
+
+`--check` realizará todas las verificaciones que no cambian el checkout, las
+imágenes ni los contenedores. `--deploy` requerirá la confirmación textual
+`DEPLOY` cuando haya una terminal interactiva. Para automatización futura se
+aceptará `--yes`, sin cambiar el alcance del despliegue.
+
+## Precondiciones
+
+El script debe abortar antes de cambiar estado cuando:
+
+- el hostname no sea `fg-ubuntu`;
+- falten `git`, `docker` o `curl`;
+- el directorio de aplicación no sea
+  `/srv/apps/registro_produccion`;
+- el checkout tenga cambios trackeados o archivos no trackeados;
+- `origin/main` no pueda obtenerse o el avance no sea fast-forward;
+- falte alguno de los env files absolutos de `indufor` o `produccion_fg`;
+- Docker Compose no pueda resolver la configuración;
+- falte alguno de los servicios `indufor` o `produccion_fg`.
+
+Los env files sólo se comprobarán por existencia; nunca se imprimirán.
+
+## Flujo de despliegue
+
+1. Adquirir un lock no bloqueante para impedir dos despliegues simultáneos.
+2. Registrar el commit, la rama y el ID de imagen actualmente usados.
+3. Ejecutar `git fetch --prune origin`.
+4. Confirmar que el commit actual y la rama local `main` son ancestros de
+   `origin/main`.
+5. Cambiar a `main` y actualizar mediante
+   `git merge --ff-only origin/main`. El árbol limpio y las validaciones de
+   ancestro evitan descartar trabajo local.
+6. Construir una imagen candidata e inspeccionarla mediante `compileall` y una
+   importación de `app.main` dentro de un contenedor efímero.
+7. Etiquetar la imagen candidata de forma inmutable como
+   `registro_produccion:<commit-completo>` sin reemplazar todavía los
+   contenedores.
+8. Actualizar `indufor`, esperar que su healthcheck quede `healthy` y comprobar
+   `http://127.0.0.1:18004/health`.
+9. Actualizar `produccion_fg`, esperar que su healthcheck quede `healthy` y
+   comprobar `http://127.0.0.1:18005/health`.
+10. Etiquetar la imagen validada como `registro_produccion:latest`.
+11. Mostrar commit desplegado, IDs de imagen, estado de contenedores y URLs
+    comprobadas.
+
+La actualización será secuencial para evitar bajar ambas instancias al mismo
+tiempo.
+
+## Rollback
+
+Antes de publicar, el script guardará un manifiesto bajo
+`/srv/apps/registro_produccion/.deploy-backups/` con:
+
+- commit anterior;
+- rama anterior;
+- imagen anterior de cada contenedor;
+- fecha y commit objetivo.
+
+Si falla la construcción o las pruebas, ningún contenedor será reemplazado. Si
+falla `indufor`, se restaurará su imagen anterior y no se tocará
+`produccion_fg`. Si falla `produccion_fg`, se restaurarán ambos servicios para
+evitar que queden en revisiones diferentes. Después del rollback se repetirán
+los dos healthchecks.
+
+El checkout se devolverá al commit y rama anteriores únicamente cuando el
+rollback de contenedores haya terminado. El manifiesto se conservará como
+evidencia.
+
+## Implementación y aislamiento
+
+El script reutilizará `docker-compose.yml` para resolver nombres, puertos y env
+files, pero utilizará una sobreescritura temporal de imagen para seleccionar la
+etiqueta inmutable del commit. No editará el Compose ni los env files en el
+servidor.
+
+El lock, el override temporal y el manifiesto se limpiarán mediante traps. Los
+errores incluirán la fase que falló sin mostrar secretos.
+
+## Pruebas y aceptación
+
+Se ampliará `backend/tests/test_deploy_scripts_contract.py` con contratos que
+comprueben:
+
+- rama y remoto fijos en `main` y `origin/main`;
+- rechazo de árboles sucios y avances no fast-forward;
+- presencia de `--check`, `--deploy`, confirmación y lock;
+- imagen etiquetada por commit;
+- actualización secuencial `indufor` antes de `produccion_fg`;
+- healthchecks en los puertos `18004` y `18005`;
+- rollback de ambos servicios;
+- ausencia de operaciones sobre Nginx, bases e `indufor_demo`.
+
+La validación final incluirá:
+
+```bash
+pytest backend/tests/test_deploy_scripts_contract.py
+bash -n scripts/deploy_main_fasa195.sh
+git diff --check
+```
+
+En `fasa_195` se ejecutará primero `--check`. El despliegue real sólo avanzará
+si el preflight termina correctamente. La aceptación requiere que ambos
+contenedores queden `healthy`, respondan sus endpoints locales y utilicen la
+misma imagen correspondiente al commit actual de `origin/main`.
+
+## Fuera de alcance
+
+- Migraciones o modificaciones manuales de bases.
+- Cambios de Nginx, DNS, certificados o puertos.
+- Despliegue del frontend fuera de lo que ya contenga la imagen backend.
+- Actualización o seed de `indufor_demo`.
+- Limpieza automática de imágenes Docker antiguas.

--- a/scripts/deploy_main_fasa195.sh
+++ b/scripts/deploy_main_fasa195.sh
@@ -51,8 +51,15 @@ rollback() {
 
   log "rollback_service $service $image"
   write_service_override "$service" "$image"
-  compose_target up -d --no-build --force-recreate "$service"
-  wait_healthy "$container" "$health_url"
+  if ! compose_target up -d --no-build --force-recreate "$service"; then
+    printf 'ERROR: rollback compose failed for %s\n' "$service" >&2
+    return 1
+  fi
+  if ! wait_healthy "$container" "$health_url"; then
+    printf 'ERROR: rollback healthcheck failed for %s\n' "$service" >&2
+    return 1
+  fi
+  return 0
 }
 
 override_file=""
@@ -158,7 +165,7 @@ wait_healthy() {
     status="$(docker inspect -f '{{.State.Health.Status}}' "$container" 2>/dev/null || true)"
     if [[ "$status" == "healthy" ]]; then
       curl -fsS "$health_url" >/dev/null
-      return
+      return 0
     fi
     sleep 2
   done
@@ -200,6 +207,7 @@ recover_and_exit() {
       "$previous_produccion_image" \
       registro_produccion_produccion_fg \
       "$HEALTH_PRODUCCION_FG"; then
+      printf 'ERROR: failed to restore produccion_fg\n' >&2
       recovery_failed=true
     fi
   fi
@@ -209,12 +217,19 @@ recover_and_exit() {
       "$previous_indufor_image" \
       registro_produccion_indufor \
       "$HEALTH_INDUFOR"; then
+      printf 'ERROR: failed to restore indufor\n' >&2
       recovery_failed=true
     fi
   fi
 
-  git switch "$previous_branch" || recovery_failed=true
-  git reset --keep "$previous_commit" || recovery_failed=true
+  if ! git switch "$previous_branch"; then
+    printf 'ERROR: failed to restore Git branch %s\n' "$previous_branch" >&2
+    recovery_failed=true
+  fi
+  if ! git reset --keep "$previous_commit"; then
+    printf 'ERROR: failed to restore Git commit %s\n' "$previous_commit" >&2
+    recovery_failed=true
+  fi
   if [[ -n "$manifest" && -f "$manifest" ]]; then
     if [[ "$recovery_failed" == true ]]; then
       printf 'status=rollback_failed\n' >>"$manifest"
@@ -273,13 +288,13 @@ resolved_target_count="$(
   fail "compose override did not resolve both services to $target_image"
 
 log "Updating indufor"
-compose_target up -d --no-build --force-recreate indufor
 indufor_updated=true
+compose_target up -d --no-build --force-recreate indufor
 wait_healthy registro_produccion_indufor "$HEALTH_INDUFOR"
 
 log "Updating produccion_fg"
-compose_target up -d --no-build --force-recreate produccion_fg
 produccion_updated=true
+compose_target up -d --no-build --force-recreate produccion_fg
 wait_healthy registro_produccion_produccion_fg "$HEALTH_PRODUCCION_FG"
 
 docker tag "$target_image" registro_produccion:latest

--- a/scripts/deploy_main_fasa195.sh
+++ b/scripts/deploy_main_fasa195.sh
@@ -5,8 +5,9 @@ EXPECTED_HOSTNAME="${EXPECTED_HOSTNAME:-fg-ubuntu}"
 APP_DIR="${APP_DIR:-/srv/apps/registro_produccion}"
 REMOTE="${REMOTE:-origin}"
 BRANCH="${BRANCH:-main}"
-BACKUP_DIR="${BACKUP_DIR:-$APP_DIR/.deploy-backups}"
-LOCK_FILE="${LOCK_FILE:-$APP_DIR/.deploy-main.lock}"
+ENV_DIR="${ENV_DIR:-/srv/env/registro_produccion}"
+BACKUP_DIR="${BACKUP_DIR:-${HOME}/.deploy-backups/registro_produccion}"
+LOCK_FILE="${LOCK_FILE:-${TMPDIR:-/tmp}/registro_produccion-deploy-main.lock}"
 SERVICES=(indufor produccion_fg)
 HEALTH_INDUFOR="${HEALTH_INDUFOR:-http://127.0.0.1:18004/health}"
 HEALTH_PRODUCCION_FG="${HEALTH_PRODUCCION_FG:-http://127.0.0.1:18005/health}"
@@ -29,18 +30,74 @@ for argument in "$@"; do
 done
 [[ -n "$mode" ]] || { usage >&2; exit 2; }
 
+log() {
+  printf '==> %s\n' "$*"
+}
+
+fail() {
+  printf 'ERROR: %s\n' "$*" >&2
+  exit 1
+}
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || fail "missing command: $1"
+}
+
 rollback() {
   printf 'ERROR: rollback requested before implementation\n' >&2
   return 1
 }
 
-# Contract markers replaced with executable behavior in the next TDD cycles:
-# git status --porcelain
-# git fetch --prune
-# git merge-base --is-ancestor
+preflight() {
+  [[ "$(hostname)" == "$EXPECTED_HOSTNAME" ]] ||
+    fail "hostname must be $EXPECTED_HOSTNAME"
+
+  for command_name in git docker curl flock; do
+    require_command "$command_name"
+  done
+
+  [[ -d "$APP_DIR" ]] || fail "application checkout not found: $APP_DIR"
+  cd "$APP_DIR"
+  git rev-parse --is-inside-work-tree >/dev/null 2>&1 ||
+    fail "application checkout not found: $APP_DIR"
+  [[ -z "$(git status --porcelain)" ]] || fail "checkout is not clean"
+  [[ -f "$ENV_DIR/indufor.env" ]] || fail "missing indufor env file"
+  [[ -f "$ENV_DIR/produccion_fg.env" ]] || fail "missing produccion_fg env file"
+
+  git fetch --prune "$REMOTE"
+  target_commit="$(git rev-parse "$REMOTE/$BRANCH")"
+  current_commit="$(git rev-parse HEAD)"
+  git merge-base --is-ancestor "$current_commit" "$target_commit" ||
+    fail "current commit is not a fast-forward of $REMOTE/$BRANCH"
+
+  if git show-ref --verify --quiet "refs/heads/$BRANCH"; then
+    local_main="$(git rev-parse "$BRANCH")"
+    git merge-base --is-ancestor "$local_main" "$target_commit" ||
+      fail "local $BRANCH is not a fast-forward of $REMOTE/$BRANCH"
+  fi
+
+  docker compose config >/dev/null
+  available_services="$(docker compose config --services)"
+  for service in "${SERVICES[@]}"; do
+    grep -Fxq "$service" <<<"$available_services" ||
+      fail "missing compose service: $service"
+  done
+}
+
+exec 9>"$LOCK_FILE"
+flock -n 9 || fail "another deploy is running"
+preflight
+
+if [[ "$mode" == "--check" ]]; then
+  log "Preflight successful"
+  printf 'current_commit=%s\n' "$current_commit"
+  printf 'target_commit=%s\n' "$target_commit"
+  exit 0
+fi
+
+# Contract markers implemented in later TDD cycles:
 # git merge --ff-only
 # registro_produccion:${target_commit}
-# docker compose config
 # python -m compileall
 # import app.main
 # indufor produccion_fg

--- a/scripts/deploy_main_fasa195.sh
+++ b/scripts/deploy_main_fasa195.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+EXPECTED_HOSTNAME="${EXPECTED_HOSTNAME:-fg-ubuntu}"
+APP_DIR="${APP_DIR:-/srv/apps/registro_produccion}"
+REMOTE="${REMOTE:-origin}"
+BRANCH="${BRANCH:-main}"
+BACKUP_DIR="${BACKUP_DIR:-$APP_DIR/.deploy-backups}"
+LOCK_FILE="${LOCK_FILE:-$APP_DIR/.deploy-main.lock}"
+SERVICES=(indufor produccion_fg)
+HEALTH_INDUFOR="${HEALTH_INDUFOR:-http://127.0.0.1:18004/health}"
+HEALTH_PRODUCCION_FG="${HEALTH_PRODUCCION_FG:-http://127.0.0.1:18005/health}"
+
+usage() {
+  printf '%s\n' \
+    "Usage: $0 --check" \
+    "       $0 --deploy [--yes]"
+}
+
+mode=""
+assume_yes=false
+for argument in "$@"; do
+  case "$argument" in
+    --check|--deploy) mode="$argument" ;;
+    --yes) assume_yes=true ;;
+    -h|--help) usage; exit 0 ;;
+    *) printf 'ERROR: unknown argument: %s\n' "$argument" >&2; exit 2 ;;
+  esac
+done
+[[ -n "$mode" ]] || { usage >&2; exit 2; }
+
+rollback() {
+  printf 'ERROR: rollback requested before implementation\n' >&2
+  return 1
+}
+
+# Contract markers replaced with executable behavior in the next TDD cycles:
+# git status --porcelain
+# git fetch --prune
+# git merge-base --is-ancestor
+# git merge --ff-only
+# registro_produccion:${target_commit}
+# docker compose config
+# python -m compileall
+# import app.main
+# indufor produccion_fg
+printf '%s\n' "$HEALTH_INDUFOR" "$HEALTH_PRODUCCION_FG" "$BACKUP_DIR" >/dev/null
+command -v flock >/dev/null

--- a/scripts/deploy_main_fasa195.sh
+++ b/scripts/deploy_main_fasa195.sh
@@ -48,6 +48,15 @@ rollback() {
   return 1
 }
 
+override_file=""
+
+cleanup() {
+  if [[ -n "$override_file" && -f "$override_file" ]]; then
+    rm -f "$override_file"
+  fi
+}
+trap cleanup EXIT
+
 preflight() {
   [[ "$(hostname)" == "$EXPECTED_HOSTNAME" ]] ||
     fail "hostname must be $EXPECTED_HOSTNAME"
@@ -95,11 +104,71 @@ if [[ "$mode" == "--check" ]]; then
   exit 0
 fi
 
-# Contract markers implemented in later TDD cycles:
-# git merge --ff-only
-# registro_produccion:${target_commit}
-# python -m compileall
-# import app.main
-# indufor produccion_fg
-printf '%s\n' "$HEALTH_INDUFOR" "$HEALTH_PRODUCCION_FG" "$BACKUP_DIR" >/dev/null
-command -v flock >/dev/null
+confirm_deploy() {
+  if [[ "$assume_yes" == true ]]; then
+    return
+  fi
+  [[ -t 0 ]] || fail "--deploy requires an interactive terminal or --yes"
+  read -r -p "Type DEPLOY to continue: " answer
+  [[ "$answer" == "DEPLOY" ]] || fail "deployment cancelled"
+}
+
+write_override() {
+  override_file="$(mktemp)"
+  cat >"$override_file" <<YAML
+services:
+  indufor:
+    image: registro_produccion:${target_commit}
+  produccion_fg:
+    image: registro_produccion:${target_commit}
+YAML
+}
+
+compose_target() {
+  docker compose -f docker-compose.yml -f "$override_file" "$@"
+}
+
+wait_healthy() {
+  local container="$1"
+  local health_url="$2"
+  local status
+
+  for _ in {1..30}; do
+    status="$(docker inspect -f '{{.State.Health.Status}}' "$container" 2>/dev/null || true)"
+    if [[ "$status" == "healthy" ]]; then
+      curl -fsS "$health_url" >/dev/null
+      return
+    fi
+    sleep 2
+  done
+  fail "$container did not become healthy"
+}
+
+confirm_deploy
+
+log "Updating local $BRANCH from $REMOTE/$BRANCH"
+git switch "$BRANCH"
+git merge --ff-only "$REMOTE/$BRANCH"
+target_commit="$(git rev-parse HEAD)"
+target_image="registro_produccion:${target_commit}"
+
+log "Building immutable image $target_image"
+docker build --tag "$target_image" .
+docker run --rm "$target_image" python -m compileall -q /app
+docker run --rm "$target_image" python -c "import app.main"
+
+write_override
+
+log "Updating indufor"
+compose_target up -d --no-build --force-recreate indufor
+wait_healthy registro_produccion_indufor "$HEALTH_INDUFOR"
+
+log "Updating produccion_fg"
+compose_target up -d --no-build --force-recreate produccion_fg
+wait_healthy registro_produccion_produccion_fg "$HEALTH_PRODUCCION_FG"
+
+docker tag "$target_image" registro_produccion:latest
+
+log "Deploy successful"
+printf 'target_commit=%s\n' "$target_commit"
+printf 'target_image=%s\n' "$target_image"

--- a/scripts/deploy_main_fasa195.sh
+++ b/scripts/deploy_main_fasa195.sh
@@ -3,8 +3,8 @@ set -Eeuo pipefail
 
 EXPECTED_HOSTNAME="${EXPECTED_HOSTNAME:-fg-ubuntu}"
 APP_DIR="${APP_DIR:-/srv/apps/registro_produccion}"
-REMOTE="${REMOTE:-origin}"
-BRANCH="${BRANCH:-main}"
+REMOTE="origin"
+BRANCH="main"
 ENV_DIR="${ENV_DIR:-/srv/env/registro_produccion}"
 BACKUP_DIR="${BACKUP_DIR:-${HOME}/.deploy-backups/registro_produccion}"
 LOCK_FILE="${LOCK_FILE:-${TMPDIR:-/tmp}/registro_produccion-deploy-main.lock}"
@@ -179,36 +179,67 @@ previous_produccion_image="$(
 indufor_updated=false
 produccion_updated=false
 manifest=""
+recovery_started=false
 
-restore_after_error() {
-  local exit_code=$?
-  trap - ERR
+recover_and_exit() {
+  local exit_code="$1"
+  local reason="$2"
+  local recovery_failed=false
+
+  if [[ "$recovery_started" == true ]]; then
+    exit "$exit_code"
+  fi
+  recovery_started=true
+  trap - ERR INT TERM
   set +e
 
-  printf 'ERROR: deploy failed; starting rollback\n' >&2
+  printf 'ERROR: %s; starting rollback\n' "$reason" >&2
   if [[ "$produccion_updated" == true ]]; then
-    rollback \
+    if ! rollback \
       produccion_fg \
       "$previous_produccion_image" \
       registro_produccion_produccion_fg \
-      "$HEALTH_PRODUCCION_FG"
+      "$HEALTH_PRODUCCION_FG"; then
+      recovery_failed=true
+    fi
   fi
   if [[ "$indufor_updated" == true ]]; then
-    rollback \
+    if ! rollback \
       indufor \
       "$previous_indufor_image" \
       registro_produccion_indufor \
-      "$HEALTH_INDUFOR"
+      "$HEALTH_INDUFOR"; then
+      recovery_failed=true
+    fi
   fi
 
-  git switch "$previous_branch"
-  git reset --keep "$previous_commit"
+  git switch "$previous_branch" || recovery_failed=true
+  git reset --keep "$previous_commit" || recovery_failed=true
   if [[ -n "$manifest" && -f "$manifest" ]]; then
-    printf 'status=rolled_back\n' >>"$manifest"
+    if [[ "$recovery_failed" == true ]]; then
+      printf 'status=rollback_failed\n' >>"$manifest"
+    else
+      printf 'status=rolled_back\n' >>"$manifest"
+    fi
+  fi
+  if [[ "$recovery_failed" == true ]]; then
+    printf 'ERROR: rollback failed; inspect containers and manifest: %s\n' \
+      "$manifest" >&2
   fi
   exit "$exit_code"
 }
-trap restore_after_error ERR
+
+handle_error() {
+  local exit_code=$?
+  recover_and_exit "$exit_code" "deploy failed"
+}
+
+handle_signal() {
+  recover_and_exit 130 "deployment interrupted"
+}
+
+trap handle_error ERR
+trap handle_signal INT TERM
 
 log "Updating local $BRANCH from $REMOTE/$BRANCH"
 git switch "$BRANCH"
@@ -234,6 +265,12 @@ docker run --rm "$target_image" python -m compileall -q /app
 docker run --rm "$target_image" python -c "import app.main"
 
 write_override
+resolved_target_count="$(
+  compose_target config --images |
+    grep -Fxc "$target_image"
+)"
+[[ "$resolved_target_count" -eq 2 ]] ||
+  fail "compose override did not resolve both services to $target_image"
 
 log "Updating indufor"
 compose_target up -d --no-build --force-recreate indufor
@@ -247,8 +284,27 @@ wait_healthy registro_produccion_produccion_fg "$HEALTH_PRODUCCION_FG"
 
 docker tag "$target_image" registro_produccion:latest
 printf 'status=success\n' >>"$manifest"
-trap - ERR
+trap - ERR INT TERM
+
+indufor_image="$(
+  docker inspect -f '{{.Image}}' registro_produccion_indufor
+)"
+produccion_fg_image="$(
+  docker inspect -f '{{.Image}}' registro_produccion_produccion_fg
+)"
+indufor_health="$(
+  docker inspect -f '{{.State.Health.Status}}' registro_produccion_indufor
+)"
+produccion_fg_health="$(
+  docker inspect -f '{{.State.Health.Status}}' registro_produccion_produccion_fg
+)"
 
 log "Deploy successful"
 printf 'target_commit=%s\n' "$target_commit"
 printf 'target_image=%s\n' "$target_image"
+printf 'indufor_image=%s\n' "$indufor_image"
+printf 'indufor_health=%s\n' "$indufor_health"
+printf 'indufor_health_url=%s\n' "$HEALTH_INDUFOR"
+printf 'produccion_fg_image=%s\n' "$produccion_fg_image"
+printf 'produccion_fg_health=%s\n' "$produccion_fg_health"
+printf 'produccion_fg_health_url=%s\n' "$HEALTH_PRODUCCION_FG"

--- a/scripts/deploy_main_fasa195.sh
+++ b/scripts/deploy_main_fasa195.sh
@@ -44,8 +44,15 @@ require_command() {
 }
 
 rollback() {
-  printf 'ERROR: rollback requested before implementation\n' >&2
-  return 1
+  local service="$1"
+  local image="$2"
+  local container="$3"
+  local health_url="$4"
+
+  log "rollback_service $service $image"
+  write_service_override "$service" "$image"
+  compose_target up -d --no-build --force-recreate "$service"
+  wait_healthy "$container" "$health_url"
 }
 
 override_file=""
@@ -124,6 +131,20 @@ services:
 YAML
 }
 
+write_service_override() {
+  local service="$1"
+  local image="$2"
+
+  if [[ -z "$override_file" ]]; then
+    override_file="$(mktemp)"
+  fi
+  cat >"$override_file" <<YAML
+services:
+  ${service}:
+    image: ${image}
+YAML
+}
+
 compose_target() {
   docker compose -f docker-compose.yml -f "$override_file" "$@"
 }
@@ -141,16 +162,71 @@ wait_healthy() {
     fi
     sleep 2
   done
-  fail "$container did not become healthy"
+  printf 'ERROR: %s did not become healthy\n' "$container" >&2
+  return 1
 }
 
 confirm_deploy
+
+previous_branch="$(git branch --show-current)"
+previous_commit="$(git rev-parse HEAD)"
+previous_indufor_image="$(
+  docker inspect -f '{{.Image}}' registro_produccion_indufor
+)"
+previous_produccion_image="$(
+  docker inspect -f '{{.Image}}' registro_produccion_produccion_fg
+)"
+indufor_updated=false
+produccion_updated=false
+manifest=""
+
+restore_after_error() {
+  local exit_code=$?
+  trap - ERR
+  set +e
+
+  printf 'ERROR: deploy failed; starting rollback\n' >&2
+  if [[ "$produccion_updated" == true ]]; then
+    rollback \
+      produccion_fg \
+      "$previous_produccion_image" \
+      registro_produccion_produccion_fg \
+      "$HEALTH_PRODUCCION_FG"
+  fi
+  if [[ "$indufor_updated" == true ]]; then
+    rollback \
+      indufor \
+      "$previous_indufor_image" \
+      registro_produccion_indufor \
+      "$HEALTH_INDUFOR"
+  fi
+
+  git switch "$previous_branch"
+  git reset --keep "$previous_commit"
+  if [[ -n "$manifest" && -f "$manifest" ]]; then
+    printf 'status=rolled_back\n' >>"$manifest"
+  fi
+  exit "$exit_code"
+}
+trap restore_after_error ERR
 
 log "Updating local $BRANCH from $REMOTE/$BRANCH"
 git switch "$BRANCH"
 git merge --ff-only "$REMOTE/$BRANCH"
 target_commit="$(git rev-parse HEAD)"
 target_image="registro_produccion:${target_commit}"
+
+timestamp="$(date -u +%Y%m%dT%H%M%SZ)"
+mkdir -p "$BACKUP_DIR"
+manifest="$BACKUP_DIR/deploy_${timestamp}_${target_commit}.env"
+printf '%s\n' \
+  "previous_branch=$previous_branch" \
+  "previous_commit=$previous_commit" \
+  "previous_indufor_image=$previous_indufor_image" \
+  "previous_produccion_fg_image=$previous_produccion_image" \
+  "target_commit=$target_commit" \
+  "target_image=$target_image" >"$manifest"
+chmod 600 "$manifest"
 
 log "Building immutable image $target_image"
 docker build --tag "$target_image" .
@@ -161,13 +237,17 @@ write_override
 
 log "Updating indufor"
 compose_target up -d --no-build --force-recreate indufor
+indufor_updated=true
 wait_healthy registro_produccion_indufor "$HEALTH_INDUFOR"
 
 log "Updating produccion_fg"
 compose_target up -d --no-build --force-recreate produccion_fg
+produccion_updated=true
 wait_healthy registro_produccion_produccion_fg "$HEALTH_PRODUCCION_FG"
 
 docker tag "$target_image" registro_produccion:latest
+printf 'status=success\n' >>"$manifest"
+trap - ERR
 
 log "Deploy successful"
 printf 'target_commit=%s\n' "$target_commit"


### PR DESCRIPTION
## Objetivo

Agregar un deploy seguro desde GitHub `origin/main` para las instancias Docker `indufor` y `produccion_fg` en `fasa_195`.

## Cambios

- agrega `scripts/deploy_main_fasa195.sh` con preflight, lock y confirmación
- fija la fuente en `origin/main` y exige fast-forward
- construye una imagen inmutable por commit
- actualiza `indufor` antes de `produccion_fg`
- valida imagen resuelta por Compose, health Docker y endpoints HTTP
- registra manifiestos y ejecuta rollback automático, distinguiendo `rolled_back` de `rollback_failed`
- maneja errores y señales `INT/TERM`
- agrega harness con fallos simulados y runbook operativo

## Tests / Validaciones

- [x] 20 pruebas contractuales y de comportamiento
- [x] `bash -n` ejecutado con Bash real en `fasa_195`
- [x] `git diff --check origin/main...HEAD`
- [x] revisión independiente sin hallazgos críticos/importantes pendientes

## Fuera de alcance

- Nginx
- archivos `.env`
- bases de datos o migraciones manuales
- `indufor_demo`
- limpieza de imágenes Docker anteriores

## Riesgos / pendientes

La suite backend completa no pudo recolectarse en el entorno Python reutilizado por falta de `sqlalchemy`. El deploy valida la imagen candidata mediante `compileall`, import de `app.main`, healthchecks Docker y endpoints HTTP antes de declarar éxito.