### PR TITLE
Aceptar envíos desde PWA anterior sin redirección

### DIFF
--- a/backend/app/api/routes/produccion.py
+++ b/backend/app/api/routes/produccion.py
@@ -567,6 +567,7 @@ async def get_ultima_hora_fin(
 
 # ─── Crear registro en tablero_produccion ───
 @router.post("/", response_model=TableroProduccionResponse, status_code=201)
+@router.post("", response_model=TableroProduccionResponse, status_code=201, include_in_schema=False)
 async def create_produccion(
     data: TableroProduccionCreate,
     db: Session = Depends(get_db),

--- a/backend/tests/test_produccion_idempotency.py
+++ b/backend/tests/test_produccion_idempotency.py
@@ -10,6 +10,17 @@ from app.api.routes import produccion
 from app.schemas.produccion import TableroProduccionCreate
 
 
+def test_create_accepts_legacy_path_without_redirect():
+    create_paths = {
+        route.path
+        for route in produccion.router.routes
+        if "POST" in getattr(route, "methods", set())
+    }
+
+    assert "/produccion" in create_paths
+    assert "/produccion/" in create_paths
+
+
 def test_create_schema_accepts_form_uuid_for_idempotent_retries():
     payload = TableroProduccionCreate(
         fecha=date(2026, 7, 21),


### PR DESCRIPTION
## Causa raíz

El teléfono del operador conserva una PWA anterior que envía POST a /api/produccion. El backend sólo aceptaba /api/produccion/ y devolvía un 307 hacia HTTP, bloqueado por Android.

## Cambio

- El backend acepta ambas rutas directamente.
- La ruta heredada queda fuera del OpenAPI para no duplicar documentación.
- No requiere actualizar ni limpiar la caché del teléfono.

## Evidencia

- Intentos de las 09:44 llegaron como POST /api/produccion y recibieron 307.
- Prueba roja confirmó que sólo existía /produccion/.
- Prueba corregida confirma ambas rutas.

## Validaciones

- [x] Test específico: 6 pasaron.
- [x] Backend completo: 52 pasaron.
- [x] compileall.
- [x] git diff --check.