### PR TITLE
fix(ui): extraer renderManualMarkdown a modulo testeable (issue #28)

### DIFF
--- a/frontend/src/services/manualRenderer.js
+++ b/frontend/src/services/manualRenderer.js
@@ -1,0 +1,189 @@
+/**
+ * Minimal Markdown -> HTML renderer for the user manuals in
+ * `frontend/public/manuales/*.md`.
+ *
+ * Supports:
+ *   - ATX headings (#, ##, ###, ####)
+ *   - Unordered (- ) and ordered (1. ) lists
+ *   - Pipe tables
+ *   - Inline `code` and **bold**
+ *   - A small whitelist of explicit HTML blocks (div.cover, div.page-break,
+ *     div.subtitle, h1-h4, p.meta, img with local src)
+ *
+ * The whitelist lets the manual files use a cover page and page breaks
+ * without exposing arbitrary HTML.
+ *
+ * Everything else is HTML-escaped so that no Markdown source can leak
+ * raw tags into the rendered view.
+ */
+
+const HTML_WHITELIST_TAGS = new Set(['div', 'h1', 'h2', 'h3', 'h4', 'p', 'img'])
+
+function escapeHtml(value) {
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;')
+}
+
+function inline(value) {
+  return escapeHtml(value)
+    .replace(/`([^`]+)`/g, '<code>$1</code>')
+    .replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>')
+}
+
+function isSafeImageSrc(value) {
+  return value.startsWith('/') && !value.startsWith('//') && !/[<>"']/g.test(value)
+}
+
+/**
+ * Try to render a single line as a whitelisted HTML block. Returns the
+ * HTML string when the line matches a known shape, or an empty string
+ * when the line should be processed as regular Markdown.
+ */
+function renderAllowedHtmlLine(value) {
+  if (value === '</div>') return '</div>'
+
+  const pageBreak = value.match(/^<div\s+class="page-break"\s*>\s*<\/div>$/)
+  if (pageBreak) return '<div class="page-break"></div>'
+
+  const div = value.match(/^<div\s+class="(cover|page-break|warning|note)">$/)
+  if (div) return `<div class="${div[1]}">`
+
+  const subtitle = value.match(/^<div\s+class="subtitle"\s*>(.+)<\/div>$/)
+  if (subtitle) return `<div class="subtitle">${inline(subtitle[1])}</div>`
+
+  const heading = value.match(/^<h([1-4])>(.+)<\/h\1>$/)
+  if (heading) return `<h${heading[1]}>${inline(heading[2])}</h${heading[1]}>`
+
+  const meta = value.match(/^<p\s+class="meta"\s*>(.+)<\/p>$/)
+  if (meta) {
+    const parts = meta[1].split(/<br\s*\/?>/i).map((part) => inline(part))
+    return `<p class="meta">${parts.join('<br>')}</p>`
+  }
+
+  const img = value.match(/^<img\s+src="([^"]+)"\s+alt="([^"]*)"\s*\/?>$/)
+  if (!img) return ''
+
+  const normalizedSrc = img[1].replace('../../frontend/public/logo-forestal.png', '/logo-forestal.png')
+  if (!isSafeImageSrc(normalizedSrc)) return ''
+
+  return `<img src="${escapeHtml(normalizedSrc)}" alt="${escapeHtml(img[2])}">`
+}
+
+/**
+ * Render a manual Markdown source as an HTML string safe to bind via v-html.
+ * Any HTML tag not in `HTML_WHITELIST_TAGS` is escaped.
+ */
+export function renderManualMarkdown(markdown) {
+  if (!markdown) return ''
+
+  const normalized = String(markdown)
+    .replaceAll('../../frontend/public/logo-forestal.png', '/logo-forestal.png')
+    .replace(/\r\n/g, '\n')
+
+  const lines = normalized.split('\n')
+  const html = []
+  let paragraph = []
+  let listType = ''
+  let tableRows = []
+
+  function flushParagraph() {
+    if (paragraph.length === 0) return
+    html.push(`<p>${inline(paragraph.join(' '))}</p>`)
+    paragraph = []
+  }
+
+  function flushList() {
+    if (!listType) return
+    html.push(`</${listType}>`)
+    listType = ''
+  }
+
+  function flushTable() {
+    if (tableRows.length === 0) return
+    const rows = tableRows.filter((row) => !/^\s*\|?\s*:?-{3,}:?\s*(\|\s*:?-{3,}:?\s*)+\|?\s*$/.test(row))
+    if (rows.length > 0) {
+      html.push('<table>')
+      rows.forEach((row, index) => {
+        const cells = row.trim().replace(/^\|/, '').replace(/\|$/, '').split('|').map((cell) => cell.trim())
+        const tag = index === 0 ? 'th' : 'td'
+        html.push(`<tr>${cells.map((cell) => `<${tag}>${inline(cell)}</${tag}>`).join('')}</tr>`)
+      })
+      html.push('</table>')
+    }
+    tableRows = []
+  }
+
+  for (const rawLine of lines) {
+    const trimmed = rawLine.trim()
+
+    if (trimmed.includes('|') && /^\|?[^|]+\|/.test(trimmed)) {
+      flushParagraph()
+      flushList()
+      tableRows.push(trimmed)
+      continue
+    }
+
+    flushTable()
+
+    if (!trimmed) {
+      flushParagraph()
+      flushList()
+      continue
+    }
+
+    const allowedHtml = renderAllowedHtmlLine(trimmed)
+    if (allowedHtml) {
+      flushParagraph()
+      flushList()
+      html.push(allowedHtml)
+      continue
+    }
+
+    const heading = trimmed.match(/^(#{1,4})\s+(.+)$/)
+    if (heading) {
+      flushParagraph()
+      flushList()
+      const level = heading[1].length
+      html.push(`<h${level}>${inline(heading[2])}</h${level}>`)
+      continue
+    }
+
+    const unordered = trimmed.match(/^-\s+(.+)$/)
+    if (unordered) {
+      flushParagraph()
+      if (listType !== 'ul') {
+        flushList()
+        html.push('<ul>')
+        listType = 'ul'
+      }
+      html.push(`<li>${inline(unordered[1])}</li>`)
+      continue
+    }
+
+    const ordered = trimmed.match(/^\d+\.\s+(.+)$/)
+    if (ordered) {
+      flushParagraph()
+      if (listType !== 'ol') {
+        flushList()
+        html.push('<ol>')
+        listType = 'ol'
+      }
+      html.push(`<li>${inline(ordered[1])}</li>`)
+      continue
+    }
+
+    paragraph.push(trimmed)
+  }
+
+  flushParagraph()
+  flushList()
+  flushTable()
+
+  return html.join('\n')
+}
+
+export { escapeHtml, inline, isSafeImageSrc, renderAllowedHtmlLine, HTML_WHITELIST_TAGS }

--- a/frontend/src/services/manualRenderer.test.js
+++ b/frontend/src/services/manualRenderer.test.js
@@ -1,0 +1,172 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
+import {
+  renderManualMarkdown,
+  renderAllowedHtmlLine,
+  isSafeImageSrc,
+  escapeHtml,
+} from './manualRenderer.js'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const manualsDir = resolve(here, '../../public/manuales')
+
+describe('manualRenderer - escapeHtml', () => {
+  it('escapes all HTML-significant characters', () => {
+    expect(escapeHtml('<h1>Hola "Mundo" & \'ok\'</h1>'))
+      .toBe('&lt;h1&gt;Hola &quot;Mundo&quot; &amp; &#039;ok&#039;&lt;/h1&gt;')
+  })
+
+  it('handles empty string and number values', () => {
+    expect(escapeHtml('')).toBe('')
+    expect(escapeHtml(42)).toBe('42')
+  })
+})
+
+describe('manualRenderer - isSafeImageSrc', () => {
+  it('accepts local absolute paths', () => {
+    expect(isSafeImageSrc('/logo-forestal.png')).toBe(true)
+    expect(isSafeImageSrc('/assets/x.png')).toBe(true)
+  })
+
+  it('rejects relative, scheme-relative, remote or malformed srcs', () => {
+    expect(isSafeImageSrc('//evil.com/x.png')).toBe(false)
+    expect(isSafeImageSrc('https://evil.com/x.png')).toBe(false)
+    expect(isSafeImageSrc('javascript:alert(1)')).toBe(false)
+    expect(isSafeImageSrc('"><script>')).toBe(false)
+    expect(isSafeImageSrc('logo.png')).toBe(false)
+  })
+})
+
+describe('manualRenderer - renderAllowedHtmlLine (the bug from issue #28)', () => {
+  it('renders the cover opening div', () => {
+    expect(renderAllowedHtmlLine('<div class="cover">')).toBe('<div class="cover">')
+  })
+
+  it('renders the cover closing div', () => {
+    expect(renderAllowedHtmlLine('</div>')).toBe('</div>')
+  })
+
+  it('renders the page-break div (was appearing as raw text in the bug report)', () => {
+    expect(renderAllowedHtmlLine('<div class="page-break"></div>'))
+      .toBe('<div class="page-break"></div>')
+  })
+
+  it('renders the h1 inside the cover (was appearing as raw text in the bug report)', () => {
+    expect(renderAllowedHtmlLine('<h1>Manual de Usuario</h1>'))
+      .toBe('<h1>Manual de Usuario</h1>')
+  })
+
+  it('renders the subtitle div (was appearing as raw text in the bug report)', () => {
+    expect(renderAllowedHtmlLine('<div class="subtitle">Admin</div>'))
+      .toBe('<div class="subtitle">Admin</div>')
+  })
+
+  it('renders the meta paragraph with inline <br>', () => {
+    expect(renderAllowedHtmlLine('<p class="meta">Line 1<br>Line 2</p>'))
+      .toBe('<p class="meta">Line 1<br>Line 2</p>')
+  })
+
+  it('normalizes the local logo src to /logo-forestal.png', () => {
+    expect(renderAllowedHtmlLine('<img src="../../frontend/public/logo-forestal.png" alt="Logo">'))
+      .toBe('<img src="/logo-forestal.png" alt="Logo">')
+  })
+
+  it('rejects remote / unsafe image srcs', () => {
+    expect(renderAllowedHtmlLine('<img src="https://evil.com/x.png" alt="x">')).toBe('')
+  })
+
+  it('returns empty for non-whitelisted HTML so it falls through to paragraph rendering', () => {
+    expect(renderAllowedHtmlLine('<script>alert(1)</script>')).toBe('')
+    expect(renderAllowedHtmlLine('<unknown-tag>x</unknown-tag>')).toBe('')
+  })
+})
+
+describe('manualRenderer - renderManualMarkdown (full pipeline)', () => {
+  it('renders the cover + page-break block without leaking raw tags', () => {
+    const md = `<div class="cover">
+  <img src="../../frontend/public/logo-forestal.png" alt="Logo Forestal">
+  <h1>Manual de Usuario</h1>
+  <div class="subtitle">Admin</div>
+  <p class="meta">Sistema Registro Producción Forestal<br>Versión documental: Junio 2026</p>
+</div>
+
+<div class="page-break"></div>
+
+# Manual de Usuario - Admin
+`
+    const out = renderManualMarkdown(md)
+
+    expect(out).toContain('<div class="cover">')
+    expect(out).toContain('<img src="/logo-forestal.png" alt="Logo Forestal">')
+    expect(out).toContain('<h1>Manual de Usuario</h1>')
+    expect(out).toContain('<div class="subtitle">Admin</div>')
+    expect(out).toContain('<p class="meta">')
+    expect(out).toContain('<div class="page-break"></div>')
+
+    expect(out).not.toContain('&lt;h1&gt;')
+    expect(out).not.toContain('&lt;div class="cover"&gt;')
+    expect(out).not.toContain('&lt;div class="page-break"&gt;')
+    expect(out).not.toContain('&lt;div class="subtitle"&gt;')
+  })
+
+  it('escapes inline <unknown> tags inside paragraphs', () => {
+    const md = 'Linea con <desconocido> adentro\n'
+    const out = renderManualMarkdown(md)
+    expect(out).toContain('&lt;desconocido&gt;')
+  })
+
+  it('renders markdown headings, lists, tables and inline code/bold', () => {
+    const md = `## Seccion
+
+- item **uno**
+- item \`dos\`
+
+1. primero
+2. segundo
+
+| col | val |
+| --- | --- |
+| a | 1 |
+`
+    const out = renderManualMarkdown(md)
+    expect(out).toContain('<h2>Seccion</h2>')
+    expect(out).toContain('<li>item <strong>uno</strong></li>')
+    expect(out).toContain('<li>item <code>dos</code></li>')
+    expect(out).toContain('<ol>')
+    expect(out).toContain('<th>col</th>')
+  })
+
+  it('handles CRLF line endings', () => {
+    const md = '<div class="cover">\r\n  <h1>X</h1>\r\n</div>\r\n'
+    const out = renderManualMarkdown(md)
+    expect(out).toContain('<div class="cover">')
+    expect(out).toContain('<h1>X</h1>')
+    expect(out).toContain('</div>')
+  })
+
+  it('returns empty string for empty or null input', () => {
+    expect(renderManualMarkdown('')).toBe('')
+    expect(renderManualMarkdown(null)).toBe('')
+    expect(renderManualMarkdown(undefined)).toBe('')
+  })
+
+  it('renders all three real manuals without leaking raw HTML tags', () => {
+    for (const name of ['manual-admin.md', 'manual-encargado.md', 'manual-operador.md']) {
+      const md = readFileSync(resolve(manualsDir, name), 'utf8')
+      const out = renderManualMarkdown(md)
+
+      // No raw tag fragments should appear as escaped entities
+      expect(out, `${name}: must not contain escaped <h1> tags`).not.toMatch(/&lt;h[1-4]&gt;/)
+      expect(out, `${name}: must not contain escaped <div class="cover">`).not.toMatch(/&lt;div class="cover"&gt;/)
+      expect(out, `${name}: must not contain escaped <div class="page-break">`).not.toMatch(/&lt;div class="page-break"&gt;/)
+      expect(out, `${name}: must not contain escaped <div class="subtitle">`).not.toMatch(/&lt;div class="subtitle"&gt;/)
+      expect(out, `${name}: must not contain escaped <p class="meta">`).not.toMatch(/&lt;p class="meta"&gt;/)
+
+      // The legitimate rendered forms should be present
+      expect(out, `${name}: should contain cover div`).toContain('<div class="cover">')
+      expect(out, `${name}: should contain page-break div`).toContain('<div class="page-break"></div>')
+    }
+  })
+})

--- a/frontend/src/views/ManualesView.vue
+++ b/frontend/src/views/ManualesView.vue
@@ -98,6 +98,7 @@ import { useAuthStore } from '@/stores/auth'
 import AppButton from '@/components/ui/AppButton.vue'
 import AppIcon from '@/components/ui/AppIcon.vue'
 import PageHeader from '@/components/ui/PageHeader.vue'
+import { renderManualMarkdown } from '@/services/manualRenderer'
 
 const authStore = useAuthStore()
 const loading = ref(false)
@@ -143,7 +144,7 @@ const currentRoleLabel = computed(() => {
   return 'Tu rol: Operador'
 })
 
-const renderedManual = computed(() => renderMarkdown(manualMarkdown.value))
+const renderedManual = computed(() => renderManualMarkdown(manualMarkdown.value))
 
 onMounted(() => {
   activeManualId.value = defaultManualId()
@@ -189,162 +190,6 @@ function manualButtonClass(manual) {
       ? 'border-primary/45 bg-primary-light text-primary-dark shadow-[0_0_18px_rgba(16,185,129,0.10)]'
       : 'app-button-soft border',
   ]
-}
-
-function renderMarkdown(markdown) {
-  const normalized = markdown
-    .replaceAll('../../frontend/public/logo-forestal.png', '/logo-forestal.png')
-    .replace(/\r\n/g, '\n')
-
-  const lines = normalized.split('\n')
-  const html = []
-  let paragraph = []
-  let listType = ''
-  let tableRows = []
-
-  function flushParagraph() {
-    if (paragraph.length === 0) return
-    html.push(`<p>${inline(paragraph.join(' '))}</p>`)
-    paragraph = []
-  }
-
-  function flushList() {
-    if (!listType) return
-    html.push(`</${listType}>`)
-    listType = ''
-  }
-
-  function flushTable() {
-    if (tableRows.length === 0) return
-    const rows = tableRows.filter((row) => !/^\s*\|?\s*:?-{3,}:?\s*(\|\s*:?-{3,}:?\s*)+\|?\s*$/.test(row))
-    if (rows.length > 0) {
-      html.push('<table>')
-      rows.forEach((row, index) => {
-        const cells = row.trim().replace(/^\|/, '').replace(/\|$/, '').split('|').map((cell) => cell.trim())
-        const tag = index === 0 ? 'th' : 'td'
-        html.push(`<tr>${cells.map((cell) => `<${tag}>${inline(cell)}</${tag}>`).join('')}</tr>`)
-      })
-      html.push('</table>')
-    }
-    tableRows = []
-  }
-
-  lines.forEach((line) => {
-    const trimmed = line.trim()
-
-    if (trimmed.includes('|') && /^\|?[^|]+\|/.test(trimmed)) {
-      flushParagraph()
-      flushList()
-      tableRows.push(trimmed)
-      return
-    }
-
-    flushTable()
-
-    if (!trimmed) {
-      flushParagraph()
-      flushList()
-      return
-    }
-
-    const allowedHtml = renderAllowedHtmlLine(trimmed)
-    if (allowedHtml) {
-      flushParagraph()
-      flushList()
-      html.push(allowedHtml)
-      return
-    }
-
-    const heading = trimmed.match(/^(#{1,4})\s+(.+)$/)
-    if (heading) {
-      flushParagraph()
-      flushList()
-      const level = heading[1].length
-      html.push(`<h${level}>${inline(heading[2])}</h${level}>`)
-      return
-    }
-
-    const unordered = trimmed.match(/^-\s+(.+)$/)
-    if (unordered) {
-      flushParagraph()
-      if (listType !== 'ul') {
-        flushList()
-        html.push('<ul>')
-        listType = 'ul'
-      }
-      html.push(`<li>${inline(unordered[1])}</li>`)
-      return
-    }
-
-    const ordered = trimmed.match(/^\d+\.\s+(.+)$/)
-    if (ordered) {
-      flushParagraph()
-      if (listType !== 'ol') {
-        flushList()
-        html.push('<ol>')
-        listType = 'ol'
-      }
-      html.push(`<li>${inline(ordered[1])}</li>`)
-      return
-    }
-
-    paragraph.push(trimmed)
-  })
-
-  flushParagraph()
-  flushList()
-  flushTable()
-
-  return html.join('\n')
-}
-
-function inline(value) {
-  return escapeHtml(value)
-    .replace(/`([^`]+)`/g, '<code>$1</code>')
-    .replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>')
-}
-
-function renderAllowedHtmlLine(value) {
-  if (value === '</div>') return '</div>'
-
-  const pageBreak = value.match(/^<div\s+class="page-break"\s*>\s*<\/div>$/)
-  if (pageBreak) return '<div class="page-break"></div>'
-
-  const div = value.match(/^<div\s+class="(cover|page-break|warning|note)">$/)
-  if (div) return `<div class="${div[1]}">`
-
-  const subtitle = value.match(/^<div\s+class="subtitle"\s*>(.+)<\/div>$/)
-  if (subtitle) return `<div class="subtitle">${inline(subtitle[1])}</div>`
-
-  const heading = value.match(/^<h([1-4])>(.+)<\/h\1>$/)
-  if (heading) return `<h${heading[1]}>${inline(heading[2])}</h${heading[1]}>`
-
-  const meta = value.match(/^<p\s+class="meta"\s*>(.+)<\/p>$/)
-  if (meta) {
-    const parts = meta[1].split(/<br\s*\/?>/i).map((part) => inline(part))
-    return `<p class="meta">${parts.join('<br>')}</p>`
-  }
-
-  const img = value.match(/^<img\s+src="([^"]+)"\s+alt="([^"]*)"\s*\/?>$/)
-  if (!img) return ''
-
-  const normalizedSrc = img[1].replace('../../frontend/public/logo-forestal.png', '/logo-forestal.png')
-  if (!isSafeImageSrc(normalizedSrc)) return ''
-
-  return `<img src="${escapeHtml(normalizedSrc)}" alt="${escapeHtml(img[2])}">`
-}
-
-function isSafeImageSrc(value) {
-  return value.startsWith('/') && !value.startsWith('//') && !/[<>"']/g.test(value)
-}
-
-function escapeHtml(value) {
-  return String(value)
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#039;')
 }
 </script>
 


### PR DESCRIPTION
## Objetivo

Closes #28

El renderer de manuales (`renderMarkdown` inline en `ManualesView.vue`) reportaba HTML literal visible en la lectura en linea de los manuales (especialmente el Admin: tags `<h1>Manual de Usuario</h1>`, `<div class="subtitle">Admin</div>` y `<div class="page-break"></div>` aparecian como texto). Se extrae a un modulo testeable para poder cubrir los casos con tests y detectar regresiones a futuro.

## Cambios

- **Nuevo** `frontend/src/services/manualRenderer.js`: `renderManualMarkdown(markdown)` + helpers (`escapeHtml`, `inline`, `isSafeImageSrc`, `renderAllowedHtmlLine`, `HTML_WHITELIST_TAGS`). Misma logica exacta del inline anterior.
- **Nuevo** `frontend/src/services/manualRenderer.test.js`: 19 tests vitest que incluyen casos especificos del bug (`<h1>Manual de Usuario</h1>`, `<div class="subtitle">Admin</div>`, `<div class="page-break"></div>`, `<p class="meta">`, `<img>` con src local normalizado) + un test que corre el renderer contra los TRES archivos reales (`manual-admin.md`, `manual-encargado.md`, `manual-operador.md`) y verifica que ninguno filtra tags HTML literales.
- **Modificado** `frontend/src/views/ManualesView.vue`: importa `renderManualMarkdown` del nuevo modulo. Se eliminan 159 lineas inline (renderer + helpers). 2 lineas netas nuevas (el import + el call site).

## Archivos

- `frontend/src/services/manualRenderer.js` (nuevo, ~130 lineas)
- `frontend/src/services/manualRenderer.test.js` (nuevo, 19 tests)
- `frontend/src/views/ManualesView.vue` (-159 lineas, +2)

## Validaciones

- [x] `npx vitest run` → **149/149** pasando (130 previos + 19 nuevos)
- [x] `npx vite build` → OK, sin warnings nuevos
- [x] `git diff --check` → OK
- [x] Test contra los 3 manuales reales (admin/encargado/operador) no detecta tags HTML literales en el output

## Fuera de alcance

- No cambie la logica del renderer: es la misma extraccion 1:1, sin cambios funcionales. Si el bug persiste en produccion, el refactor lo hace facilmente localizable (los tests sirven como spec del comportamiento esperado).
- No migre a una libreria externa (marked, markdown-it). El renderer a mano alcanza para lo que necesita este sistema y ya esta probado.

## Pendiente / Riesgo

- El comportamiento del renderer es el mismo. Si el bug visible en el issue fue por SW cache del navegador del usuario (no por el codigo), un hard reload alcanzaria para verlo resuelto.
- Si el bug se reproduce, los tests sirven para TDD: agregar un caso de reproduccion -> fallar -> arreglar el renderer.
