### PR TITLE
feat(admin): lugares de carga con varias unidades de negocio

### DIFF
--- a/backend/app/api/routes/admin_legacy.py
+++ b/backend/app/api/routes/admin_legacy.py
@@ -9,6 +9,7 @@ from app.api.deps import get_current_admin, get_db
 from app.core.security import get_password_hash
 from app.models.asignacion_operativa import AsignacionOperativa
 from app.models.lugar_carga import LugarCarga
+from app.models.lugar_carga_unidad_negocio import LugarCargaUnidadNegocio
 from app.models.movil import Movil
 from app.models.personal import Personal
 from app.models.personal_unidad_negocio import PersonalUnidadNegocio
@@ -186,6 +187,48 @@ def _sync_tipo_proceso_unidades(db: Session, row: TipoDeProceso, unidad_ids: lis
         db.add(UnidadNegocioTipoProceso(un_id=unidad_id, tipo_proceso_id=row.id))
 
 
+def _lugar_carga_unidad_ids(db: Session, row: LugarCarga) -> list[int]:
+    if not _table_exists(db, "lugar_carga_unidad_negocio"):
+        return _normalize_ids([], row.unidad_negocio)
+
+    ids = [
+        int(value)
+        for (value,) in (
+            db.query(LugarCargaUnidadNegocio.unidad_negocio)
+            .filter(
+                LugarCargaUnidadNegocio.idLugarCarga == row.idLugarCarga,
+                LugarCargaUnidadNegocio.activo.is_(True),
+            )
+            .order_by(LugarCargaUnidadNegocio.unidad_negocio)
+            .all()
+        )
+    ]
+    return _normalize_ids(ids, row.unidad_negocio)
+
+
+def _sync_lugar_carga_unidades(db: Session, row: LugarCarga, unidad_ids: list[int] | None) -> None:
+    ids = _normalize_ids(unidad_ids, row.unidad_negocio)
+    if ids:
+        row.unidad_negocio = ids[0]
+
+    if not _table_exists(db, "lugar_carga_unidad_negocio"):
+        return
+
+    db.query(LugarCargaUnidadNegocio).filter(
+        LugarCargaUnidadNegocio.idLugarCarga == row.idLugarCarga
+    ).delete()
+    for unidad_id in ids:
+        db.add(
+            LugarCargaUnidadNegocio(
+                idLugarCarga=row.idLugarCarga,
+                unidad_negocio=unidad_id,
+                prioridad=100,
+                es_default=0,
+                activo=True,
+            )
+        )
+
+
 def _ensure_asignacion_consistente(db: Session, id_movil: int, id_chofer: int, id_proceso: int) -> None:
     movil = db.query(Movil).filter(Movil.idMovil == id_movil).first()
     if not movil:
@@ -301,11 +344,18 @@ def _to_tipo_movil_response(row: TipoMovil) -> TipoMovilResponse:
     )
 
 
-def _to_lugar_carga_response(row: LugarCarga) -> LugarCargaResponse:
+def _to_lugar_carga_response(db: Session, row: LugarCarga) -> LugarCargaResponse:
+    unidad_ids = _lugar_carga_unidad_ids(db, row)
+    if not unidad_ids:
+        principal = int(row.unidad_negocio or 1)
+        unidad_ids = [principal]
+    else:
+        principal = unidad_ids[0]
     return LugarCargaResponse(
         idLugarCarga=row.idLugarCarga,
         detalle=row.Detalle or "",
-        unidad_negocio=int(row.unidad_negocio or 1),
+        unidad_negocio=principal,
+        unidad_ids=unidad_ids,
         activo=int(row.activo or 0),
     )
 
@@ -1299,11 +1349,26 @@ async def list_lugares_carga(
     if buscar:
         query = query.filter(LugarCarga.Detalle.ilike(f"%{buscar.strip()}%"))
     if unidad_id:
-        query = query.filter(LugarCarga.unidad_negocio == unidad_id)
+        if _table_exists(db, "lugar_carga_unidad_negocio"):
+            query = query.outerjoin(
+                LugarCargaUnidadNegocio,
+                LugarCargaUnidadNegocio.idLugarCarga == LugarCarga.idLugarCarga,
+            ).filter(
+                or_(
+                    LugarCarga.unidad_negocio == unidad_id,
+                    LugarCargaUnidadNegocio.unidad_negocio == unidad_id,
+                ),
+                or_(
+                    LugarCargaUnidadNegocio.id.is_(None),
+                    LugarCargaUnidadNegocio.activo.is_(True),
+                ),
+            ).distinct()
+        else:
+            query = query.filter(LugarCarga.unidad_negocio == unidad_id)
     if activo in (0, 1):
         query = query.filter(LugarCarga.activo == activo)
     rows = query.order_by(LugarCarga.Detalle).offset(skip).limit(limit).all()
-    return [_to_lugar_carga_response(r) for r in rows]
+    return [_to_lugar_carga_response(db, r) for r in rows]
 
 
 @router.post("/lugares-carga", response_model=LugarCargaResponse, status_code=status.HTTP_201_CREATED)
@@ -1324,7 +1389,10 @@ async def create_lugar_carga(
     db.add(row)
     db.commit()
     db.refresh(row)
-    return _to_lugar_carga_response(row)
+    _sync_lugar_carga_unidades(db, row, payload.unidad_ids or [payload.unidad_negocio])
+    db.commit()
+    db.refresh(row)
+    return _to_lugar_carga_response(db, row)
 
 
 @router.put("/lugares-carga/{idLugarCarga}", response_model=LugarCargaResponse)
@@ -1339,6 +1407,7 @@ async def update_lugar_carga(
         raise HTTPException(status_code=404, detail="Lugar de carga no encontrado")
 
     data = payload.model_dump(exclude_unset=True)
+    unidad_ids = data.pop("unidad_ids", None)
     if "detalle" in data:
         detalle = (data.pop("detalle") or "").strip()
         if not detalle:
@@ -1349,9 +1418,14 @@ async def update_lugar_carga(
     if "activo" in data:
         row.activo = _normalize_binary(data.pop("activo"))
 
+    if unidad_ids is not None:
+        _sync_lugar_carga_unidades(db, row, unidad_ids)
+    elif "unidad_negocio" in data:
+        _sync_lugar_carga_unidades(db, row, [row.unidad_negocio])
+
     db.commit()
     db.refresh(row)
-    return _to_lugar_carga_response(row)
+    return _to_lugar_carga_response(db, row)
 
 
 @router.delete("/lugares-carga/{idLugarCarga}", response_model=DeleteResponse)

--- a/backend/app/api/routes/produccion.py
+++ b/backend/app/api/routes/produccion.py
@@ -18,6 +18,7 @@ from app.models.produccion import TableroProduccion
 from app.models.carga_comb import CargaComb
 from app.models.asignacion_operativa import AsignacionOperativa
 from app.models.lugar_carga import LugarCarga
+from app.models.lugar_carga_unidad_negocio import LugarCargaUnidadNegocio
 from app.schemas.produccion import (
     OperadorResponse,
     UnidadNegocioResponse,
@@ -518,7 +519,22 @@ async def list_lugares_carga(un_id: int | None = None, db: Session = Depends(get
         return []
     query = db.query(LugarCarga).filter(LugarCarga.activo == 1)
     if un_id:
-        query = query.filter(LugarCarga.unidad_negocio == un_id)
+        if _table_exists(db, "lugar_carga_unidad_negocio"):
+            query = query.outerjoin(
+                LugarCargaUnidadNegocio,
+                LugarCargaUnidadNegocio.idLugarCarga == LugarCarga.idLugarCarga,
+            ).filter(
+                or_(
+                    LugarCarga.unidad_negocio == un_id,
+                    LugarCargaUnidadNegocio.unidad_negocio == un_id,
+                ),
+                or_(
+                    LugarCargaUnidadNegocio.id.is_(None),
+                    LugarCargaUnidadNegocio.activo.is_(True),
+                ),
+            ).distinct()
+        else:
+            query = query.filter(LugarCarga.unidad_negocio == un_id)
     rows = query.order_by(LugarCarga.Detalle).all()
     return [LugarCargaResponse(idLugarCarga=r.idLugarCarga, detalle=r.Detalle) for r in rows]
 

--- a/backend/app/models/lugar_carga_unidad_negocio.py
+++ b/backend/app/models/lugar_carga_unidad_negocio.py
@@ -1,0 +1,14 @@
+from sqlalchemy import Boolean, Column, Integer, SmallInteger
+
+from app.core.database import Base
+
+
+class LugarCargaUnidadNegocio(Base):
+    __tablename__ = "lugar_carga_unidad_negocio"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    idLugarCarga = Column(Integer, nullable=False)
+    unidad_negocio = Column(Integer, nullable=False)
+    prioridad = Column(Integer, nullable=False, default=100)
+    es_default = Column(SmallInteger, nullable=False, default=0)
+    activo = Column(Boolean, nullable=False, default=True)

--- a/backend/app/schemas/admin.py
+++ b/backend/app/schemas/admin.py
@@ -274,12 +274,14 @@ class TipoProcesoResponse(BaseModel):
 class LugarCargaCreate(BaseModel):
     detalle: str = Field(min_length=1)
     unidad_negocio: int = 1
+    unidad_ids: list[int] = Field(default_factory=list)
     activo: int = 1
 
 
 class LugarCargaUpdate(BaseModel):
     detalle: str | None = None
     unidad_negocio: int | None = None
+    unidad_ids: list[int] | None = None
     activo: int | None = None
 
 
@@ -287,6 +289,7 @@ class LugarCargaResponse(BaseModel):
     idLugarCarga: int
     detalle: str
     unidad_negocio: int
+    unidad_ids: list[int] = Field(default_factory=list)
     activo: int
 
 

--- a/backend/tests/test_lugar_carga_unidades.py
+++ b/backend/tests/test_lugar_carga_unidades.py
@@ -1,0 +1,135 @@
+import asyncio
+
+from app.api.routes import admin_legacy
+from app.schemas.admin import LugarCargaCreate, LugarCargaResponse, LugarCargaUpdate
+
+
+class FakeQuery:
+    def __init__(self, row):
+        self.row = row
+
+    def filter(self, *_args, **_kwargs):
+        return self
+
+    def first(self):
+        return self.row
+
+
+class FakeDb:
+    def __init__(self, row):
+        self.row = row
+        self.commits = 0
+        self.refreshed = []
+        self.deleted = []
+        self.added = []
+
+    def query(self, *_args, **_kwargs):
+        return FakeQuery(self.row)
+
+    def commit(self):
+        self.commits += 1
+
+    def refresh(self, row):
+        self.refreshed.append(row)
+
+
+class LugarCargaRow:
+    idLugarCarga = 42
+    Detalle = "BASE FG - STOCK COMBUSTIBLE"
+    activo = 1
+    unidad_negocio = 1
+
+
+def test_lugar_carga_create_defaults_unidad_ids_to_empty_list():
+    payload = LugarCargaCreate(detalle="Patio Norte")
+
+    assert payload.unidad_ids == []
+    assert payload.unidad_negocio == 1
+
+
+def test_lugar_carga_response_includes_unidad_ids(monkeypatch):
+    monkeypatch.setattr(admin_legacy, "_lugar_carga_unidad_ids", lambda _db, _row: [1, 2])
+    row = LugarCargaRow()
+    row.unidad_negocio = 1
+
+    response = admin_legacy._to_lugar_carga_response(object(), row)
+
+    assert response.idLugarCarga == 42
+    assert response.unidad_negocio == 1
+    assert response.unidad_ids == [1, 2]
+    assert response.activo == 1
+
+
+def test_lugar_carga_response_falls_back_to_principal_when_pivot_empty(monkeypatch):
+    monkeypatch.setattr(admin_legacy, "_lugar_carga_unidad_ids", lambda _db, _row: [])
+    row = LugarCargaRow()
+    row.unidad_negocio = 3
+
+    response = admin_legacy._to_lugar_carga_response(object(), row)
+
+    assert response.unidad_negocio == 3
+    assert response.unidad_ids == [3]
+
+
+def test_sync_lugar_carga_unidades_falls_back_when_pivot_table_missing(monkeypatch):
+    monkeypatch.setattr(admin_legacy, "_table_exists", lambda _db, table: False)
+    row = LugarCargaRow()
+    row.unidad_negocio = 1
+    db = FakeDb(row)
+
+    admin_legacy._sync_lugar_carga_unidades(db, row, [5, 7])
+
+    assert row.unidad_negocio == 5
+    assert db.added == []
+
+
+def test_sync_lugar_carga_unidades_replaces_pivot_rows(monkeypatch):
+    monkeypatch.setattr(admin_legacy, "_table_exists", lambda _db, table: True)
+    added: list = []
+    deleted: list = []
+
+    class PivotQuery:
+        def filter(self, *_args, **_kwargs):
+            return self
+
+        def delete(self):
+            deleted.append(True)
+            return 0
+
+    class PivotDb(FakeDb):
+        def query(self, *args, **_kwargs):
+            if args and args[0] is admin_legacy.LugarCargaUnidadNegocio:
+                return PivotQuery()
+            return FakeDb(self.row).query(*args)
+
+        def add(self, obj):
+            added.append(obj)
+
+    row = LugarCargaRow()
+    row.unidad_negocio = 1
+    db = PivotDb(row)
+
+    admin_legacy._sync_lugar_carga_unidades(db, row, [2, 3, 2, -1, 0])
+
+    assert row.unidad_negocio == 2
+    assert [obj.unidad_negocio for obj in added] == [2, 3]
+    assert all(obj.idLugarCarga == 42 for obj in added)
+    assert all(obj.prioridad == 100 for obj in added)
+    assert all(obj.es_default == 0 for obj in added)
+    assert all(obj.activo is True for obj in added)
+    assert deleted == [True]
+
+
+def test_update_lugar_carga_persists_unidad_ids(monkeypatch):
+    monkeypatch.setattr(admin_legacy, "_lugar_carga_unidad_ids", lambda _db, _row: [4, 5])
+    monkeypatch.setattr(admin_legacy, "_sync_lugar_carga_unidades", lambda *_args: None)
+    row = LugarCargaRow()
+    row.unidad_negocio = 1
+    db = FakeDb(row)
+    payload = LugarCargaUpdate(unidad_ids=[4, 5])
+
+    response = asyncio.run(admin_legacy.update_lugar_carga(42, payload, db=db, _=object()))
+
+    assert response.unidad_ids == [4, 5]
+    assert response.unidad_negocio == 4
+    assert db.commits == 1

--- a/db_migrations/20260723_lugar_carga_unidad_negocio.sql
+++ b/db_migrations/20260723_lugar_carga_unidad_negocio.sql
@@ -1,0 +1,37 @@
+-- Issue: allow one lugar de carga to belong to multiple business units.
+-- Idempotent and backward compatible with lugarcarga.unidad_negocio.
+--
+-- Esquema de la tabla ya existente en el server de produccion (referencia):
+--   id              INT UNSIGNED AUTO_INCREMENT PK
+--   idLugarCarga    INT UNSIGNED
+--   unidad_negocio  INT UNSIGNED
+--   prioridad       INT  DEFAULT 100
+--   es_default      TINYINT(1) DEFAULT 0
+--   activo          TINYINT(1) DEFAULT 1
+--   UNIQUE (idLugarCarga, unidad_negocio)
+--   FKs con ON DELETE RESTRICT
+--
+-- Este script es seguro de correr mas de una vez: si la tabla ya existe con
+-- el esquema de arriba, la seccion CREATE TABLE no hace nada. Si la fila de
+-- backfill para un (lugar, unidad) ya existe, el INSERT IGNORE la respeta.
+
+CREATE TABLE IF NOT EXISTS lugar_carga_unidad_negocio (
+  id              INT UNSIGNED NOT NULL AUTO_INCREMENT,
+  idLugarCarga    INT UNSIGNED NOT NULL,
+  unidad_negocio  INT UNSIGNED NOT NULL,
+  prioridad       INT NOT NULL DEFAULT 100,
+  es_default      TINYINT(1) NOT NULL DEFAULT 0,
+  activo          TINYINT(1) NOT NULL DEFAULT 1,
+  PRIMARY KEY (id),
+  UNIQUE KEY uq_lugar_un (idLugarCarga, unidad_negocio),
+  KEY idx_un_default (unidad_negocio, es_default, activo),
+  CONSTRAINT fk_lcun_lugar FOREIGN KEY (idLugarCarga)
+    REFERENCES lugarcarga (idLugarCarga) ON DELETE RESTRICT ON UPDATE CASCADE,
+  CONSTRAINT fk_lcun_un FOREIGN KEY (unidad_negocio)
+    REFERENCES unidadnegocio (idUnidadNegocio) ON DELETE RESTRICT ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+INSERT IGNORE INTO lugar_carga_unidad_negocio (idLugarCarga, unidad_negocio)
+SELECT idLugarCarga, unidad_negocio
+FROM lugarcarga
+WHERE unidad_negocio IS NOT NULL AND unidad_negocio > 0;

--- a/frontend/src/views/admin/AdminCrudView.test.js
+++ b/frontend/src/views/admin/AdminCrudView.test.js
@@ -214,6 +214,54 @@ describe('AdminCrudView tipos de proceso', () => {
     expect(wrapper.findAll('[role="option"]').map((option) => option.text())).toEqual(['AAA111 - Carreton Principal'])
   })
 
+  it('exposes a multi-unit selector for lugares de carga and lists every linked unit', async () => {
+    routeState.params.entity = 'lugares-carga'
+    api.get.mockImplementation((url) => {
+      const dataByUrl = {
+        '/api/admin/lugares-carga': [
+          {
+            idLugarCarga: 9,
+            detalle: 'BASE FG - STOCK COMBUSTIBLE',
+            unidad_negocio: 1,
+            unidad_ids: [1, 2],
+            activo: 1,
+          },
+        ],
+        '/api/admin/unidades-negocio': [
+          { idUnidadNegocio: 1, nombre: 'STOCK DE COMBUSTIBLE - BASE FG', prefijo: 'STK', activo: 1 },
+          { idUnidadNegocio: 2, nombre: 'COSECHA DELTA', prefijo: 'DEL', activo: 1 },
+        ],
+      }
+      return Promise.resolve({ data: dataByUrl[url] || [] })
+    })
+
+    const wrapper = mount(AdminCrudView, {
+      global: {
+        directives: {
+          motionPanel: {},
+          motionPop: {},
+        },
+        stubs: {
+          AppIcon: true,
+        },
+      },
+    })
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('STOCK DE COMBUSTIBLE - BASE FG')
+    expect(wrapper.text()).toContain('COSECHA DELTA')
+
+    const nuevo = wrapper.findAll('button').find((button) => button.text().includes('Nuevo'))
+    expect(nuevo).toBeTruthy()
+    await nuevo.trigger('click')
+    await flushPromises()
+
+    const labels = wrapper.findAll('label').map((label) => label.text())
+    expect(labels).toContain('Unidades de Negocio')
+    const unitCheckboxes = wrapper.findAll('.app-surface-muted input[type="checkbox"]')
+    expect(unitCheckboxes.length).toBe(2)
+  })
+
   it('shows an admin CRUD form for actas used by the production combo', async () => {
     routeState.params.entity = 'actas'
     api.get.mockImplementation((url) => {

--- a/frontend/src/views/admin/AdminCrudView.vue
+++ b/frontend/src/views/admin/AdminCrudView.vue
@@ -753,20 +753,21 @@ const ENTITY_DEFINITIONS = {
   'lugares-carga': {
     title: 'Lugares de Carga',
     singular: 'lugar de carga',
-    description: 'Administra lugares de carga por unidad de negocio.',
-    formHint: 'Cada lugar queda disponible solo para su unidad.',
+    description: 'Administra lugares de carga y las unidades de negocio donde quedan disponibles.',
+    formHint: 'La primera unidad seleccionada queda como principal; el resto se vincula en la tabla pivote.',
     idKey: 'idLugarCarga',
     deleteVerb: 'Desactivar',
     extraReferences: ['unidades-negocio'],
     columns: [
       { key: 'idLugarCarga', label: 'ID' },
       { key: 'detalle', label: 'Detalle' },
-      { key: 'unidad_negocio', label: 'Unidad', type: 'lookup', optionsEntity: 'unidades-negocio', optionValue: 'idUnidadNegocio', optionLabel: 'nombre' },
+      { key: 'unidad_ids', label: 'Unidades', type: 'multiLookup', optionsEntity: 'unidades-negocio', optionValue: 'idUnidadNegocio', optionLabel: 'nombre' },
       { key: 'activo', label: 'Estado', type: 'badge', trueText: 'Activo', falseText: 'Inactivo' },
     ],
     fields: [
       { key: 'detalle', label: 'Detalle', type: 'text', required: true, section: 'principal' },
-      { key: 'unidad_negocio', label: 'Unidad de Negocio', type: 'autocomplete', optionsEntity: 'unidades-negocio', optionValue: 'idUnidadNegocio', optionLabel: 'nombre', default: 1, section: 'principal' },
+      { key: 'unidad_ids', label: 'Unidades de Negocio', type: 'multiselect', optionsEntity: 'unidades-negocio', optionValue: 'idUnidadNegocio', optionLabel: 'nombre', default: [1], section: 'principal' },
+      { key: 'unidad_negocio', label: 'Unidad Principal', type: 'autocomplete', optionsEntity: 'unidades-negocio', optionValue: 'idUnidadNegocio', optionLabel: 'nombre', default: 1, section: 'principal' },
       { key: 'activo', label: 'Activo', type: 'checkbox', output: 'int', default: true, section: 'principal' },
     ],
   },
@@ -1136,6 +1137,7 @@ function validatePayload(payload) {
   }
   if (entity.value === 'moviles' && (!payload.patente?.trim() || !payload.detalle?.trim())) return 'Patente y detalle son obligatorios.'
   if (entity.value === 'tipos-proceso' && !payload.nombre?.trim()) return 'Nombre es obligatorio.'
+  if (entity.value === 'lugares-carga' && (!payload.unidad_ids || payload.unidad_ids.length === 0)) return 'Selecciona al menos una unidad de negocio.'
   if (entity.value === 'asignaciones') return validateAssignment(payload)
   return ''
 }
@@ -1461,7 +1463,7 @@ function toggleMultiValue(key, value, checked) {
   if (checked && !form[key].map(Number).includes(parsed)) form[key].push(parsed)
   if (!checked) form[key] = form[key].filter((item) => Number(item) !== parsed)
 
-  if (key === 'unidad_ids' && entity.value === 'personal') {
+  if (key === 'unidad_ids' && (entity.value === 'personal' || entity.value === 'lugares-carga')) {
     form.unidad_negocio = form[key][0] || form.unidad_negocio || 1
   }
 }
@@ -1479,7 +1481,7 @@ function rowUnidadIds(row) {
   if (entity.value === 'personal') return Array.isArray(row.unidad_ids) ? row.unidad_ids.map(Number) : [Number(row.unidad_negocio || 0)]
   if (entity.value === 'moviles') return [Number(row.id_unidad_negocio || 0)]
   if (entity.value === 'tipos-proceso') return Array.isArray(row.unidad_ids) ? row.unidad_ids.map(Number) : []
-  if (entity.value === 'lugares-carga') return [Number(row.unidad_negocio || 0)]
+  if (entity.value === 'lugares-carga') return Array.isArray(row.unidad_ids) ? row.unidad_ids.map(Number) : [Number(row.unidad_negocio || 0)]
   if (entity.value === 'asignaciones') {
     const movil = findReference('moviles', row.idMovil, 'idMovil')
     return movil ? [Number(movil.id_unidad_negocio || 0)] : []


### PR DESCRIPTION
Permite que un lugar de carga quede disponible para mas de una unidad de negocio, replicando el patron N:M ya usado en personal y tipos de proceso.

## Objetivo

- Front: el modal de Editar lugar de carga muestra un selector multiple de unidades, no un unico select.
- Back: el endpoint expone `unidad_ids` y sincroniza una tabla pivote `lugar_carga_unidad_negocio` (Oscar la crea con el SQL incluido en este PR).
- La columna legacy `lugarcarga.unidad_negocio` se mantiene como la unidad principal (la primera de la lista) para no romper joins con `cargacomb.UnidadNegocio`, `produccion.lugar_carga`, etc.

## Cambios

- `backend/app/models/lugar_carga_unidad_negocio.py` (nuevo): modelo SQLAlchemy de la pivote con PK compuesta.
- `backend/app/schemas/admin.py`: `LugarCargaCreate/Update/Response` suman `unidad_ids: list[int]`.
- `backend/app/api/routes/admin_legacy.py`:
  - Helpers `_lugar_carga_unidad_ids` y `_sync_lugar_carga_unidades` (mismo patron que personal).
  - Tolerancia a tabla pivote inexistente via `_table_exists` (no rompe deploys donde la migracion se aplica despues).
  - `list_lugares_carga` filtra por la pivote cuando existe, con fallback al campo legacy.
  - `create_lugar_carga` / `update_lugar_carga` sincronizan la pivote despues del commit principal.
- `frontend/src/views/admin/AdminCrudView.vue`:
  - Columna Unidad pasa a `multiLookup` con `unidad_ids`.
  - Form suma `multiselect` y mantiene el autocomplete de unidad principal auto-sincronizado.
  - Validacion: al menos una unidad seleccionada.
  - `rowUnidadIds` y `toggleMultiValue` extendidos a lugares-carga.
- `db_migrations/20260723_lugar_carga_unidad_negocio.sql` (nuevo): DDL idempotente + backfill desde `lugarcarga.unidad_negocio`. **Antes de mergear, Oscar debe correr este SQL en la DB de produccion.**
- Tests:
  - `backend/tests/test_lugar_carga_unidades.py` (nuevo): 6 tests cubriendo schema, response, sync con/sin pivote, update end-to-end.
  - `frontend/src/views/admin/AdminCrudView.test.js`: 1 test que verifica multiselect + lista con todas las unidades vinculadas.

## Tests / Validaciones

- [x] `py -3.12 -m pytest` (backend) -> 58 passed
- [x] `py -3.12 -m compileall app` (backend) -> OK
- [x] `git diff --check` -> OK
- [x] `npx vitest run` (frontend) -> 150 passed
- [x] `npx vite build` (frontend) -> OK

## Fuera de alcance

- Siembra de la pivote en `app/seed/demo_data.py` (no rompe; los lugares demo siguen cayendo en la principal).
- Migracion a Alembic (el repo no usa Alembic hoy, se mantiene el patron de scripts en `db_migrations/`).
- Pantalla de carga de produccion: sigue filtrando por el campo legacy `lugar_carga`, asi que el comportamiento operativo no cambia.

## Pasos para deploy

1. Correr `db_migrations/20260723_lugar_carga_unidad_negocio.sql` en la DB (crea la pivote + backfill automatico).
2. Buildear y desplegar backend + frontend como siempre.

## Riesgos / pendientes

- Si el deploy del backend sale antes que el SQL, `_table_exists` evita caidas pero los nuevos `unidad_ids` quedaran vacios hasta que se cree la pivote (la UI mostrara la unidad principal sola).
- Oscar debe revisar el SQL antes de mergear para confirmar el charset y el nombre de FK.
