### PR TITLE
Evitar redirección insegura al guardar producción

### DIFF
--- a/frontend/src/stores/produccion.js
+++ b/frontend/src/stores/produccion.js
@@ -284,7 +284,7 @@ export const useProduccionStore = defineStore('produccion', {
           return { offline: true }
         }
 
-        const { data } = await api.post('/api/produccion', submissionPayload)
+        const { data } = await api.post('/api/produccion/', submissionPayload)
         useToastStore().success('Registro guardado')
         return data
       } catch (err) {
@@ -334,7 +334,7 @@ export const useProduccionStore = defineStore('produccion', {
               retryCount: Number(record.retryCount || 0) + 1,
             })
             const submissionPayload = await ensurePendingIdentity(record)
-            await api.post('/api/produccion', submissionPayload, {
+            await api.post('/api/produccion/', submissionPayload, {
               _suppressErrorToast: true,
             })
             await db.pendingRecords.delete(record.id)

--- a/frontend/src/stores/produccion.test.js
+++ b/frontend/src/stores/produccion.test.js
@@ -167,7 +167,7 @@ describe('produccion sync offline', () => {
 
     const result = await store.syncPending()
 
-    expect(api.post).toHaveBeenCalledWith('/api/produccion', expect.objectContaining({
+    expect(api.post).toHaveBeenCalledWith('/api/produccion/', expect.objectContaining({
       fecha: '2026-07-21',
       form_uuid: 'offline-uuid-7',
     }), expect.objectContaining({ _suppressErrorToast: true }))
@@ -228,6 +228,7 @@ describe('produccion sync offline', () => {
     const result = await store.submitProduccion({ fecha: '2026-07-21' })
 
     const postedPayload = api.post.mock.calls[0][1]
+    expect(api.post.mock.calls[0][0]).toBe('/api/produccion/')
     expect(postedPayload.form_uuid).toBeTruthy()
     expect(queuePendingProductionRecord).toHaveBeenCalledWith(postedPayload)
     expect(result).toEqual({ offline: true })


### PR DESCRIPTION
## Causa raíz

El frontend enviaba POST a /api/produccion sin barra final. FastAPI respondía 307 hacia http://produccion.servinlgsm.com.ar/api/produccion/ detrás del proxy. Android bloqueaba esa redirección insegura y el POST nunca llegaba al endpoint.

## Cambio

- Usa /api/produccion/ tanto en alta directa como en sincronización pendiente.
- Agrega cobertura de regresión para ambas rutas.

## Validaciones

- [x] Prueba roja observada: 2 fallos por URL sin barra.
- [x] Prueba específica: 11 pasaron.
- [x] Suite frontend: 122 pasaron.
- [x] Build PWA exitoso.
- [x] git diff --check.

## Evidencia de producción

Nginx registró tres POST del dispositivo a las 09:12:57, 09:13:06 y 09:13:12, todos con 307 y sin POST posterior a la URL con barra.