### PR TITLE
fix(ui): dropdown maquinaria se mantiene abierto en mobile (issue #27)

### DIFF
--- a/frontend/src/utils/focusInside.js
+++ b/frontend/src/utils/focusInside.js
@@ -1,0 +1,17 @@
+/**
+ * Returns true when the element receiving focus on blur
+ * is inside the given CSS selector.
+ *
+ * Replaces the `setTimeout(close, 200)` trick which fails on iOS
+ * because `mousedown.prevent` does not delay the blur long enough.
+ *
+ * @param {FocusEvent} event The blur event from the input.
+ * @param {string} selector CSS selector for the dropdown container.
+ * @returns {boolean} true if the next focused element is inside the selector.
+ */
+export function focusInside(event, selector) {
+  const next = event && event.relatedTarget
+  if (!next || !selector) return false
+  if (typeof next.closest !== 'function') return false
+  return Boolean(next.closest(selector))
+}

--- a/frontend/src/utils/focusInside.test.js
+++ b/frontend/src/utils/focusInside.test.js
@@ -1,0 +1,64 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { focusInside } from './focusInside.js'
+
+afterEach(() => {
+  document.body.innerHTML = ''
+})
+
+describe('focusInside', () => {
+  it('returns true when relatedTarget is inside the selector (real DOM)', () => {
+    const dropdown = document.createElement('div')
+    dropdown.setAttribute('data-moviles-dropdown', '')
+    const item = document.createElement('button')
+    item.setAttribute('data-moviles-item', '')
+    dropdown.appendChild(item)
+    document.body.appendChild(dropdown)
+
+    const ev = { relatedTarget: item }
+    expect(focusInside(ev, '[data-moviles-dropdown]')).toBe(true)
+  })
+
+  it('returns true when relatedTarget is the selector itself', () => {
+    const dropdown = document.createElement('div')
+    dropdown.setAttribute('data-moviles-dropdown', '')
+    document.body.appendChild(dropdown)
+
+    const ev = { relatedTarget: dropdown }
+    expect(focusInside(ev, '[data-moviles-dropdown]')).toBe(true)
+  })
+
+  it('returns false when relatedTarget is outside the selector', () => {
+    const dropdown = document.createElement('div')
+    dropdown.setAttribute('data-moviles-dropdown', '')
+    document.body.appendChild(dropdown)
+    const outside = document.createElement('button')
+    document.body.appendChild(outside)
+
+    const ev = { relatedTarget: outside }
+    expect(focusInside(ev, '[data-moviles-dropdown]')).toBe(false)
+  })
+
+  it('returns false when event is null', () => {
+    expect(focusInside(null, '[data-moviles-dropdown]')).toBe(false)
+  })
+
+  it('returns false when relatedTarget is null (blur to nothing)', () => {
+    const ev = { relatedTarget: null }
+    expect(focusInside(ev, '[data-moviles-dropdown]')).toBe(false)
+  })
+
+  it('returns false when relatedTarget is undefined', () => {
+    const ev = {}
+    expect(focusInside(ev, '[data-moviles-dropdown]')).toBe(false)
+  })
+
+  it('returns false when selector is empty', () => {
+    const ev = { relatedTarget: document.createElement('div') }
+    expect(focusInside(ev, '')).toBe(false)
+  })
+
+  it('returns false when relatedTarget has no closest method', () => {
+    const ev = { relatedTarget: {} }
+    expect(focusInside(ev, '[data-moviles-dropdown]')).toBe(false)
+  })
+})

--- a/frontend/src/views/ProduccionFormView.vue
+++ b/frontend/src/views/ProduccionFormView.vue
@@ -277,7 +277,7 @@
                 @focus="abrirListaMoviles"
                 @click="abrirListaMoviles"
                 @input="abrirListaMoviles"
-                @blur="cerrarListaMovilesDiferido"
+                @blur="onInputBlur"
                 :class="fieldClass"
                 placeholder="Ej: 1470, JOHN DEERE, N° 3..."
               />
@@ -292,12 +292,14 @@
             </div>
             <div
               v-if="mostrarListaMoviles"
+              data-moviles-dropdown
               class="app-table mt-1.5 max-h-52 overflow-y-auto rounded-xl"
             >
               <button
                 v-for="movil in movilesFiltrados"
                 :key="movil.idMovil"
                 type="button"
+                data-moviles-item
                 @mousedown.prevent="seleccionarMovil(movil)"
                 class="app-table-row w-full border-b border-neutral-100 px-3 py-2 text-left last:border-b-0"
               >
@@ -941,6 +943,7 @@ import AutocompleteField from '@/components/AutocompleteField.vue'
 import AppIcon from '@/components/ui/AppIcon.vue'
 import motivosNoOperativos from '@/data/motivosNoOperativos.json'
 import { cleanLocationValues, getLocationRequirements, shouldShowActaPredioFields } from '@/services/actaPredioRules'
+import { focusInside } from '@/utils/focusInside'
 
 const router = useRouter()
 const authStore = useAuthStore()
@@ -1574,10 +1577,13 @@ function abrirListaMoviles() {
   listaMovilesAbierta.value = true
 }
 
-function cerrarListaMovilesDiferido() {
-  setTimeout(() => {
-    listaMovilesAbierta.value = false
-  }, 200)
+// iOS / mobile: mousedown.prevent no previene el blur con timing
+// suficiente. Usamos relatedTarget del blur: si el focus va a un item
+// del propio dropdown, NO cerramos. Patron equivalente al que usa
+// AutocompleteField para el campo de operador.
+function onInputBlur(event) {
+  if (focusInside(event, '[data-moviles-dropdown]')) return
+  listaMovilesAbierta.value = false
 }
 
 function limpiarBusquedaMovil() {


### PR DESCRIPTION
## Objetivo

Closes #27

El dropdown de maquinaria (paso 3 de Carga de Producción) se cerraba de inmediato al tocar un item en iOS/mobile. En desktop funcionaba porque mousedown.prevent alcanzaba a ejecutarse antes del blur, pero en mobile el blur se dispara antes y el setTimeout(200) terminaba cerrando la lista antes de que el tap registrara la selección.

## Cambios

- Reemplaza \cerrarListaMovilesDiferido()\ (setTimeout 200ms) por \onInputBlur(event)\ que inspecciona \vent.relatedTarget\ con el helper \ocusInside\. Si el próximo focus está dentro del dropdown, no cierra. Patrón equivalente al que ya usa \AutocompleteField\ para el campo de operador.
- Nuevo helper puro \rontend/src/utils/focusInside.js\ para mantenerlo testeable de forma aislada.
- Atributos \data-moviles-dropdown\ y \data-moviles-item\ agregados al template para que el selector sea explícito y robusto.
- Tests unitarios del helper (8 casos: dentro, fuera, null, undefined, event null, selector vacío, relatedTarget sin closest, relatedTarget = dropdown mismo).

## Archivos

- \rontend/src/utils/focusInside.js\ (nuevo, 18 líneas)
- \rontend/src/utils/focusInside.test.js\ (nuevo, 8 tests vitest)
- \rontend/src/views/ProduccionFormView.vue\ (import + onInputBlur + atributos data-)

## Validaciones

- [x] npx vitest run → 130/130 pasando (8 nuevos)
- [x] npx vite build → OK, sin warnings nuevos
- [x] git diff --check

## Fuera de alcance

- Reemplazar el bloque completo de maquinaria por AutocompleteField. Eso sería un refactor mayor; este PR solo arregla el bug puntual del blur en mobile.
- Validar visualmente con PWA instalada en un celular real (lo harás vos al testear offline; yo puedo iterar si detectás algo más).

## Pendiente

- Confirmar manualmente en celular que el dropdown ahora se mantiene abierto al tap.