### PR TITLE
fix(security): pin bcrypt compatible con passlib 1.7.4 (issue #79)

### DIFF
--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -6,7 +6,7 @@ from app.core.config import settings
 ALGORITHM = "HS256"
 PASSWORD_MAX_BYTES = 72
 PASSWORD_TOO_LONG_MESSAGE = "La contrasena es demasiado larga. Usa hasta 72 caracteres o una clave mas corta."
-pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto", bcrypt__truncate_error=False)
 
 
 def validate_password_length(password: str) -> None:

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -7,3 +7,4 @@ python-multipart==0.0.6
 pymysql==1.1.0
 python-jose[cryptography]==3.3.0
 passlib[bcrypt]==1.7.4
+bcrypt>=4.0,<4.2


### PR DESCRIPTION
## Objetivo

Closes #79

## Cambios

- backend/requirements.txt: pin bcrypt>=4.0,<4.2 (passlib 1.7.4 necesita __about__)
- backend/app/core/security.py: bcrypt__truncate_error=False en CryptContext

## Causa raiz

bcrypt 5.0.0 removio __about__, passlib 1.7.4 no puede cargar el backend.
Cualquier hash()/verify() via pwd_context falla. El login no se ve afectado porque los usuarios legacy tienen passwords en texto plano.

## Tests

- py -3.12 -m pytest backend/tests/ -> 46 passed
- py -3.12 -m compileall backend/app -> OK