### PR TITLE
fix(ui): silenciar toast global cuando el store ya muestra fallback (issue #62)

### DIFF
--- a/frontend/src/stores/admin.js
+++ b/frontend/src/stores/admin.js
@@ -65,7 +65,7 @@ export const useAdminStore = defineStore('admin', {
       this.loading = true
       this.error = null
       try {
-        const { data } = await api.get('/api/admin/dashboard', { params: filters })
+        const { data } = await api.get('/api/admin/dashboard', { params: filters, _suppressErrorToast: true })
         this.dashboard = data
       } catch (error) {
         this.error = error.response?.data?.detail || 'No se pudo cargar el dashboard de administracion'
@@ -79,7 +79,7 @@ export const useAdminStore = defineStore('admin', {
       this.loadingDashboardOverview = true
       this.dashboardOverviewError = null
       try {
-        const { data } = await api.get('/api/admin/dashboard/overview', { params: filters })
+        const { data } = await api.get('/api/admin/dashboard/overview', { params: filters, _suppressErrorToast: true })
         this.dashboardOverview = data
       } catch (error) {
         this.dashboardOverviewError = error.response?.data?.detail || 'No se pudo cargar el resumen ejecutivo'
@@ -94,7 +94,7 @@ export const useAdminStore = defineStore('admin', {
       try {
         const params = { limit }
         if (fecha) params.fecha = fecha
-        const { data } = await api.get('/api/admin/dashboard/recent-records', { params })
+        const { data } = await api.get('/api/admin/dashboard/recent-records', { params, _suppressErrorToast: true })
         this.recentRecords = data
       } catch {
         this.recentRecords = []
@@ -109,7 +109,7 @@ export const useAdminStore = defineStore('admin', {
       try {
         const params = {}
         if (buscar?.trim()) params.buscar = buscar.trim()
-        const { data } = await api.get('/api/admin/configuracion/usuarios', { params })
+        const { data } = await api.get('/api/admin/configuracion/usuarios', { params, _suppressErrorToast: true })
         this.usuariosConfiguracion = data
       } catch (error) {
         this.error = error.response?.data?.detail || 'No se pudo cargar la configuracion de acceso'

--- a/frontend/src/stores/admin.test.js
+++ b/frontend/src/stores/admin.test.js
@@ -3,6 +3,7 @@ import { createPinia, setActivePinia } from 'pinia'
 
 vi.mock('@/services/api', () => ({
   default: {
+    get: vi.fn(),
     post: vi.fn(),
     put: vi.fn(),
   },
@@ -49,5 +50,65 @@ describe('admin store tipos de proceso requirements', () => {
     await store.updateEntity('tipos-proceso', 12, payload)
 
     expect(api.put).toHaveBeenCalledWith('/api/admin/tipos-proceso/12', payload)
+  })
+})
+
+describe('admin store - toast suppression on local fallback', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  it('fetchDashboard passes _suppressErrorToast when falling back to empty list', async () => {
+    api.get.mockRejectedValueOnce(new Error('boom'))
+    const store = useAdminStore()
+
+    await store.fetchDashboard({ un_id: 1 })
+
+    expect(api.get).toHaveBeenCalledWith(
+      '/api/admin/dashboard',
+      expect.objectContaining({ _suppressErrorToast: true, params: { un_id: 1 } }),
+    )
+    expect(store.dashboard).toEqual([])
+  })
+
+  it('fetchDashboardOverview passes _suppressErrorToast when falling back to null', async () => {
+    api.get.mockRejectedValueOnce(new Error('boom'))
+    const store = useAdminStore()
+
+    await store.fetchDashboardOverview({ un_id: 1 })
+
+    expect(api.get).toHaveBeenCalledWith(
+      '/api/admin/dashboard/overview',
+      expect.objectContaining({ _suppressErrorToast: true, params: { un_id: 1 } }),
+    )
+    expect(store.dashboardOverview).toBeNull()
+  })
+
+  it('fetchRecentRecords passes _suppressErrorToast when falling back to empty list', async () => {
+    api.get.mockRejectedValueOnce(new Error('boom'))
+    const store = useAdminStore()
+
+    await store.fetchRecentRecords({ limit: 5 })
+
+    expect(api.get).toHaveBeenCalledWith(
+      '/api/admin/dashboard/recent-records',
+      expect.objectContaining({ _suppressErrorToast: true, params: { limit: 5 } }),
+    )
+    expect(store.recentRecords).toEqual([])
+  })
+
+  it('fetchUsuariosConfiguracion passes _suppressErrorToast when falling back to empty list', async () => {
+    api.get.mockRejectedValueOnce(new Error('boom'))
+    const store = useAdminStore()
+
+    await store.fetchUsuariosConfiguracion('')
+
+    expect(api.get).toHaveBeenCalledWith(
+      '/api/admin/configuracion/usuarios',
+      expect.objectContaining({ _suppressErrorToast: true, params: {} }),
+    )
+    expect(store.usuariosConfiguracion).toEqual([])
   })
 })

--- a/frontend/src/stores/dashboard.js
+++ b/frontend/src/stores/dashboard.js
@@ -59,7 +59,7 @@ export const useDashboardStore = defineStore('dashboard', {
 
     async loadUnidadesNegocio() {
       try {
-        const { data } = await api.get('/api/produccion/unidades-negocio')
+        const { data } = await api.get('/api/produccion/unidades-negocio', { _suppressErrorToast: true })
         this.unidadesNegocio = Array.isArray(data) ? data : []
       } catch (err) {
         console.error('Error cargando unidades de negocio:', err)
@@ -71,6 +71,7 @@ export const useDashboardStore = defineStore('dashboard', {
       try {
         const { data } = await api.get('/api/dashboard/tipos-proceso-disponibles', {
           params: { un_id: unId },
+          _suppressErrorToast: true,
         })
         this.tiposProceso = data
       } catch (err) {
@@ -83,7 +84,7 @@ export const useDashboardStore = defineStore('dashboard', {
       try {
         const params = { un_id: unId }
         if (tipoProcesoKey) params.tipo_proceso_key = tipoProcesoKey
-        const { data } = await api.get('/api/dashboard/moviles-disponibles', { params })
+        const { data } = await api.get('/api/dashboard/moviles-disponibles', { params, _suppressErrorToast: true })
         this.movilesDisponibles = data
       } catch (err) {
         console.error('Error cargando móviles:', err)
@@ -96,7 +97,7 @@ export const useDashboardStore = defineStore('dashboard', {
       this.loading.kpis = true
       this.error = null
       try {
-        const { data } = await api.get('/api/dashboard/kpis', { params: this._buildParams() })
+        const { data } = await api.get('/api/dashboard/kpis', { params: this._buildParams(), _suppressErrorToast: true })
         this.kpis = data.kpis
         this.filtrosAplicados = data.filtros_aplicados
       } catch (err) {
@@ -117,6 +118,7 @@ export const useDashboardStore = defineStore('dashboard', {
             tipoProcesoKey: this.filtros.evolucion_tipo_proceso_key || this.filtros.tipo_proceso_key,
             metric: 'produccion',
           }),
+          _suppressErrorToast: true,
         })
         this.evolucion = data
       } catch (err) {
@@ -136,6 +138,7 @@ export const useDashboardStore = defineStore('dashboard', {
             tipoProcesoKey: this.filtros.evolucion_tipo_proceso_key || this.filtros.tipo_proceso_key,
             metric: 'combustible',
           }),
+          _suppressErrorToast: true,
         })
         this.evolucionCombustible = data
       } catch (err) {
@@ -155,6 +158,7 @@ export const useDashboardStore = defineStore('dashboard', {
             tipoProcesoKey: this.filtros.ranking_tipo_proceso_key || this.filtros.tipo_proceso_key,
             metric: this.filtros.ranking_metric,
           }),
+          _suppressErrorToast: true,
         })
         this.rankingMaquinas = data
       } catch (err) {

--- a/frontend/src/stores/dashboard.test.js
+++ b/frontend/src/stores/dashboard.test.js
@@ -1,0 +1,115 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createPinia, setActivePinia } from 'pinia'
+
+vi.mock('@/services/api', () => ({
+  default: {
+    get: vi.fn(),
+  },
+}))
+
+import api from '@/services/api'
+import { useDashboardStore } from './dashboard'
+
+describe('dashboard store - toast suppression on local fallback', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  it('loadUnidadesNegocio passes _suppressErrorToast to skip the global toast when fallback is shown', async () => {
+    api.get.mockRejectedValueOnce(new Error('boom'))
+    const store = useDashboardStore()
+
+    await store.loadUnidadesNegocio()
+
+    expect(api.get).toHaveBeenCalledWith(
+      '/api/produccion/unidades-negocio',
+      expect.objectContaining({ _suppressErrorToast: true }),
+    )
+    expect(store.unidadesNegocio).toEqual([])
+  })
+
+  it('loadTiposProceso passes _suppressErrorToast when falling back to empty list', async () => {
+    api.get.mockRejectedValueOnce(new Error('boom'))
+    const store = useDashboardStore()
+
+    await store.loadTiposProceso(7)
+
+    expect(api.get).toHaveBeenCalledWith(
+      '/api/dashboard/tipos-proceso-disponibles',
+      expect.objectContaining({ _suppressErrorToast: true, params: { un_id: 7 } }),
+    )
+    expect(store.tiposProceso).toEqual([])
+  })
+
+  it('loadMovilesDisponibles passes _suppressErrorToast when falling back to empty list', async () => {
+    api.get.mockRejectedValueOnce(new Error('boom'))
+    const store = useDashboardStore()
+
+    await store.loadMovilesDisponibles(7)
+
+    expect(api.get).toHaveBeenCalledWith(
+      '/api/dashboard/moviles-disponibles',
+      expect.objectContaining({ _suppressErrorToast: true, params: { un_id: 7 } }),
+    )
+    expect(store.movilesDisponibles).toEqual([])
+  })
+
+  it('fetchKpis passes _suppressErrorToast when falling back to empty kpis', async () => {
+    api.get.mockRejectedValueOnce(new Error('boom'))
+    const store = useDashboardStore()
+    store.filtros.un_id = 1
+
+    await store.fetchKpis()
+
+    expect(api.get).toHaveBeenCalledWith(
+      '/api/dashboard/kpis',
+      expect.objectContaining({ _suppressErrorToast: true }),
+    )
+    expect(store.kpis).toEqual([])
+  })
+
+  it('fetchEvolucion passes _suppressErrorToast when falling back to empty chart', async () => {
+    api.get.mockRejectedValueOnce(new Error('boom'))
+    const store = useDashboardStore()
+    store.filtros.un_id = 1
+
+    await store.fetchEvolucion()
+
+    expect(api.get).toHaveBeenCalledWith(
+      '/api/dashboard/evolucion',
+      expect.objectContaining({ _suppressErrorToast: true }),
+    )
+    expect(store.evolucion).toEqual({ labels: [], datasets: [] })
+  })
+
+  it('fetchEvolucionCombustible passes _suppressErrorToast when falling back to empty chart', async () => {
+    api.get.mockRejectedValueOnce(new Error('boom'))
+    const store = useDashboardStore()
+    store.filtros.un_id = 1
+
+    await store.fetchEvolucionCombustible()
+
+    expect(api.get).toHaveBeenCalledWith(
+      '/api/dashboard/evolucion',
+      expect.objectContaining({ _suppressErrorToast: true }),
+    )
+    expect(store.evolucionCombustible).toEqual({ labels: [], datasets: [] })
+  })
+
+  it('fetchRanking passes _suppressErrorToast when falling back to empty ranking', async () => {
+    api.get.mockRejectedValueOnce(new Error('boom'))
+    const store = useDashboardStore()
+    store.filtros.un_id = 1
+    store.filtros.ranking_metric = 'produccion'
+
+    await store.fetchRanking()
+
+    expect(api.get).toHaveBeenCalledWith(
+      '/api/dashboard/ranking-maquinas',
+      expect.objectContaining({ _suppressErrorToast: true }),
+    )
+    expect(store.rankingMaquinas).toEqual([])
+  })
+})

--- a/frontend/src/stores/misRegistros.js
+++ b/frontend/src/stores/misRegistros.js
@@ -50,7 +50,7 @@ export const useMisRegistrosStore = defineStore('misRegistros', {
         if (this.filtros.fecha_desde) params.fecha_desde = this.filtros.fecha_desde
         if (this.filtros.fecha_hasta) params.fecha_hasta = this.filtros.fecha_hasta
 
-        const { data } = await api.get('/api/produccion/mis-registros', { params })
+        const { data } = await api.get('/api/produccion/mis-registros', { params, _suppressErrorToast: true })
         this.registros = data.registros
         this.totales = {
           total: data.total,

--- a/frontend/src/stores/misRegistros.test.js
+++ b/frontend/src/stores/misRegistros.test.js
@@ -1,0 +1,34 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createPinia, setActivePinia } from 'pinia'
+
+vi.mock('@/services/api', () => ({
+  default: {
+    get: vi.fn(),
+  },
+}))
+
+import api from '@/services/api'
+import { useMisRegistrosStore } from './misRegistros'
+
+describe('misRegistros store - toast suppression on local fallback', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  it('fetchMisRegistros passes _suppressErrorToast when falling back to empty registros', async () => {
+    api.get.mockRejectedValueOnce(new Error('boom'))
+    const store = useMisRegistrosStore()
+    store.initFiltros()
+
+    await store.fetchMisRegistros()
+
+    expect(api.get).toHaveBeenCalledWith(
+      '/api/produccion/mis-registros',
+      expect.objectContaining({ _suppressErrorToast: true }),
+    )
+    expect(store.registros).toEqual([])
+    expect(store.error).toBe('No se pudieron cargar los registros')
+  })
+})

--- a/frontend/src/stores/produccion.js
+++ b/frontend/src/stores/produccion.js
@@ -100,7 +100,9 @@ export const useProduccionStore = defineStore('produccion', {
       })
 
       try {
-        const { data } = await api.get(url, params ? { params } : undefined)
+        const config = params ? { params } : {}
+        config._suppressErrorToast = true
+        const { data } = await api.get(url, config)
         if (!isValidCatalogPayload(data)) {
           throw new Error('Respuesta invalida del servidor')
         }

--- a/frontend/src/stores/produccion.test.js
+++ b/frontend/src/stores/produccion.test.js
@@ -106,4 +106,28 @@ describe('produccion catalogos offline', () => {
     expect(store.catalogStatus.tiposProceso.state).toBe('empty')
     expect(store.catalogStatus.tiposProceso.stale).toBe(false)
   })
+
+  it('passes _suppressErrorToast so the global toast stays silent when the catalog shows its own fallback', async () => {
+    api.get.mockRejectedValueOnce(new Error('boom'))
+    const store = useProduccionStore()
+
+    await store.fetchOperadores(7)
+
+    expect(api.get).toHaveBeenCalledWith(
+      '/api/produccion/operadores',
+      expect.objectContaining({ _suppressErrorToast: true, params: { un_id: 7 } }),
+    )
+  })
+
+  it('passes _suppressErrorToast on catalog fetches without params', async () => {
+    api.get.mockResolvedValueOnce({ data: [{ id: 1 }] })
+    const store = useProduccionStore()
+
+    await store.fetchUnidadesNegocio()
+
+    expect(api.get).toHaveBeenCalledWith(
+      '/api/produccion/unidades-negocio',
+      expect.objectContaining({ _suppressErrorToast: true }),
+    )
+  })
 })


### PR DESCRIPTION
## Objetivo

Closes #62

## Cambios

- **4 stores + 3 tests** que pasan _suppressErrorToast: true en las fetchXxx que tienen fallback contextual propio ([] / 
ull / {labels:[], datasets:[]}), para que el interceptor global no dispare el toast rojo «Error del servidor» cuando el slot ya muestra la historia.
- **Archivos modificados:**
  - rontend/src/stores/dashboard.js — 7 fetches: loadUnidadesNegocio, loadTiposProceso, loadMovilesDisponibles, fetchKpis, fetchEvolucion, fetchEvolucionCombustible, fetchRanking.
  - rontend/src/stores/admin.js — 4 fetches: fetchDashboard, fetchDashboardOverview, fetchRecentRecords, fetchUsuariosConfiguracion.
  - rontend/src/stores/misRegistros.js — fetchMisRegistros.
  - rontend/src/stores/produccion.js — fetchCatalog (cubre todos los fetchOperadores / fetchMoviles / fetchUnidadesNegocio / fetchTiposProceso / fetchActas / fetchPredios / fetchRodales / fetchLugaresCarga / fetchAsignaciones).
- **Tests nuevos / extendidos:**
  - rontend/src/stores/dashboard.test.js — NUEVO, 7 tests que verifican que cada fetch pasa _suppressErrorToast: true y usa su fallback contextual.
  - rontend/src/stores/misRegistros.test.js — NUEVO, 1 test idem.
  - rontend/src/stores/admin.test.js — +4 tests de supresión (se mockeó pi.get adicional).
  - rontend/src/stores/produccion.test.js — +2 tests de supresión (catalog con params y sin params).

## Comportamiento esperado

- **Dashboard** con ranking vacío / KPI sin datos → NO se ve el toast «Error del servidor».
- **Admin dashboard** con overview fallido → NO se ve el toast.
- **Mis registros** fallando → NO se ve el toast.
- **Catálogos** de producción fallando (con fallback a cache o []) → NO se ve el toast.
- **Login** fallando → SÍ se ve el toast (sin cambios en auth.js).
- **CRUD de admin** → SÍ se ve el toast (fetchEntity/create/update/delete no se tocaron).
- **401** → SÍ se dispara sesión expirada (sin cambios en el interceptor).

## Tests / Validaciones

- [x] 
pm test → **115 passed** (101 existentes + 14 nuevos)
- [x] 
pm run build → build exitoso sin errores
- [x] git diff --check OK

## Evidencia visual

No aplica (cambio de código sin UI nueva; el comportamiento observable es la ausencia del toast rojo en pantallas con fallback).

## Fuera de alcance

- No se modifica el interceptor pi.js — ya tenía el soporte _suppressErrorToast.
- No se tocan fetches sin fallback (login, CRUD, syncPending, submitProduccion). Esos siguen mostrando toast.
- No se toca el backend.

## Riesgos / pendientes

- Si en el futuro se agrega un nuevo endpoint con fallback en slot, la persona que lo cree debe acordarse de pasar _suppressErrorToast: true en su fetch (patrón establecido en este PR).