### PR TITLE
fix(db): pool_pre_ping + pool_recycle para conexiones MySQL remotas (issue #81)

### DIFF
--- a/backend/app/core/database.py
+++ b/backend/app/core/database.py
@@ -44,7 +44,12 @@ elif "mysql" in settings.DATABASE_URL or "pymysql" in settings.DATABASE_URL:
     connect_args["read_timeout"] = 10
     connect_args["write_timeout"] = 10
 
-engine = create_engine(settings.DATABASE_URL, connect_args=connect_args)
+engine = create_engine(
+    settings.DATABASE_URL,
+    connect_args=connect_args,
+    pool_pre_ping=True,
+    pool_recycle=1800,
+)
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
 Base = declarative_base()


### PR DESCRIPTION
Closes #81. pool_pre_ping=True evita que el pool reutilice conexiones ya cerradas por MySQL remoto. pool_recycle=1800 renueva cada 30 min.