### PR TITLE
fix(admin): set porcentaje=0.0 al crear personal (issue #74)

### DIFF
--- a/backend/app/api/routes/admin_legacy.py
+++ b/backend/app/api/routes/admin_legacy.py
@@ -864,6 +864,7 @@ async def create_personal(
         activo=_normalize_binary(payload.activo),
         encargado=_normalize_binary(payload.encargado),
         is_admin=_normalize_binary(payload.is_admin),
+        porcentaje=0.0,
     )
 
     if payload.password:

--- a/backend/app/models/personal.py
+++ b/backend/app/models/personal.py
@@ -26,7 +26,7 @@ class Personal(Base):
     domicilio = Column(String(50), nullable=False, default="")
     concepto_sueldo = Column(Integer, nullable=False, default=0)
     codigo_kobo = Column(String(50), nullable=False, default="")
-    porcentaje = Column(Float, nullable=False)
+    porcentaje = Column(Float, nullable=False, default=0.0)
     activo = Column(SmallInteger, nullable=False)
     encargado = Column(SmallInteger, nullable=False, default=0)
     is_admin = Column(SmallInteger, nullable=False, default=0)

--- a/backend/tests/test_admin_personal_porcentaje.py
+++ b/backend/tests/test_admin_personal_porcentaje.py
@@ -1,0 +1,48 @@
+import asyncio
+
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import sessionmaker
+
+from app.api.routes import admin_legacy
+from app.core.database import Base
+from app.models.personal import Personal
+from app.schemas.admin import PersonalCreate
+
+
+def _admin_user() -> Personal:
+    return Personal(
+        idPersonal=1,
+        Nombre="Admin Test",
+        is_admin=1,
+        encargado=0,
+        activo=1,
+        porcentaje=0.0,
+        unidad_negocio=1,
+        dni="1",
+    )
+
+
+def _make_session():
+    engine = create_engine("sqlite://", echo=False)
+    Base.metadata.create_all(engine, tables=[Personal.__table__])
+    Session = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+    return Session()
+
+
+def test_personal_model_porcentaje_column_is_not_null_with_default():
+    column = Personal.__table__.c.porcentaje
+    assert column.nullable is False
+    assert column.default is not None
+    assert column.default.arg == 0.0
+
+
+def test_create_personal_sets_porcentaje_so_insert_does_not_raise_integrity_error():
+    db = _make_session()
+    payload = PersonalCreate(nombre="Operario Porcentaje", dni="12345678")
+
+    response = asyncio.run(admin_legacy.create_personal(payload, db, _admin_user()))
+
+    persisted = db.execute(
+        select(Personal).where(Personal.idPersonal == response.idPersonal)
+    ).scalar_one()
+    assert persisted.porcentaje == 0.0


### PR DESCRIPTION
## Objetivo

Closes #74

## Cambios

- `backend/app/api/routes/admin_legacy.py:867` — `create_personal` ahora construye `Personal(...)` con `porcentaje=0.0` explícito.
- `backend/app/models/personal.py:29` — `porcentaje` ahora Declara `default=0.0` en el modelo (defensa extra para cualquier otro INSERT futuro).
- `backend/tests/test_admin_personal_porcentaje.py` — nuevo, 2 tests:
  - `test_personal_model_porcentaje_column_is_not_null_with_default`: assertion de contrato del modelo.
  - `test_create_personal_sets_porcentaje_so_insert_does_not_raise_integrity_error`: regression test que arranca SQLite en memoria, crea la tabla `personal`, invoca `admin_legacy.create_personal` y verifica el INSERT no rompe y `porcentaje` queda persistido en `0.0`.

## Causa raíz (verificada en prod)

Logs del contenedor `registro_produccion_produccion_fg` en fasa_195:

```
pymysql.err.IntegrityError: (1048, "Column 'porcentaje' cannot be null")
Unhandled database error while processing POST /api/admin/personal
```

`create_personal` no seteaba `porcentaje` al construir `Personal(...)`. La columna es `NOT NULL` sin default en MySQL de prod (`fg_structure.sql:2348`) -> SQLAlchemy emitía `INSERT INTO personal (..., porcentaje) VALUES (..., NULL)` -> MySQL rechazaba -> el handler global `database_exception_handler` (`backend/app/main.py:45-52`) lo convertía en 503 con el detalle seguro `"No se pudieron cargar los datos necesarios..."`, opaco para el usuario.

El GET (listado) andaba bien porque el SELECT no toca `porcentaje`.

## Tests / Validaciones

- [x] `git diff --check`
- [x] `git diff --cached --check`
- [x] `py -3.12 -m pytest backend/tests/` -> 44 passed (incluye nuevos regression tests)
- [x] `py -3.12 -m compileall backend/app`
- [x] Test de regresion confirmado: revirtiendo el fix, el test falla con el mismo `IntegrityError` que en prod (solo que contra SQLite).

## Evidencia visual

No aplica (cambio solo de backend; el comportamiento exteriorsolo cambia: antes 503 opaco, ahora alta exitosa).

## Fuera de alcance

- No se toco el DDL de prod (`fg_structure.sql`) ni se agrego migracion. Mantener `NOT NULL` con default en el modelo es suficiente. Si en el futuro se quiere agregar `DEFAULT 0` en MySQL, corresponde otra tarea.
- `update_personal` no se toca: no setea `porcentaje` en PUT, pero al ser NULL-safe (PATCH parcial) no lo necesita.
- No se toco el handler global de errores 503/500 (issue #34 ya abierto para logging/errores).
- No se eliminaron archivos locales fuera de alcance (`.codegraph/`, `.cursor/` quedan sin commitear).

## Riesgos / pendientes

- **Despliegue**: requiere re-deploy del backend (`registro_produccion_produccion_fg`) para que tome el cambio. Una vez deployado, el alta de personal desde el admin vuelve a funcionar.
- El campo `porcentaje` legacy es NOT NULL sin default en prod. Si hay otros consumers (VFP bridge, reportes directos) que inserten personal sin setear porcentaje, seguiran rompiendo — fuera del alcance de este fix.