### PR TITLE
fix(ui): mostrar error al intentar desvincular la ultima unidad de un personal (issue #83)

### DIFF
--- a/frontend/src/views/admin/AdminCrudView.vue
+++ b/frontend/src/views/admin/AdminCrudView.vue
@@ -1408,6 +1408,12 @@ async function unlinkPersonalFromUnidad(personalId, unidadId) {
   if (!person) return
   const unidadIds = (Array.isArray(person.unidad_ids) ? person.unidad_ids.map(Number) : [])
     .filter((id) => id !== Number(unidadId))
+
+  if (unidadIds.length === 0) {
+    error.value = 'No se puede desvincular al personal de su ultima unidad asignada. Asigna otra unidad antes de quitar esta.'
+    return
+  }
+
   await updateRelationEntity('personal', personalId, { unidad_ids: unidadIds })
 }
 


### PR DESCRIPTION
Closes #83. Evita el caso donde el backend reasigna silenciosamente la unidad_negocio cuando se intenta quitar la ultima vinculacion.