### PR TITLE
fix(admin): set concepto_sueldo=1 al crear personal (issue #76)

### DIFF
--- a/backend/app/api/routes/admin_legacy.py
+++ b/backend/app/api/routes/admin_legacy.py
@@ -865,6 +865,7 @@ async def create_personal(
         encargado=_normalize_binary(payload.encargado),
         is_admin=_normalize_binary(payload.is_admin),
         porcentaje=0.0,
+        concepto_sueldo=1,
     )
 
     if payload.password:

--- a/backend/app/models/personal.py
+++ b/backend/app/models/personal.py
@@ -24,7 +24,7 @@ class Personal(Base):
     expediente = Column(SmallInteger, nullable=False, default=0)
     telefono = Column(String(50), nullable=False, default="")
     domicilio = Column(String(50), nullable=False, default="")
-    concepto_sueldo = Column(Integer, nullable=False, default=0)
+    concepto_sueldo = Column(Integer, nullable=False, default=1)
     codigo_kobo = Column(String(50), nullable=False, default="")
     porcentaje = Column(Float, nullable=False, default=0.0)
     activo = Column(SmallInteger, nullable=False)

--- a/backend/tests/test_admin_personal_porcentaje.py
+++ b/backend/tests/test_admin_personal_porcentaje.py
@@ -46,3 +46,22 @@ def test_create_personal_sets_porcentaje_so_insert_does_not_raise_integrity_erro
         select(Personal).where(Personal.idPersonal == response.idPersonal)
     ).scalar_one()
     assert persisted.porcentaje == 0.0
+
+
+def test_personal_model_concepto_sueldo_column_is_not_null_with_valid_default():
+    column = Personal.__table__.c.concepto_sueldo
+    assert column.nullable is False
+    assert column.default is not None
+    assert column.default.arg == 1
+
+
+def test_create_personal_sets_concepto_sueldo_to_valid_id_not_zero():
+    db = _make_session()
+    payload = PersonalCreate(nombre="Operario Concepto", dni="87654321")
+
+    response = asyncio.run(admin_legacy.create_personal(payload, db, _admin_user()))
+
+    persisted = db.execute(
+        select(Personal).where(Personal.idPersonal == response.idPersonal)
+    ).scalar_one()
+    assert persisted.concepto_sueldo == 1


### PR DESCRIPTION
## Objetivo

Closes #76

## Cambios

- `backend/app/models/personal.py:27` — `concepto_sueldo` cambia `default=0` -> `default=1` (id válido en catálogo prod).
- `backend/app/api/routes/admin_legacy.py:867` — `create_personal` setea `concepto_sueldo=1` explícito (defensa en profundidad para cualquier otroINSERT futuro).
- `backend/tests/test_admin_personal_porcentaje.py` — 2 tests nuevos:
  - `test_personal_model_concepto_sueldo_column_is_not_null_with_valid_default`: contrato de modelo (default arg == 1).
  - `test_create_personal_sets_concepto_sueldo_to_valid_id_not_zero`: regression test que arranca SQLite en memoria, invoca `admin_legacy.create_personal`, persiste y verifica `concepto_sueldo == 1`.

## Causa raíz (verificada en prod)

Tras deployar #74, los logs mostrar el nuevo error destapado:

```
pymysql.err.IntegrityError: (1452,
 "Cannot add or update a child row: a foreign key constraint fails
  (`fg`.`personal`, CONSTRAINT `FK_concepto`
   FOREIGN KEY (`concepto_sueldo`) REFERENCES `conceptoliquidacion` (`id`)
   ON DELETE RESTRICT ON UPDATE CASCADE)")
```

Modelo tenía `concepto_sueldo = Column(Integer, nullable=False, default=0)`, pero `conceptoliquidacion.id = 0` no existe en prod (IDs reales: 1..17, 101..103). `create_personal` no seteaba el campo -> SQLAlchemy usaba default 0 -> INSERT -> FK 1452 -> handler global -> 503 opaco.

Verificado en prod vía `docker exec ... mysql`:
- `conceptoliquidacion`: ids 1..17, 101..103 (no id 0)
- `puestos`: 1..10 (id 1 válido); `unidad_negocio` default 1 válido.

Solo `concepto_sueldo` estaba mal.

## Tests / Validaciones

- [x] `git diff --check`
- [x] `git diff --cached --check`
- [x] `py -3.12 -m pytest backend/tests/` -> 46 passed
- [x] `py -3.12 -m compileall backend/app` -> OK
- [x] Regression confirmada: revirtiendo el fix, los 2 tests nuevos fallan (`assert 0 == 1`).

## Evidencia visual

No aplica (cambio solo backend; el comportamiento exterior solo cambia: antes 503 opaco, ahora alta exitosa).

## Fuera de alcance

- No se agrega `concepto_sueldo` al schema `PersonalCreate` ni a la UI. Queda fijo en 1. Si el negocio lo necesita editable, otro issue.
- No se toco DDL de prod. Mantener `NOT NULL` con default válido en el modelo es suficiente.
- No se toco el handler global de 503/500 (issue #34 ya abierto).

## Riesgos / pendientes

- **Despliegue**: requiere re-deploy del backend (`registro_produccion_produccion_fg`). Una vez deployado, el alta de personal desde el admin debería funcionar end-to-end.
- `concepto_sueldo=1` es el id mínimo del catálogo en prod. Si en algún momento migran o limpian el catálogo y el id 1 deja de existir, volvería a romper. Considerar exponerlo en `PersonalCreate` para que el admin elija (issue separado).
- Es el segundo IntegrityError destapado en la misma ruta (#74 porcentaje, #76 concepto_sueldo). Si aparecen más FK con defaults inválidos al intentar de nuevo, considerar un barrido más sistemático de defaults de `Personal` vs catálogos reales (issue separado).