### PR TITLE
Corregir sincronización confiable de registros offline

### DIFF
--- a/backend/app/api/routes/produccion.py
+++ b/backend/app/api/routes/produccion.py
@@ -1,9 +1,10 @@
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
-from sqlalchemy import or_, and_, func, inspect
+from sqlalchemy import or_, and_, func, inspect, text
 from sqlalchemy.exc import SQLAlchemyError
 from typing import List
 from datetime import date, datetime
+from contextlib import contextmanager
 
 from app.api.deps import get_db, get_current_user
 from app.models.personal import Personal
@@ -35,6 +36,40 @@ from app.schemas.produccion import (
 )
 
 router = APIRouter(prefix="/produccion", tags=["produccion"])
+
+
+def _acquire_form_submission_lock(db: Session, lock_name: str) -> bool:
+    result = db.execute(
+        text("SELECT GET_LOCK(:lock_name, 10)"),
+        {"lock_name": lock_name},
+    ).scalar()
+    return result == 1
+
+
+def _release_form_submission_lock(db: Session, lock_name: str) -> None:
+    db.execute(
+        text("SELECT RELEASE_LOCK(:lock_name)"),
+        {"lock_name": lock_name},
+    )
+
+
+@contextmanager
+def _form_submission_lock(db: Session, lock_name: str):
+    # Named locks belong to a MySQL connection, not a transaction. Keep this
+    # dedicated connection checked out until RELEASE_LOCK has completed.
+    connection = db.get_bind().connect()
+    try:
+        if not _acquire_form_submission_lock(connection, lock_name):
+            raise HTTPException(
+                status_code=503,
+                detail="No se pudo reservar el envío. Se reintentará automáticamente.",
+            )
+        yield
+    finally:
+        try:
+            _release_form_submission_lock(connection, lock_name)
+        finally:
+            connection.close()
 
 
 def _table_exists(db: Session, table_name: str) -> bool:
@@ -539,86 +574,103 @@ async def create_produccion(
 ):
     _validate_restricted_payload(data, user, db)
 
-    # Get next ID (tablero_produccion doesn't have auto_increment)
-    max_id = db.query(func.max(TableroProduccion.id)).scalar() or 0
-    new_id = max_id + 1
+    # This table assigns IDs with MAX(id)+1, so serialize all creations. The
+    # same lock also makes the idempotency lookup + insert atomic.
+    with _form_submission_lock(db, "registro_produccion:create"):
+        # The named MySQL lock makes the lookup + insert atomic across workers.
+        if data.form_uuid:
+            existing = (
+                db.query(TableroProduccion)
+                .filter(
+                    TableroProduccion.form_uuid == data.form_uuid,
+                    TableroProduccion.cod_operador == data.cod_operador,
+                )
+                .first()
+            )
+            if existing:
+                return existing
 
-    registro = TableroProduccion(
-        id=new_id,
-        UN=data.UN,
-        operacion=data.operacion,
-        fecha=data.fecha,
-        equipo=data.equipo,
-        operador=data.operador,
-        cod_operador=data.cod_operador,
-        cod_equipo=data.cod_equipo,
-        cod_un=data.cod_un,
-        hr_inicio=data.hr_inicio,
-        hr_fin=data.hr_fin,
-        combustible=data.combustible,
-        aceite_cadena=data.aceite_cadena,
-        aceite_hidraulico=data.aceite_hidraulico,
-        aceite_motor=data.aceite_motor,
-        aceite_transmision=data.aceite_transmision,
-        aceite_embrague=data.aceite_embrague,
-        acta=data.acta,
-        rodal=data.rodal,
-        predio=data.predio,
-        m3=data.m3,
-        carros=data.carros,
-        tn_despachadas=data.tn_despachadas,
-        has=data.has,
-        produccion=data.produccion,
-        plantas=data.plantas,
-        mtrs_recorridos=data.mtrs_recorridos,
-        km_carreteo=data.km_carreteo,
-        km_perfilado=data.km_perfilado,
-        hr_disposicion=data.hr_disposicion,
-        hrs_no_op=data.hrs_no_op,
-        motivo_no_op=data.motivo_no_op,
-        observaciones=data.observaciones,
-        unidad_produccion=data.unidad_produccion,
-        espada=data.espada,
-        puntera=data.puntera,
-        cadena=data.cadena,
-        pinon=data.pinon,
-        cantidad_cadenas=data.cantidad_cadenas,
-        pies_16=data.pies_16,
-        pies_14=data.pies_14,
-        pies_12=data.pies_12,
-        pies_10=data.pies_10,
-        pulpable=data.pulpable,
-        lugar_carga=data.lugar_carga,
-        tabla=data.tabla,
-        codigo_tabla=data.codigo_tabla,
-        fecha_hora=datetime.now(),
-        origen="web",
-    )
-    db.add(registro)
-    db.flush()
+        # Get next ID (tablero_produccion doesn't have auto_increment)
+        max_id = db.query(func.max(TableroProduccion.id)).scalar() or 0
+        new_id = max_id + 1
 
-    # Si se cargó combustible, crear registro en cargacomb
-    if data.combustible and data.combustible > 0:
-        now = datetime.now()
-        carga = CargaComb(
-            idMovil=data.cod_equipo or 0,
-            idTipoComb=1,  # Gasoil por defecto
-            Fecha=data.fecha,
-            KM=0,
-            Litros=data.combustible,
-            UnidadNegocio=data.cod_un or 1,
-            personal=data.cod_operador or 1,
-            idtabla=str(new_id),
-            tabla="tablero_produccion",
-            _usuario="web",
-            _fecha=now.date(),
-            _hora=now.strftime("%H:%M:%S"),
+        registro = TableroProduccion(
+            id=new_id,
+            form_uuid=data.form_uuid,
+            UN=data.UN,
+            operacion=data.operacion,
+            fecha=data.fecha,
+            equipo=data.equipo,
+            operador=data.operador,
+            cod_operador=data.cod_operador,
+            cod_equipo=data.cod_equipo,
+            cod_un=data.cod_un,
+            hr_inicio=data.hr_inicio,
+            hr_fin=data.hr_fin,
+            combustible=data.combustible,
+            aceite_cadena=data.aceite_cadena,
+            aceite_hidraulico=data.aceite_hidraulico,
+            aceite_motor=data.aceite_motor,
+            aceite_transmision=data.aceite_transmision,
+            aceite_embrague=data.aceite_embrague,
+            acta=data.acta,
+            rodal=data.rodal,
+            predio=data.predio,
+            m3=data.m3,
+            carros=data.carros,
+            tn_despachadas=data.tn_despachadas,
+            has=data.has,
+            produccion=data.produccion,
+            plantas=data.plantas,
+            mtrs_recorridos=data.mtrs_recorridos,
+            km_carreteo=data.km_carreteo,
+            km_perfilado=data.km_perfilado,
+            hr_disposicion=data.hr_disposicion,
+            hrs_no_op=data.hrs_no_op,
+            motivo_no_op=data.motivo_no_op,
+            observaciones=data.observaciones,
+            unidad_produccion=data.unidad_produccion,
+            espada=data.espada,
+            puntera=data.puntera,
+            cadena=data.cadena,
+            pinon=data.pinon,
+            cantidad_cadenas=data.cantidad_cadenas,
+            pies_16=data.pies_16,
+            pies_14=data.pies_14,
+            pies_12=data.pies_12,
+            pies_10=data.pies_10,
+            pulpable=data.pulpable,
+            lugar_carga=data.lugar_carga,
+            tabla=data.tabla,
+            codigo_tabla=data.codigo_tabla,
+            fecha_hora=datetime.now(),
+            origen="web",
         )
-        db.add(carga)
+        db.add(registro)
+        db.flush()
 
-    db.commit()
-    db.refresh(registro)
-    return registro
+        # Si se cargó combustible, crear registro en cargacomb
+        if data.combustible and data.combustible > 0:
+            now = datetime.now()
+            carga = CargaComb(
+                idMovil=data.cod_equipo or 0,
+                idTipoComb=1,  # Gasoil por defecto
+                Fecha=data.fecha,
+                KM=0,
+                Litros=data.combustible,
+                UnidadNegocio=data.cod_un or 1,
+                personal=data.cod_operador or 1,
+                idtabla=str(new_id),
+                tabla="tablero_produccion",
+                _usuario="web",
+                _fecha=now.date(),
+                _hora=now.strftime("%H:%M:%S"),
+            )
+            db.add(carga)
+
+        db.commit()
+        db.refresh(registro)
+        return registro
 
 
 @router.get("/mis-registros", response_model=MisRegistrosResponse)

--- a/backend/app/schemas/produccion.py
+++ b/backend/app/schemas/produccion.py
@@ -105,6 +105,7 @@ class LugarCargaResponse(BaseModel):
 
 # --- Tablero Produccion ---
 class TableroProduccionCreate(BaseModel):
+    form_uuid: str = Field(default="", max_length=36)
     UN: str = ""
     operacion: str = ""
     fecha: date

--- a/backend/tests/test_produccion_idempotency.py
+++ b/backend/tests/test_produccion_idempotency.py
@@ -1,0 +1,130 @@
+from datetime import date
+import asyncio
+from types import SimpleNamespace
+from contextlib import contextmanager
+
+import pytest
+from pydantic import ValidationError
+
+from app.api.routes import produccion
+from app.schemas.produccion import TableroProduccionCreate
+
+
+def test_create_schema_accepts_form_uuid_for_idempotent_retries():
+    payload = TableroProduccionCreate(
+        fecha=date(2026, 7, 21),
+        form_uuid="offline-uuid-7",
+    )
+
+    assert payload.form_uuid == "offline-uuid-7"
+
+
+def test_form_uuid_is_limited_to_database_column_length():
+    with pytest.raises(ValidationError):
+        TableroProduccionCreate(
+            fecha=date(2026, 7, 21),
+            form_uuid="x" * 40,
+        )
+
+
+class DuplicateQuery:
+    def __init__(self, existing):
+        self.existing = existing
+
+    def filter(self, *_args):
+        return self
+
+    def first(self):
+        return self.existing
+
+
+class DuplicateDb:
+    def __init__(self, existing):
+        self.existing = existing
+        self.add_called = False
+        self.is_active = True
+
+    def query(self, *_args):
+        return DuplicateQuery(self.existing)
+
+    def add(self, _row):
+        self.add_called = True
+
+
+class ScalarResult:
+    def __init__(self, value):
+        self.value = value
+
+    def scalar(self):
+        return self.value
+
+
+class LockDb:
+    def __init__(self, value=1):
+        self.value = value
+        self.calls = []
+
+    def execute(self, statement, params):
+        self.calls.append((str(statement), params))
+        return ScalarResult(self.value)
+
+    def close(self):
+        self.calls.append(("CLOSE", {}))
+
+
+class LockBind:
+    def __init__(self, connection):
+        self.connection = connection
+
+    def connect(self):
+        return self.connection
+
+
+class SessionWithBind:
+    def __init__(self, connection):
+        self.bind = LockBind(connection)
+
+    def get_bind(self):
+        return self.bind
+
+
+def test_form_submission_lock_uses_mysql_named_lock():
+    db = LockDb()
+
+    assert produccion._acquire_form_submission_lock(db, "registro_produccion:create") is True
+    produccion._release_form_submission_lock(db, "registro_produccion:create")
+
+    assert "GET_LOCK" in db.calls[0][0]
+    assert "RELEASE_LOCK" in db.calls[1][0]
+
+
+def test_form_submission_lock_keeps_one_dedicated_connection_until_release():
+    connection = LockDb()
+    session = SessionWithBind(connection)
+
+    with produccion._form_submission_lock(session, "registro_produccion:create"):
+        assert "GET_LOCK" in connection.calls[0][0]
+        assert all("RELEASE_LOCK" not in statement for statement, _ in connection.calls)
+
+    assert "RELEASE_LOCK" in connection.calls[-2][0]
+    assert connection.calls[-1][0] == "CLOSE"
+
+
+def test_create_returns_existing_record_for_a_retried_form_uuid(monkeypatch):
+    existing = SimpleNamespace(id=42, form_uuid="offline-uuid-7")
+    db = DuplicateDb(existing)
+    monkeypatch.setattr(produccion, "_validate_restricted_payload", lambda *_args: None)
+    @contextmanager
+    def no_lock(*_args):
+        yield
+
+    monkeypatch.setattr(produccion, "_form_submission_lock", no_lock)
+    payload = TableroProduccionCreate(
+        fecha=date(2026, 7, 21),
+        form_uuid="offline-uuid-7",
+    )
+
+    result = asyncio.run(produccion.create_produccion(payload, db=db, user=SimpleNamespace()))
+
+    assert result is existing
+    assert db.add_called is False

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -19,7 +19,7 @@
             </button>
             <div class="min-w-0 px-3 text-center">
               <p class="truncate text-sm font-extrabold text-white">Registro Producción</p>
-              <p class="truncate text-xs font-semibold text-[#9FE1CB]">{{ userRoleLabel }} - {{ connectivityStore.isOnline ? 'En línea' : 'Sin conexión' }}</p>
+              <p class="truncate text-xs font-semibold text-[#9FE1CB]">{{ userRoleLabel }} - {{ backendConnectionLabel }}</p>
             </div>
             <button
               type="button"
@@ -84,7 +84,7 @@
                 <p class="truncate text-sm font-extrabold uppercase text-white">{{ authStore.userName }}</p>
                 <p class="flex items-center gap-1.5 text-xs font-medium text-white">
                   <span class="app-led h-1.5 w-1.5 rounded-full bg-[#10B981] text-[#10B981]"></span>
-                  {{ userRoleLabel }} - {{ connectivityStore.isOnline ? 'En línea' : 'Sin conexión' }}
+                  {{ userRoleLabel }} - {{ backendConnectionLabel }}
                 </p>
               </div>
             </div>
@@ -269,6 +269,11 @@ const openSections = reactive({
 const isAdmin = computed(() => authStore.isAdmin)
 const isEncargado = computed(() => authStore.user?.encargado === 1)
 const canViewDashboard = computed(() => isAdmin.value || isEncargado.value)
+const backendConnectionLabel = computed(() => {
+  if (!connectivityStore.isOnline) return 'Sin conexión'
+  if (connectivityStore.pendingInitialHealthCheck) return 'Verificando servidor'
+  return connectivityStore.isBackendUp ? 'Servidor disponible' : 'Servidor no disponible'
+})
 
 // Whether the operator has ever signed in on this device (has an offline
 // session cache, valid or not). Drives the OfflineBanner copy: when false the
@@ -441,15 +446,19 @@ provide('pwaInstall', { deferredInstallPrompt, installApp })
 // Offline / sync management.
 // `isOnline` now lives in the connectivity store — it is updated by window
 // events registered in main.js via `connectivityStore.init()`.
-const SYNC_INTERVAL_MS = 5 * 60 * 1000
+const SYNC_INTERVAL_MS = 30 * 1000
 let syncIntervalId = null
 
-async function handleOnline() {
-  // The connectivity store handles the boolean; here we just kick off the
-  // sync when we come back online while authenticated.
-  if (authStore.isAuthenticated) {
+async function attemptPendingSync({ forceHealthCheck = false } = {}) {
+  if (!authStore.isAuthenticated || !navigator.onLine) return
+  const backendUp = await connectivityStore.refreshBackendHealth({ force: forceHealthCheck })
+  if (backendUp) {
     await produccionStore.syncPending()
   }
+}
+
+async function handleOnline() {
+  await attemptPendingSync({ forceHealthCheck: true })
 }
 
 onMounted(() => {
@@ -457,13 +466,11 @@ onMounted(() => {
   window.addEventListener('appinstalled', handleAppInstalled)
   window.addEventListener('online', handleOnline)
   if (authStore.isAuthenticated) {
-    produccionStore.refreshPendingCount()
+    produccionStore.refreshPendingCount().then(() => attemptPendingSync({ forceHealthCheck: true }))
   }
 
   syncIntervalId = setInterval(async () => {
-    if (navigator.onLine && authStore.isAuthenticated) {
-      await produccionStore.syncPending()
-    }
+    await attemptPendingSync()
   }, SYNC_INTERVAL_MS)
 })
 

--- a/frontend/src/services/pendingRecords.js
+++ b/frontend/src/services/pendingRecords.js
@@ -7,13 +7,26 @@ function createClientId() {
 }
 
 export async function queuePendingProductionRecord(payload) {
+  const clientId = payload?.form_uuid || createClientId()
   return db.pendingRecords.add({
     payload,
-    clientId: createClientId(),
+    clientId,
     schemaVersion: OFFLINE_SCHEMA_VERSION,
     timestamp: Date.now(),
     synced: 0,
     syncStatus: 'pending',
     retryCount: 0,
   })
+}
+
+export async function ensurePendingIdentity(record) {
+  const formUuid = record.payload?.form_uuid || record.clientId || createClientId()
+  const payload = {
+    ...record.payload,
+    form_uuid: formUuid,
+  }
+  if (record.clientId !== formUuid || record.payload?.form_uuid !== formUuid) {
+    await db.pendingRecords.update(record.id, { clientId: formUuid, payload })
+  }
+  return payload
 }

--- a/frontend/src/services/pendingRecords.test.js
+++ b/frontend/src/services/pendingRecords.test.js
@@ -1,0 +1,39 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/services/db', () => ({
+  default: {
+    pendingRecords: {
+      add: vi.fn(async () => 1),
+      update: vi.fn(async () => 1),
+    },
+  },
+}))
+
+import db from '@/services/db'
+import { ensurePendingIdentity, queuePendingProductionRecord } from './pendingRecords'
+
+describe('pending production records', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('uses form_uuid as the stable local client id', async () => {
+    await queuePendingProductionRecord({ fecha: '2026-07-21', form_uuid: 'form-123' })
+
+    expect(db.pendingRecords.add).toHaveBeenCalledWith(expect.objectContaining({
+      clientId: 'form-123',
+      payload: expect.objectContaining({ form_uuid: 'form-123' }),
+    }))
+  })
+
+  it('persists an identity for a v1 record before retrying it', async () => {
+    const payload = await ensurePendingIdentity({
+      id: 9,
+      payload: { fecha: '2026-07-21' },
+    })
+
+    expect(payload.form_uuid).toBeTruthy()
+    expect(db.pendingRecords.update).toHaveBeenCalledWith(9, expect.objectContaining({
+      clientId: payload.form_uuid,
+      payload,
+    }))
+  })
+})

--- a/frontend/src/stores/produccion.js
+++ b/frontend/src/stores/produccion.js
@@ -1,7 +1,7 @@
 import { defineStore } from 'pinia'
 import api from '@/services/api'
 import db from '@/services/db'
-import { queuePendingProductionRecord } from '@/services/pendingRecords'
+import { ensurePendingIdentity, queuePendingProductionRecord } from '@/services/pendingRecords'
 import { useToastStore } from '@/stores/toast'
 
 const ensureArray = (value) => (Array.isArray(value) ? value : [])
@@ -33,6 +33,14 @@ const createCatalogStatus = () => Object.fromEntries(
 const catalogCacheKey = (catalog, scope = '') => `${catalog}:${scope || 'all'}`
 
 const errorMessage = (err) => err?.response?.data?.detail || err?.message || 'No se pudo cargar el catalogo'
+
+const createFormUuid = () => (
+  globalThis.crypto?.randomUUID?.() || `${Date.now()}-${Math.random()}`
+)
+
+const isPermanentSyncError = (status) => (
+  status >= 400 && status < 500 && ![401, 403, 408, 429].includes(status)
+)
 
 function isValidCatalogPayload(data) {
   return Array.isArray(data)
@@ -260,24 +268,34 @@ export const useProduccionStore = defineStore('produccion', {
     async submitProduccion(formData) {
       this.submitting = true
       this.error = null
+      const submissionPayload = {
+        ...formData,
+        form_uuid: formData.form_uuid || createFormUuid(),
+      }
       try {
         // If offline, queue locally instead of posting
         if (!navigator.onLine) {
-          await queuePendingProductionRecord(formData)
+          await queuePendingProductionRecord(submissionPayload)
           await this.refreshPendingCount()
-          useToastStore().info('Registro guardado offline', 'Se sincronizara cuando vuelva la conexion.')
+          useToastStore().info(
+            'Guardado solo en este teléfono',
+            'Todavía no está confirmado por el servidor. Podés verificarlo en Pendientes.',
+          )
           return { offline: true }
         }
 
-        const { data } = await api.post('/api/produccion', formData)
+        const { data } = await api.post('/api/produccion', submissionPayload)
         useToastStore().success('Registro guardado')
         return data
       } catch (err) {
         // Network error → queue for later
         if (!err.response) {
-          await queuePendingProductionRecord(formData)
+          await queuePendingProductionRecord(submissionPayload)
           await this.refreshPendingCount()
-          useToastStore().info('Registro guardado offline', 'No hubo conexion con el servidor; quedo en cola.')
+          useToastStore().info(
+            'Guardado solo en este teléfono',
+            'El servidor no confirmó la recepción. El registro permanece en Pendientes.',
+          )
           return { offline: true }
         }
         this.error = err.response?.data?.detail || 'Error al guardar el registro'
@@ -289,16 +307,18 @@ export const useProduccionStore = defineStore('produccion', {
     },
 
     async refreshPendingCount() {
-      this.pendingCount = await db.pendingRecords.where('synced').equals(0).count()
+      this.pendingCount = await db.pendingRecords.count()
     },
 
     async syncPending() {
-      if (this.syncingPending) return 0
+      if (this.syncingPending) {
+        return { successCount: 0, pendingCount: this.pendingCount, permanentFailureCount: 0 }
+      }
       this.syncingPending = true
       const pending = await db.pendingRecords.where('synced').equals(0).toArray()
       if (!pending.length) {
         this.syncingPending = false
-        return 0
+        return { successCount: 0, pendingCount: 0, permanentFailureCount: 0 }
       }
 
       this.error = null
@@ -313,13 +333,16 @@ export const useProduccionStore = defineStore('produccion', {
               lastAttemptAt: Date.now(),
               retryCount: Number(record.retryCount || 0) + 1,
             })
-            await api.post('/api/produccion', record.payload)
+            const submissionPayload = await ensurePendingIdentity(record)
+            await api.post('/api/produccion', submissionPayload, {
+              _suppressErrorToast: true,
+            })
             await db.pendingRecords.delete(record.id)
             successCount++
           } catch (err) {
             const status = err?.response?.status
 
-            if (status >= 400 && status < 500) {
+            if (isPermanentSyncError(status)) {
               const detail = err.response?.data?.detail || 'Error permanente al sincronizar el registro'
               await db.pendingRecords.update(record.id, {
                 synced: 1,
@@ -332,8 +355,11 @@ export const useProduccionStore = defineStore('produccion', {
             }
 
             await db.pendingRecords.update(record.id, {
+              synced: 0,
               syncStatus: 'pending',
-              syncError: err.response?.data?.detail || 'Error transitorio. Se reintentara automaticamente.',
+              syncError: [401, 403].includes(status)
+                ? 'La sesión debe validarse nuevamente antes de enviar.'
+                : err.response?.data?.detail || 'Error transitorio. Se reintentará automáticamente.',
             })
           }
         }
@@ -345,7 +371,11 @@ export const useProduccionStore = defineStore('produccion', {
         } else if (successCount > 0) {
           useToastStore().success('Pendientes sincronizados', `${successCount} registro(s) enviados.`)
         }
-        return successCount
+        return {
+          successCount,
+          pendingCount: this.pendingCount,
+          permanentFailureCount,
+        }
       } finally {
         this.syncingPending = false
       }

--- a/frontend/src/stores/produccion.test.js
+++ b/frontend/src/stores/produccion.test.js
@@ -6,6 +6,7 @@ const catalogRows = new Map()
 vi.mock('@/services/api', () => ({
   default: {
     get: vi.fn(),
+    post: vi.fn(),
   },
 }))
 
@@ -18,6 +19,9 @@ vi.mock('@/services/db', () => ({
       get: vi.fn(async (key) => catalogRows.get(key)),
     },
     pendingRecords: {
+      count: vi.fn(async () => 0),
+      delete: vi.fn(),
+      update: vi.fn(),
       where: vi.fn(() => ({
         equals: vi.fn(() => ({
           count: vi.fn(async () => 0),
@@ -29,11 +33,16 @@ vi.mock('@/services/db', () => ({
 }))
 
 vi.mock('@/services/pendingRecords', () => ({
+  ensurePendingIdentity: vi.fn(async (record) => ({
+    ...record.payload,
+    form_uuid: record.payload?.form_uuid || record.clientId,
+  })),
   queuePendingProductionRecord: vi.fn(),
 }))
 
 import api from '@/services/api'
 import db from '@/services/db'
+import { queuePendingProductionRecord } from '@/services/pendingRecords'
 import { useProduccionStore } from './produccion'
 
 describe('produccion catalogos offline', () => {
@@ -129,5 +138,98 @@ describe('produccion catalogos offline', () => {
       '/api/produccion/unidades-negocio',
       expect.objectContaining({ _suppressErrorToast: true }),
     )
+  })
+})
+
+describe('produccion sync offline', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+    api.post.mockReset()
+    queuePendingProductionRecord.mockReset()
+    db.pendingRecords.count.mockReset().mockResolvedValue(0)
+  })
+
+  it('retries a queued record with its stable form_uuid', async () => {
+    db.pendingRecords.where.mockReturnValue({
+      equals: vi.fn(() => ({
+        toArray: vi.fn(async () => [{
+          id: 7,
+          clientId: 'offline-uuid-7',
+          payload: { fecha: '2026-07-21', operacion: 'PROCESO' },
+          retryCount: 0,
+        }]),
+        count: vi.fn(async () => 0),
+      })),
+    })
+    api.post.mockResolvedValueOnce({ data: { id: 99 } })
+    const store = useProduccionStore()
+
+    const result = await store.syncPending()
+
+    expect(api.post).toHaveBeenCalledWith('/api/produccion', expect.objectContaining({
+      fecha: '2026-07-21',
+      form_uuid: 'offline-uuid-7',
+    }), expect.objectContaining({ _suppressErrorToast: true }))
+    expect(db.pendingRecords.delete).toHaveBeenCalledWith(7)
+    expect(result).toEqual({ successCount: 1, pendingCount: 0, permanentFailureCount: 0 })
+  })
+
+  it('reports a transient retry as still pending instead of successful', async () => {
+    db.pendingRecords.count.mockResolvedValueOnce(1)
+    db.pendingRecords.where.mockReturnValue({
+      equals: vi.fn(() => ({
+        toArray: vi.fn(async () => [{ id: 8, clientId: 'offline-uuid-8', payload: {}, retryCount: 1 }]),
+        count: vi.fn(async () => 1),
+      })),
+    })
+    api.post.mockRejectedValueOnce(new Error('network unreachable'))
+    const store = useProduccionStore()
+
+    const result = await store.syncPending()
+
+    expect(result).toEqual({ successCount: 0, pendingCount: 1, permanentFailureCount: 0 })
+  })
+
+  it('keeps authentication failures pending so login can retry them later', async () => {
+    db.pendingRecords.count.mockResolvedValueOnce(1)
+    db.pendingRecords.where.mockReturnValue({
+      equals: vi.fn(() => ({
+        toArray: vi.fn(async () => [{ id: 10, clientId: 'offline-uuid-10', payload: {}, retryCount: 0 }]),
+        count: vi.fn(async () => 1),
+      })),
+    })
+    api.post.mockRejectedValueOnce({ response: { status: 401, data: { detail: 'Sesión expirada' } } })
+    const store = useProduccionStore()
+
+    const result = await store.syncPending()
+
+    expect(db.pendingRecords.update).toHaveBeenLastCalledWith(10, expect.objectContaining({
+      synced: 0,
+      syncStatus: 'pending',
+    }))
+    expect(result).toEqual({ successCount: 0, pendingCount: 1, permanentFailureCount: 0 })
+  })
+
+  it('counts failed local records as requiring attention', async () => {
+    db.pendingRecords.count.mockResolvedValueOnce(3)
+    const store = useProduccionStore()
+
+    await store.refreshPendingCount()
+
+    expect(store.pendingCount).toBe(3)
+  })
+
+  it('keeps one form_uuid when an online request loses its response and is queued', async () => {
+    Object.defineProperty(navigator, 'onLine', { configurable: true, value: true })
+    api.post.mockRejectedValueOnce(new Error('connection reset after commit'))
+    const store = useProduccionStore()
+
+    const result = await store.submitProduccion({ fecha: '2026-07-21' })
+
+    const postedPayload = api.post.mock.calls[0][1]
+    expect(postedPayload.form_uuid).toBeTruthy()
+    expect(queuePendingProductionRecord).toHaveBeenCalledWith(postedPayload)
+    expect(result).toEqual({ offline: true })
   })
 })

--- a/frontend/src/views/HomeView.vue
+++ b/frontend/src/views/HomeView.vue
@@ -5,9 +5,9 @@
         <div class="flex flex-col gap-3 xl:flex-row xl:items-center xl:justify-between">
           <div class="min-w-0">
             <div class="mb-2 flex flex-wrap items-center gap-2">
-              <span :class="['inline-flex items-center gap-2 rounded-full border px-3 py-1 text-[11px] font-extrabold uppercase', isOnline ? 'app-chip-success' : 'app-chip-warning']">
-                <span :class="['app-led h-2 w-2 rounded-full', isOnline ? 'bg-primary text-primary' : 'bg-warning text-warning']"></span>
-                {{ isOnline ? 'En línea' : 'Sin conexión' }}
+              <span :class="['inline-flex items-center gap-2 rounded-full border px-3 py-1 text-[11px] font-extrabold uppercase', backendReachable ? 'app-chip-success' : 'app-chip-warning']">
+                <span :class="['app-led h-2 w-2 rounded-full', backendReachable ? 'bg-primary text-primary' : 'bg-warning text-warning']"></span>
+                {{ backendConnectionLabel }}
               </span>
               <span class="rounded-full border px-3 py-1 text-xs font-bold app-chip-info">{{ isAdmin ? 'Administrador' : roleLabel }}</span>
               <span class="rounded-full border px-3 py-1 text-xs font-bold app-state-inactive">{{ todayLabel }}</span>
@@ -242,21 +242,29 @@
 </template>
 
 <script setup>
-import { computed, defineComponent, h, inject, onMounted, onUnmounted, ref, watch } from 'vue'
+import { computed, defineComponent, h, inject, onMounted, ref, watch } from 'vue'
 import { useRouter } from 'vue-router'
 import { useAuthStore } from '@/stores/auth'
 import { useProduccionStore } from '@/stores/produccion'
 import { useMisRegistrosStore } from '@/stores/misRegistros'
 import { useAdminStore } from '@/stores/admin'
+import { useConnectivityStore } from '@/stores/connectivity'
 import AppIcon from '@/components/ui/AppIcon.vue'
 
 const authStore = useAuthStore()
 const produccionStore = useProduccionStore()
 const recordsStore = useMisRegistrosStore()
 const adminStore = useAdminStore()
+const connectivityStore = useConnectivityStore()
 const router = useRouter()
 const pwaInstall = inject('pwaInstall', null)
-const isOnline = ref(navigator.onLine)
+const isOnline = computed(() => connectivityStore.isOnline)
+const backendReachable = computed(() => connectivityStore.isOnline && connectivityStore.isBackendUp)
+const backendConnectionLabel = computed(() => {
+  if (!connectivityStore.isOnline) return 'Sin conexión'
+  if (connectivityStore.pendingInitialHealthCheck) return 'Verificando servidor'
+  return connectivityStore.isBackendUp ? 'Servidor disponible' : 'Servidor no disponible'
+})
 const selectedDatePreset = ref('today')
 const selectedDate = ref(formatDateInput(new Date()))
 const unitSearch = ref('')
@@ -505,6 +513,7 @@ const operatorSummaryCards = computed(() => [
 
 const syncText = computed(() => {
   if (!isOnline.value) return 'Sin conexión'
+  if (!connectivityStore.isBackendUp) return 'Servidor no disponible'
   if (produccionStore.syncingPending) return 'Sincronizando'
   if (produccionStore.pendingCount > 0) return 'Con pendientes'
   return 'Todo sincronizado'
@@ -779,21 +788,11 @@ function formatDisplayDate(value) {
   }).format(new Date(y, m - 1, d))
 }
 
-function updateOnline() {
-  isOnline.value = navigator.onLine
-}
-
 onMounted(async () => {
   await Promise.all([
     produccionStore.refreshPendingCount(),
     reloadSummary(),
   ])
-  window.addEventListener('online', updateOnline)
-  window.addEventListener('offline', updateOnline)
 })
 
-onUnmounted(() => {
-  window.removeEventListener('online', updateOnline)
-  window.removeEventListener('offline', updateOnline)
-})
 </script>

--- a/frontend/src/views/PendientesView.vue
+++ b/frontend/src/views/PendientesView.vue
@@ -6,8 +6,8 @@
         :description="scopeDescription"
       >
         <template #kicker>
-          <AppBadge :tone="navigatorOnline ? 'success' : 'warning'">
-            {{ navigatorOnline ? 'En línea' : 'Sin conexión' }}
+          <AppBadge :tone="backendReachable ? 'success' : navigatorOnline ? 'error' : 'warning'">
+            {{ backendReachable ? 'Servidor disponible' : navigatorOnline ? 'Servidor no disponible' : 'Sin conexión' }}
           </AppBadge>
           <AppBadge v-if="scopedFailedRecords.length > 0" tone="error">
             {{ scopedFailedRecords.length }} fallido{{ scopedFailedRecords.length !== 1 ? 's' : '' }}
@@ -18,7 +18,7 @@
             <AppIcon name="refresh" size="sm" />
             Refrescar
           </AppButton>
-          <AppButton :loading="syncing" :disabled="!navigatorOnline || scopedPendingRecords.length === 0" @click="syncAll">
+          <AppButton :loading="syncing" :disabled="!backendReachable || scopedPendingRecords.length === 0" @click="syncAll">
             <AppIcon name="sync" size="sm" />
             Sincronizar
           </AppButton>
@@ -31,7 +31,7 @@
             <p class="text-xs font-extrabold uppercase tracking-wide text-on-surface-variant">Estado de sincronización</p>
             <h2 class="mt-1 text-xl font-extrabold text-neutral-950">{{ syncStatusTitle }}</h2>
             <p class="mt-1 text-sm text-on-surface-variant">
-              {{ navigatorOnline ? 'Sistema en línea' : 'Sistema sin conexión' }} · {{ healthMessage }} · Última revisión: {{ lastCheckLabel }}
+              {{ backendReachable ? 'Servidor disponible' : navigatorOnline ? 'Wi-Fi conectado, servidor inaccesible' : 'Sistema sin conexión' }} · {{ healthMessage }} · Última revisión: {{ lastCheckLabel }}
             </p>
           </div>
           <div class="flex h-12 w-12 items-center justify-center rounded-full bg-info-light text-info-dark">
@@ -102,8 +102,8 @@
 
         <div v-else-if="visibleRecords.length === 0" class="mt-3">
           <EmptyState
-            title="Todo sincronizado"
-            description="No hay registros pendientes ni fallidos. Las cargas realizadas se encuentran guardadas correctamente."
+            :title="emptyStateTitle"
+            :description="emptyStateDescription"
             icon="sync"
           >
             <p class="mt-3 text-xs font-semibold text-outline">Última verificación: {{ lastCheckFullLabel }}</p>
@@ -189,9 +189,11 @@
 <script setup>
 import { computed, onMounted, onUnmounted, ref } from 'vue'
 import api from '@/services/api'
+import { ensurePendingIdentity } from '@/services/pendingRecords'
 import db from '@/services/db'
 import { useAuthStore } from '@/stores/auth'
 import { useProduccionStore } from '@/stores/produccion'
+import { useConnectivityStore } from '@/stores/connectivity'
 import { useToastStore } from '@/stores/toast'
 import AppBadge from '@/components/ui/AppBadge.vue'
 import AppButton from '@/components/ui/AppButton.vue'
@@ -203,6 +205,7 @@ import PageHeader from '@/components/ui/PageHeader.vue'
 
 const authStore = useAuthStore()
 const produccionStore = useProduccionStore()
+const connectivityStore = useConnectivityStore()
 const toast = useToastStore()
 
 const records = ref([])
@@ -212,6 +215,7 @@ const retryingId = ref(null)
 const showDetail = ref(false)
 const selectedRecord = ref(null)
 const navigatorOnline = ref(navigator.onLine)
+const backendReachable = computed(() => navigatorOnline.value && connectivityStore.isBackendUp)
 const lastCheckAt = ref(null)
 const activeFilter = ref('all')
 
@@ -252,6 +256,21 @@ const visibleRecords = computed(() => {
   return scopedRecords.value
 })
 
+const emptyStateTitle = computed(() => {
+  if (activeFilter.value === 'recent') return 'Sin confirmaciones recientes'
+  if (scopedRecords.value.length > 0) return 'No hay registros en este filtro'
+  return 'Todo sincronizado'
+})
+
+const emptyStateDescription = computed(() => {
+  if (activeFilter.value === 'recent' && scopedRecords.value.length > 0) {
+    return `No hay confirmaciones recientes; todavía existen ${scopedRecords.value.length} registro(s) que requieren atención.`
+  }
+  if (activeFilter.value === 'recent') return 'Esta pantalla no conserva registros después de que el servidor los confirma.'
+  if (scopedRecords.value.length > 0) return 'Cambiá el filtro para ver los registros que todavía requieren atención.'
+  return 'No hay registros pendientes ni fallidos en este teléfono.'
+})
+
 const scopeDescription = computed(() => {
   if (isAdmin.value) return 'Vista global de la cola disponible en este dispositivo y estado general de sincronización.'
   if (isEncargado.value) return 'Vista de registros pendientes o fallidos para tus unidades de negocio asignadas.'
@@ -282,9 +301,10 @@ const systemFailedDescription = computed(() => {
   return 'Errores de tus cargas locales'
 })
 
-const isHealthy = computed(() => navigatorOnline.value && scopedRecords.value.length === 0)
+const isHealthy = computed(() => backendReachable.value && scopedRecords.value.length === 0)
 const syncStatusTitle = computed(() => {
   if (!navigatorOnline.value) return 'Sin conexión'
+  if (!connectivityStore.isBackendUp) return 'Servidor no disponible'
   if (scopedFailedRecords.value.length > 0) return 'Requiere revisión'
   if (scopedPendingRecords.value.length > 0) return 'Con registros pendientes'
   return 'Todo sincronizado'
@@ -292,6 +312,7 @@ const syncStatusTitle = computed(() => {
 
 const healthMessage = computed(() => {
   if (!navigatorOnline.value) return 'Las nuevas cargas quedaran guardadas en este equipo'
+  if (!connectivityStore.isBackendUp) return 'El Wi-Fi funciona, pero el servidor no responde'
   if (scopedFailedRecords.value.length > 0) return `${scopedFailedRecords.value.length} registro(s) fallidos`
   if (scopedPendingRecords.value.length > 0) return `${scopedPendingRecords.value.length} registro(s) esperando envio`
   return 'Sin conflictos detectados'
@@ -304,11 +325,18 @@ const queueTitle = computed(() => {
 })
 
 const recentActivityTitle = computed(() => {
+  const transientAttempts = scopedPendingRecords.value.filter((record) => Number(record.retryCount || 0) > 0 || record.syncError)
+  if (transientAttempts.length > 0) return `${transientAttempts.length} envío(s) intentado(s) sin confirmación.`
   if (scopedFailedRecords.value.length === 0) return 'No hubo intentos fallidos de sincronización.'
   return `${scopedFailedRecords.value.length} intento(s) fallidos detectados.`
 })
 
 const recentActivityDescription = computed(() => {
+  const transientAttempts = scopedPendingRecords.value.filter((record) => Number(record.retryCount || 0) > 0 || record.syncError)
+  if (transientAttempts.length > 0) {
+    const lastAttempt = [...transientAttempts].sort((a, b) => Number(b.lastAttemptAt || b.timestamp || 0) - Number(a.lastAttemptAt || a.timestamp || 0))[0]
+    return `Último intento sin confirmar: ${lastAttempt?.syncError || 'el servidor no respondió'}.`
+  }
   if (scopedFailedRecords.value.length === 0) return 'La cola offline no registra errores para el alcance actual.'
   const lastFailed = [...scopedFailedRecords.value].sort((a, b) => Number(b.failedAt || b.timestamp || 0) - Number(a.failedAt || a.timestamp || 0))[0]
   return `Ultimo error: ${lastFailed?.syncError || 'sin detalle disponible'}.`
@@ -365,9 +393,21 @@ async function loadRecords() {
 async function syncAll() {
   syncing.value = true
   try {
-    const count = await produccionStore.syncPending()
+    const result = await produccionStore.syncPending()
     await loadRecords()
-    toast.success('Sincronización completa', `${count || 0} registro(s) sincronizado(s).`)
+    if (result.permanentFailureCount > 0) {
+      toast.error(
+        'Sincronización parcial',
+        `${result.permanentFailureCount} registro(s) fueron rechazados por el servidor y requieren revisión.`,
+      )
+    } else if (result.pendingCount > 0) {
+      toast.error(
+        'Sincronización pendiente',
+        `Se enviaron ${result.successCount} registro(s); ${result.pendingCount} siguen guardados solo en este teléfono.`,
+      )
+    } else {
+      toast.success('Sincronización completa', `${result.successCount} registro(s) confirmados por el servidor.`)
+    }
   } catch {
     toast.error('No se pudo sincronizar', 'Revisá la conexión o intentá de nuevo.')
   } finally {
@@ -378,19 +418,31 @@ async function syncAll() {
 async function retryRecord(record) {
   retryingId.value = record.id
   try {
-    await api.post('/api/produccion', record.payload)
+    await db.pendingRecords.update(record.id, {
+      syncStatus: 'syncing',
+      lastAttemptAt: Date.now(),
+      retryCount: Number(record.retryCount || 0) + 1,
+    })
+    const submissionPayload = await ensurePendingIdentity(record)
+    await api.post('/api/produccion', submissionPayload, {
+      _suppressErrorToast: true,
+    })
     await db.pendingRecords.delete(record.id)
     await loadRecords()
     toast.success('Registro sincronizado')
   } catch (err) {
     const detail = err.response?.data?.detail || 'No se pudo sincronizar este registro.'
     const status = err.response?.status
-    await db.pendingRecords.update(record.id, {
-      synced: status >= 400 && status < 500 ? 1 : 0,
-      syncStatus: status >= 400 && status < 500 ? 'failed' : 'pending',
-      syncError: detail,
-      failedAt: Date.now(),
-    })
+    const permanent = status >= 400 && status < 500 && ![401, 403, 408, 429].includes(status)
+    const update = {
+      synced: permanent ? 1 : 0,
+      syncStatus: permanent ? 'failed' : 'pending',
+      syncError: [401, 403].includes(status)
+        ? 'La sesión debe validarse nuevamente antes de enviar.'
+        : detail,
+    }
+    if (permanent) update.failedAt = Date.now()
+    await db.pendingRecords.update(record.id, update)
     await loadRecords()
     toast.error('Sincronización fallida', detail)
   } finally {

--- a/frontend/src/views/ProduccionFormView.vue
+++ b/frontend/src/views/ProduccionFormView.vue
@@ -1758,8 +1758,8 @@ async function handleSubmit() {
     if (result?.offline) {
       await Swal.fire({
         icon: 'info',
-        title: 'Guardado localmente',
-        text: 'Sin conexión. El registro fue guardado en este dispositivo y se enviará automáticamente al recuperar la conexión.',
+        title: 'Guardado solo en este teléfono',
+        text: 'El servidor todavía no confirmó este registro. Quedó en Pendientes y la aplicación seguirá intentando mientras esté abierta.',
         confirmButtonColor: '#3d935d',
         confirmButtonText: 'Entendido',
       })


### PR DESCRIPTION
## Objetivo

Corregir el flujo de registros de producción guardados offline para que nunca se informe confirmación del servidor antes de recibirla y para que los reintentos sean idempotentes.

## Cambios

- Asigna un `form_uuid` estable desde el primer intento y migra pendientes antiguos antes de reintentarlos.
- Serializa la creación con un named lock MySQL mantenido en una conexión dedicada y devuelve el registro existente para el mismo `form_uuid` y operador.
- Reintenta al abrir la app, al recuperar el backend y cada 30 segundos mientras la app está abierta.
- Mantiene pendientes los errores de autenticación, timeout y rate limit para reintentar luego.
- Cuenta y muestra también los registros rechazados que requieren atención.
- Distingue claramente Wi-Fi conectado, servidor disponible y registro confirmado.
- No muestra sincronización completa cuando quedaron registros pendientes o rechazados.

## Causa raíz

La cola local guardaba un `clientId`, pero no lo enviaba al backend. El servidor no tenía idempotencia para reintentos y la UI confundía `navigator.onLine` con disponibilidad real del backend.

## Tests / Validaciones

- [x] Frontend: 122 tests pasaron.
- [x] Backend: 51 tests pasaron.
- [x] `npm run build` exitoso; PWA generada.
- [x] `python -m compileall -q app` exitoso.
- [x] `git diff --check` sin errores.
- [x] Revisión independiente final sin hallazgos Critical ni Important.

## Fuera de alcance

- No se modificó producción ni la base real.
- No se eliminaron registros pendientes de dispositivos.
- No se modificó Nginx ni la red Starlink.

## Riesgos / pendientes

El despliegue y la prueba real con un dispositivo que conserve pendientes requieren aprobación separada y evidencia posterior al despliegue.