### PR TITLE
feat(moviles): permitir multiples unidades de negocio via pivote

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,9 @@ migrations.sql
 .agents/
 skills-lock.json
 .env.vps
+
+# Credenciales locales (usuario RO para Mavis, secretos, etc.)
+mavis_ro.env
+backup_mail.env
+*.local.env
+secrets/

--- a/backend/app/api/routes/admin_legacy.py
+++ b/backend/app/api/routes/admin_legacy.py
@@ -11,6 +11,7 @@ from app.models.asignacion_operativa import AsignacionOperativa
 from app.models.lugar_carga import LugarCarga
 from app.models.lugar_carga_unidad_negocio import LugarCargaUnidadNegocio
 from app.models.movil import Movil
+from app.models.movil_unidad_negocio import MovilUnidadNegocio
 from app.models.personal import Personal
 from app.models.personal_unidad_negocio import PersonalUnidadNegocio
 from app.models.produccion import TableroProduccion
@@ -229,6 +230,73 @@ def _sync_lugar_carga_unidades(db: Session, row: LugarCarga, unidad_ids: list[in
         )
 
 
+def _movil_unidad_ids(db: Session, row: Movil) -> list[int]:
+    if not _table_exists(db, "movil_unidad_negocio"):
+        return _normalize_ids([], row.idUnidadNegocio)
+
+    ids = [
+        int(value)
+        for (value,) in (
+            db.query(MovilUnidadNegocio.idUnidadNegocio)
+            .filter(MovilUnidadNegocio.idMovil == row.idMovil)
+            .order_by(MovilUnidadNegocio.idUnidadNegocio)
+            .all()
+        )
+    ]
+    return _normalize_ids(ids, row.idUnidadNegocio)
+
+
+def _movil_unidad_ids_map(db: Session, rows: list[Movil]) -> dict[int, list[int]]:
+    rows_by_id = {
+        int(row.idMovil): row
+        for row in rows
+        if row.idMovil is not None
+    }
+    unit_ids_by_movil: dict[int, list[int]] = {
+        movil_id: _normalize_ids([], row.idUnidadNegocio)
+        for movil_id, row in rows_by_id.items()
+    }
+    if not rows_by_id or not _table_exists(db, "movil_unidad_negocio"):
+        return unit_ids_by_movil
+
+    relation_rows = (
+        db.query(MovilUnidadNegocio.idMovil, MovilUnidadNegocio.idUnidadNegocio)
+        .filter(MovilUnidadNegocio.idMovil.in_(rows_by_id.keys()))
+        .all()
+    )
+    grouped_ids: dict[int, list[int]] = {movil_id: [] for movil_id in rows_by_id}
+    for movil_id, unit_id in relation_rows:
+        try:
+            grouped_ids[int(movil_id)].append(int(unit_id))
+        except (TypeError, ValueError):
+            continue
+
+    return {
+        movil_id: _normalize_ids(grouped_ids.get(movil_id), rows_by_id[movil_id].idUnidadNegocio)
+        for movil_id in rows_by_id
+    }
+
+
+def _sync_movil_unidades(db: Session, row: Movil, unidad_ids: list[int] | None) -> None:
+    ids = _normalize_ids(unidad_ids, row.idUnidadNegocio)
+    if ids:
+        row.idUnidadNegocio = ids[0]
+
+    if not _table_exists(db, "movil_unidad_negocio"):
+        return
+
+    db.query(MovilUnidadNegocio).filter(
+        MovilUnidadNegocio.idMovil == row.idMovil
+    ).delete()
+    for unidad_id in ids:
+        db.add(
+            MovilUnidadNegocio(
+                idMovil=row.idMovil,
+                idUnidadNegocio=unidad_id,
+            )
+        )
+
+
 def _ensure_asignacion_consistente(db: Session, id_movil: int, id_chofer: int, id_proceso: int) -> None:
     movil = db.query(Movil).filter(Movil.idMovil == id_movil).first()
     if not movil:
@@ -242,24 +310,37 @@ def _ensure_asignacion_consistente(db: Session, id_movil: int, id_chofer: int, i
     if not proceso:
         raise HTTPException(status_code=400, detail="Tipo de proceso no encontrado")
 
-    unidad_id = int(movil.idUnidadNegocio or 0)
-    if unidad_id <= 0:
+    movil_unidad_ids = _movil_unidad_ids(db, movil)
+    if not movil_unidad_ids:
         raise HTTPException(status_code=400, detail="El movil debe tener unidad de negocio")
 
-    if unidad_id not in _personal_unidad_ids(db, chofer):
-        raise HTTPException(status_code=400, detail="El chofer no pertenece a la unidad del movil")
+    chofer_unidad_ids = set(_personal_unidad_ids(db, chofer))
+    movil_unidad_set = set(movil_unidad_ids)
+    if not (chofer_unidad_ids & movil_unidad_set):
+        raise HTTPException(
+            status_code=400,
+            detail="El chofer no pertenece a ninguna de las unidades del movil",
+        )
 
     if _table_exists(db, "unidadnegocio_tipo_proceso"):
-        exists = (
-            db.query(UnidadNegocioTipoProceso)
-            .filter(
-                UnidadNegocioTipoProceso.un_id == unidad_id,
-                UnidadNegocioTipoProceso.tipo_proceso_id == id_proceso,
+        habilitado = False
+        for unidad_id in movil_unidad_ids:
+            exists = (
+                db.query(UnidadNegocioTipoProceso)
+                .filter(
+                    UnidadNegocioTipoProceso.un_id == unidad_id,
+                    UnidadNegocioTipoProceso.tipo_proceso_id == id_proceso,
+                )
+                .first()
             )
-            .first()
-        )
-        if not exists:
-            raise HTTPException(status_code=400, detail="El tipo de proceso no esta habilitado para la unidad del movil")
+            if exists:
+                habilitado = True
+                break
+        if not habilitado:
+            raise HTTPException(
+                status_code=400,
+                detail="El tipo de proceso no esta habilitado para ninguna de las unidades del movil",
+            )
 
 
 def _to_personal_response(db: Session, row: Personal) -> PersonalResponse:
@@ -291,13 +372,18 @@ def _to_personal_response_with_units(row: Personal, unidad_ids: list[int]) -> Pe
     )
 
 
-def _to_movil_response(row: Movil) -> MovilResponse:
+def _to_movil_response(db: Session, row: Movil) -> MovilResponse:
+    unit_ids = _movil_unidad_ids(db, row)
+    if not unit_ids:
+        unit_ids = [int(row.idUnidadNegocio or 1)]
+    principal = unit_ids[0]
     return MovilResponse(
         idMovil=row.idMovil,
         patente=row.Patente or "",
         detalle=row.Detalle or "",
         tipo_proceso=row.tipo_proceso or "1",
-        id_unidad_negocio=int(row.idUnidadNegocio or 1),
+        id_unidad_negocio=principal,
+        unidad_ids=unit_ids,
         cant_neumaticos=int(row.CantNeumaticos or 0),
         capacidad_tanque=int(row.capacidad_tanque or 0),
         consumo_promedio=float(row.consumo_promedio or 0),
@@ -311,6 +397,39 @@ def _to_movil_response(row: Movil) -> MovilResponse:
         activo=int(row.activo or 0),
         observaciones=row.observaciones,
     )
+
+
+def _to_movil_responses(db: Session, rows: list[Movil]) -> list[MovilResponse]:
+    unit_ids_map = _movil_unidad_ids_map(db, rows)
+    results: list[MovilResponse] = []
+    for row in rows:
+        unit_ids = unit_ids_map.get(int(row.idMovil), [])
+        if not unit_ids:
+            unit_ids = [int(row.idUnidadNegocio or 1)]
+        principal = unit_ids[0]
+        results.append(
+            MovilResponse(
+                idMovil=row.idMovil,
+                patente=row.Patente or "",
+                detalle=row.Detalle or "",
+                tipo_proceso=row.tipo_proceso or "1",
+                id_unidad_negocio=principal,
+                unidad_ids=unit_ids,
+                cant_neumaticos=int(row.CantNeumaticos or 0),
+                capacidad_tanque=int(row.capacidad_tanque or 0),
+                consumo_promedio=float(row.consumo_promedio or 0),
+                tipo_movil=int(row.tipo_movil or 1),
+                anio_fabricacion=int(row.anio_fabricacion or 0),
+                nro_chasis=row.nro_chasis or "",
+                nro_motor=row.nro_motor or "",
+                venc_tecnica=row.VencTecnica,
+                ruta=bool(row.Ruta),
+                venc_ruta=row.VencRuta,
+                activo=int(row.activo or 0),
+                observaciones=row.observaciones,
+            )
+        )
+    return results
 
 
 def _to_unidad_response(row: UnidadNegocio) -> UnidadNegocioResponse:
@@ -1026,12 +1145,17 @@ async def list_moviles(
     if buscar:
         pattern = f"%{buscar.strip()}%"
         query = query.filter(or_(Movil.Detalle.ilike(pattern), Movil.Patente.ilike(pattern)))
-    if unidad_id:
+    if unidad_id and _table_exists(db, "movil_unidad_negocio"):
+        query = query.join(
+            MovilUnidadNegocio,
+            MovilUnidadNegocio.idMovil == Movil.idMovil,
+        ).filter(MovilUnidadNegocio.idUnidadNegocio == unidad_id)
+    elif unidad_id:
         query = query.filter(Movil.idUnidadNegocio == unidad_id)
     if activo in (0, 1):
         query = query.filter(Movil.activo == activo)
     rows = query.order_by(Movil.Detalle).offset(skip).limit(limit).all()
-    return [_to_movil_response(r) for r in rows]
+    return _to_movil_responses(db, rows)
 
 
 @router.post("/moviles", response_model=MovilResponse, status_code=status.HTTP_201_CREATED)
@@ -1043,11 +1167,17 @@ async def create_movil(
     if not payload.patente.strip() or not payload.detalle.strip():
         raise HTTPException(status_code=400, detail="Patente y detalle son obligatorios")
 
+    principal_id = (
+        payload.unidad_ids[0]
+        if payload.unidad_ids
+        else payload.id_unidad_negocio
+    )
+
     row = Movil(
         Patente=payload.patente.strip(),
         Detalle=payload.detalle.strip(),
         tipo_proceso=payload.tipo_proceso,
-        idUnidadNegocio=payload.id_unidad_negocio,
+        idUnidadNegocio=principal_id,
         CantNeumaticos=payload.cant_neumaticos,
         capacidad_tanque=payload.capacidad_tanque,
         consumo_promedio=payload.consumo_promedio,
@@ -1065,7 +1195,10 @@ async def create_movil(
     db.add(row)
     db.commit()
     db.refresh(row)
-    return _to_movil_response(row)
+    _sync_movil_unidades(db, row, payload.unidad_ids or [payload.id_unidad_negocio])
+    db.commit()
+    db.refresh(row)
+    return _to_movil_response(db, row)
 
 
 @router.put("/moviles/{idMovil}", response_model=MovilResponse)
@@ -1080,6 +1213,8 @@ async def update_movil(
         raise HTTPException(status_code=404, detail="Movil no encontrado")
 
     data = payload.model_dump(exclude_unset=True)
+    unidad_ids = data.pop("unidad_ids", None)
+    sync_units_due_to_id = False
 
     mapping = {
         "patente": "Patente",
@@ -1107,13 +1242,20 @@ async def update_movil(
                 if not value:
                     raise HTTPException(status_code=400, detail=f"{source} es obligatorio")
             setattr(row, target, value)
+            if source == "id_unidad_negocio" and unidad_ids is None:
+                sync_units_due_to_id = True
 
     if "activo" in data:
         row.activo = _normalize_binary(data.pop("activo"))
 
+    if unidad_ids is not None:
+        _sync_movil_unidades(db, row, unidad_ids)
+    elif sync_units_due_to_id:
+        _sync_movil_unidades(db, row, [row.idUnidadNegocio])
+
     db.commit()
     db.refresh(row)
-    return _to_movil_response(row)
+    return _to_movil_response(db, row)
 
 
 @router.delete("/moviles/{idMovil}", response_model=DeleteResponse)

--- a/backend/app/api/routes/produccion.py
+++ b/backend/app/api/routes/produccion.py
@@ -13,6 +13,7 @@ from app.models.unidad_negocio import UnidadNegocio
 from app.models.tipo_proceso import TipoDeProceso, UnidadNegocioTipoProceso
 from app.models.movil import Movil
 from app.models.movil_operador import MovilOperador
+from app.models.movil_unidad_negocio import MovilUnidadNegocio
 from app.models.ubicacion import Acta, Predio, Rodal
 from app.models.produccion import TableroProduccion
 from app.models.carga_comb import CargaComb
@@ -106,6 +107,35 @@ def _personal_unidad_ids(db: Session, personal: Personal) -> list[int]:
         ]
         return _normalize_ids(ids, personal.unidad_negocio)
     return _normalize_ids([], personal.unidad_negocio)
+
+
+def _movil_unidad_ids(db: Session, movil: Movil) -> list[int]:
+    if _table_exists(db, "movil_unidad_negocio"):
+        ids = [
+            int(value)
+            for (value,) in (
+                db.query(MovilUnidadNegocio.idUnidadNegocio)
+                .filter(MovilUnidadNegocio.idMovil == movil.idMovil)
+                .all()
+            )
+        ]
+        return _normalize_ids(ids, movil.idUnidadNegocio)
+    return _normalize_ids([], movil.idUnidadNegocio)
+
+
+def _movil_belongs_to_any_unidad(db: Session, movil: Movil, unidad_ids: list[int]) -> bool:
+    if not unidad_ids:
+        return True
+    return any(unit_id in _movil_unidad_ids(db, movil) for unit_id in unidad_ids)
+
+
+def _filter_moviles_by_allowed_unidades(query, db: Session, allowed_ids: list[int]):
+    if _table_exists(db, "movil_unidad_negocio"):
+        return query.join(
+            MovilUnidadNegocio,
+            MovilUnidadNegocio.idMovil == Movil.idMovil,
+        ).filter(MovilUnidadNegocio.idUnidadNegocio.in_(allowed_ids))
+    return query.filter(Movil.idUnidadNegocio.in_(allowed_ids))
 
 
 def _personal_unidad_ids_map(db: Session, people: list[Personal]) -> dict[int, list[int]]:
@@ -205,7 +235,7 @@ def _validate_restricted_payload(data: TableroProduccionCreate, user: Personal, 
         raise HTTPException(status_code=403, detail="El operador no esta habilitado para Full Tree")
 
     movil = db.query(Movil).filter(Movil.idMovil == data.cod_equipo, Movil.activo == 1).first()
-    if not movil or int(movil.idUnidadNegocio or 0) not in restricted:
+    if not movil or not _movil_belongs_to_any_unidad(db, movil, restricted):
         raise HTTPException(status_code=403, detail="El movil no esta habilitado para Full Tree")
 
     if data.codigo_tabla and not _tipo_proceso_habilitado(db, data.codigo_tabla, int(data.cod_un)):
@@ -338,7 +368,7 @@ async def list_asignaciones(
         )
     )
     if allowed_ids:
-        query = query.filter(Movil.idUnidadNegocio.in_(allowed_ids))
+        query = _filter_moviles_by_allowed_unidades(query, db, allowed_ids)
         if _table_exists(db, "unidadnegocio_tipo_proceso"):
             allowed_process_ids = [
                 int(value)
@@ -386,7 +416,7 @@ async def get_movil_by_operador(
         if asig:
             movil_query = db.query(Movil).filter(Movil.idMovil == asig.idMovil, Movil.activo == 1)
             if allowed_ids:
-                movil_query = movil_query.filter(Movil.idUnidadNegocio.in_(allowed_ids))
+                movil_query = _filter_moviles_by_allowed_unidades(movil_query, db, allowed_ids)
             movil = movil_query.first()
             if movil:
                 return MovilResponse(
@@ -420,7 +450,7 @@ async def get_movil_by_operador(
                 Movil.activo == 1,
             )
             if allowed_ids:
-                movil_query = movil_query.filter(Movil.idUnidadNegocio.in_(allowed_ids))
+                movil_query = _filter_moviles_by_allowed_unidades(movil_query, db, allowed_ids)
             movil = movil_query.first()
             if movil:
                 return MovilResponse(
@@ -434,7 +464,7 @@ async def get_movil_by_operador(
     if _table_exists(db, "moviles"):
         movil_query = db.query(Movil).filter(Movil.idChofer == operador_id, Movil.activo == 1)
         if allowed_ids:
-            movil_query = movil_query.filter(Movil.idUnidadNegocio.in_(allowed_ids))
+            movil_query = _filter_moviles_by_allowed_unidades(movil_query, db, allowed_ids)
         movil = movil_query.first()
         if movil:
             return MovilResponse(
@@ -459,7 +489,7 @@ async def list_moviles(
     if allowed_ids == []:
         return []
     if allowed_ids:
-        query = query.filter(Movil.idUnidadNegocio.in_(allowed_ids))
+        query = _filter_moviles_by_allowed_unidades(query, db, allowed_ids)
     rows = query.order_by(Movil.Detalle, Movil.Patente).all()
     return [
         MovilResponse(

--- a/backend/app/models/movil_unidad_negocio.py
+++ b/backend/app/models/movil_unidad_negocio.py
@@ -1,0 +1,10 @@
+from sqlalchemy import Column, Integer
+
+from app.core.database import Base
+
+
+class MovilUnidadNegocio(Base):
+    __tablename__ = "movil_unidad_negocio"
+
+    idMovil = Column(Integer, primary_key=True)
+    idUnidadNegocio = Column(Integer, primary_key=True)

--- a/backend/app/schemas/admin.py
+++ b/backend/app/schemas/admin.py
@@ -159,6 +159,7 @@ class MovilCreate(BaseModel):
     detalle: str = Field(min_length=1)
     tipo_proceso: str = "1"
     id_unidad_negocio: int = 1
+    unidad_ids: list[int] = Field(default_factory=list)
     cant_neumaticos: int = 0
     capacidad_tanque: int = 0
     consumo_promedio: float = 0
@@ -178,6 +179,7 @@ class MovilUpdate(BaseModel):
     detalle: str | None = None
     tipo_proceso: str | None = None
     id_unidad_negocio: int | None = None
+    unidad_ids: list[int] | None = None
     cant_neumaticos: int | None = None
     capacidad_tanque: int | None = None
     consumo_promedio: float | None = None
@@ -198,6 +200,7 @@ class MovilResponse(BaseModel):
     detalle: str
     tipo_proceso: str
     id_unidad_negocio: int
+    unidad_ids: list[int] = Field(default_factory=list)
     cant_neumaticos: int
     capacidad_tanque: int
     consumo_promedio: float

--- a/backend/tests/test_movil_unidades.py
+++ b/backend/tests/test_movil_unidades.py
@@ -1,0 +1,211 @@
+import asyncio
+
+from app.api.routes import admin_legacy
+from app.schemas.admin import MovilCreate, MovilResponse, MovilUpdate
+
+
+class FakeQuery:
+    def __init__(self, row):
+        self.row = row
+
+    def filter(self, *_args, **_kwargs):
+        return self
+
+    def first(self):
+        return self.row
+
+
+class FakeDb:
+    def __init__(self, row):
+        self.row = row
+        self.commits = 0
+        self.refreshed = []
+        self.deleted = []
+        self.added = []
+
+    def query(self, *_args, **_kwargs):
+        return FakeQuery(self.row)
+
+    def commit(self):
+        self.commits += 1
+
+    def refresh(self, row):
+        self.refreshed.append(row)
+
+    def get_bind(self):
+        return self
+
+    def add(self, _obj):
+        self.added.append(_obj)
+
+
+class MovilRow:
+    idMovil = 17
+    Patente = "MWY673"
+    Detalle = "CAMION CARGADOR"
+    tipo_proceso = "1"
+    idUnidadNegocio = 1
+    CantNeumaticos = 6
+    capacidad_tanque = 200
+    consumo_promedio = 25.5
+    tipo_movil = 2
+    anio_fabricacion = 2019
+    nro_chasis = "CH-001"
+    nro_motor = "MTR-002"
+    VencTecnica = None
+    Ruta = False
+    VencRuta = None
+    activo = 1
+    observaciones = None
+
+
+def test_movil_create_defaults_unidad_ids_to_empty_list():
+    payload = MovilCreate(patente="MWY673", detalle="CAMION CARGADOR")
+
+    assert payload.unidad_ids == []
+    assert payload.id_unidad_negocio == 1
+
+
+def test_movil_response_includes_unidad_ids(monkeypatch):
+    monkeypatch.setattr(admin_legacy, "_movil_unidad_ids", lambda _db, _row: [1, 2, 5])
+    row = MovilRow()
+
+    response = admin_legacy._to_movil_response(object(), row)
+
+    assert response.idMovil == 17
+    assert response.id_unidad_negocio == 1
+    assert response.unidad_ids == [1, 2, 5]
+    assert response.activo == 1
+
+
+def test_movil_response_falls_back_to_principal_when_pivot_empty(monkeypatch):
+    monkeypatch.setattr(admin_legacy, "_movil_unidad_ids", lambda _db, _row: [])
+    row = MovilRow()
+    row.idUnidadNegocio = 3
+
+    response = admin_legacy._to_movil_response(object(), row)
+
+    assert response.id_unidad_negocio == 3
+    assert response.unidad_ids == [3]
+
+
+def test_movil_responses_bulk_hydrates_unit_ids(monkeypatch):
+    monkeypatch.setattr(admin_legacy, "_movil_unidad_ids_map", lambda _db, rows: {17: [4, 5], 18: [6]})
+    row_a = MovilRow()
+    row_a.idUnidadNegocio = 1
+    row_b = MovilRow()
+    row_b.idMovil = 18
+    row_b.idUnidadNegocio = 1
+
+    responses = admin_legacy._to_movil_responses(object(), [row_a, row_b])
+
+    assert [r.unidad_ids for r in responses] == [[4, 5], [6]]
+    assert responses[0].id_unidad_negocio == 4
+    assert responses[1].id_unidad_negocio == 6
+
+
+def test_sync_movil_unidades_falls_back_when_pivot_table_missing(monkeypatch):
+    monkeypatch.setattr(admin_legacy, "_table_exists", lambda _db, table: False)
+    row = MovilRow()
+    db = FakeDb(row)
+
+    admin_legacy._sync_movil_unidades(db, row, [5, 7])
+
+    assert row.idUnidadNegocio == 5
+    assert db.added == []
+
+
+def test_sync_movil_unidades_replaces_pivot_rows(monkeypatch):
+    monkeypatch.setattr(admin_legacy, "_table_exists", lambda _db, table: True)
+    added: list = []
+    deleted: list = []
+
+    class PivotQuery:
+        def filter(self, *_args, **_kwargs):
+            return self
+
+        def delete(self):
+            deleted.append(True)
+            return 0
+
+    class PivotDb(FakeDb):
+        def query(self, *args, **_kwargs):
+            if args and args[0] is admin_legacy.MovilUnidadNegocio:
+                return PivotQuery()
+            return FakeDb(self.row).query(*args)
+
+        def add(self, obj):
+            added.append(obj)
+
+    row = MovilRow()
+    db = PivotDb(row)
+
+    admin_legacy._sync_movil_unidades(db, row, [2, 3, 2, -1, 0])
+
+    assert row.idUnidadNegocio == 2
+    assert [obj.idUnidadNegocio for obj in added] == [2, 3]
+    assert all(obj.idMovil == 17 for obj in added)
+    assert deleted == [True]
+
+
+def test_update_movil_persists_unidad_ids(monkeypatch):
+    monkeypatch.setattr(admin_legacy, "_movil_unidad_ids", lambda _db, _row: [4, 5])
+    monkeypatch.setattr(admin_legacy, "_sync_movil_unidades", lambda *_args: None)
+    row = MovilRow()
+    db = FakeDb(row)
+    payload = MovilUpdate(unidad_ids=[4, 5])
+
+    response = asyncio.run(admin_legacy.update_movil(17, payload, db=db, _=object()))
+
+    assert response.unidad_ids == [4, 5]
+    assert response.id_unidad_negocio == 4
+    assert db.commits == 1
+
+
+def test_update_movil_id_unidad_negocio_resyncs_pivot_when_no_unidad_ids(monkeypatch):
+    sync_calls: list = []
+    monkeypatch.setattr(admin_legacy, "_sync_movil_unidades", lambda db, row, ids: sync_calls.append((row.idMovil, list(ids))))
+    row = MovilRow()
+    db = FakeDb(row)
+    payload = MovilUpdate(id_unidad_negocio=8)
+
+    asyncio.run(admin_legacy.update_movil(17, payload, db=db, _=object()))
+
+    assert sync_calls == [(17, [8])]
+
+
+def test_create_movil_uses_first_unidad_id_as_principal(monkeypatch):
+    sync_calls: list = []
+    monkeypatch.setattr(admin_legacy, "_sync_movil_unidades", lambda db, row, ids: (sync_calls.append(list(ids)), setattr(row, "idUnidadNegocio", ids[0] if ids else row.idUnidadNegocio)))
+    monkeypatch.setattr(admin_legacy, "_to_movil_response", lambda _db, row: MovilResponse(
+        idMovil=row.idMovil or 99,
+        patente=row.Patente or "",
+        detalle=row.Detalle or "",
+        tipo_proceso=row.tipo_proceso or "1",
+        id_unidad_negocio=int(row.idUnidadNegocio or 1),
+        unidad_ids=[int(row.idUnidadNegocio or 1)],
+        cant_neumaticos=int(row.CantNeumaticos or 0),
+        capacidad_tanque=int(row.capacidad_tanque or 0),
+        consumo_promedio=float(row.consumo_promedio or 0),
+        tipo_movil=int(row.tipo_movil or 1),
+        anio_fabricacion=int(row.anio_fabricacion or 0),
+        nro_chasis=row.nro_chasis or "",
+        nro_motor=row.nro_motor or "",
+        venc_tecnica=row.VencTecnica,
+        ruta=bool(row.Ruta),
+        venc_ruta=row.VencRuta,
+        activo=int(row.activo or 0),
+        observaciones=row.observaciones,
+    ))
+    row = MovilRow()
+    db = FakeDb(row)
+
+    asyncio.run(
+        admin_legacy.create_movil(
+            MovilCreate(patente="AA111", detalle="TRACTOR", unidad_ids=[3, 4, 5]),
+            db=db,
+            _=object(),
+        )
+    )
+
+    assert sync_calls and sync_calls[0] == [3, 4, 5]

--- a/db_migrations/20260724_movil_unidad_negocio.sql
+++ b/db_migrations/20260724_movil_unidad_negocio.sql
@@ -1,0 +1,26 @@
+-- Permite que un movil pertenezca a varias unidades de negocio.
+-- Idempotente y compatible hacia atras con moviles.idUnidadNegocio.
+--
+-- El backfill inicial toma la unidad "principal" historica de cada movil
+-- (columna moviles.idUnidadNegocio) y la inserta en la pivote para que
+-- ningun movil quede sin unidades al activar el endpoint de produccion.
+--
+-- El endpoint /api/produccion/moviles pasa a filtrar por esta pivote, por
+-- lo que es seguro correr este script antes de deployar el cambio de
+-- codigo (no se rompe nada existente).
+
+CREATE TABLE IF NOT EXISTS movil_unidad_negocio (
+  idMovil         INT UNSIGNED NOT NULL,
+  idUnidadNegocio INT UNSIGNED NOT NULL,
+  PRIMARY KEY (idMovil, idUnidadNegocio),
+  KEY idx_mun_un (idUnidadNegocio),
+  CONSTRAINT FK_mun_movil FOREIGN KEY (idMovil)
+    REFERENCES moviles (idMovil) ON UPDATE CASCADE ON DELETE CASCADE,
+  CONSTRAINT FK_mun_unidad FOREIGN KEY (idUnidadNegocio)
+    REFERENCES unidadnegocio (idUnidadNegocio) ON UPDATE CASCADE ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+INSERT IGNORE INTO movil_unidad_negocio (idMovil, idUnidadNegocio)
+SELECT idMovil, idUnidadNegocio
+FROM moviles
+WHERE idUnidadNegocio IS NOT NULL AND idUnidadNegocio > 0;

--- a/frontend/src/views/admin/AdminCrudView.test.js
+++ b/frontend/src/views/admin/AdminCrudView.test.js
@@ -214,6 +214,108 @@ describe('AdminCrudView tipos de proceso', () => {
     expect(wrapper.findAll('[role="option"]').map((option) => option.text())).toEqual(['AAA111 - Carreton Principal'])
   })
 
+  it('exposes a multi-unit Relaciones tab when editing a movil', async () => {
+    routeState.params.entity = 'moviles'
+    api.get.mockImplementation((url) => {
+      const dataByUrl = {
+        '/api/admin/moviles': [
+          { idMovil: 7, patente: 'MWY673', detalle: 'Transporte Forestal', id_unidad_negocio: 3, unidad_ids: [3, 5], activo: 1 },
+        ],
+        '/api/admin/unidades-negocio': [
+          { idUnidadNegocio: 3, nombre: 'COSECHA CTL', prefijo: 'CTL', activo: 1 },
+          { idUnidadNegocio: 5, nombre: 'TALLER', prefijo: 'TAL', activo: 1 },
+        ],
+        '/api/admin/tipos-proceso': [],
+        '/api/admin/tipos-movil': [],
+      }
+      return Promise.resolve({ data: dataByUrl[url] || [] })
+    })
+
+    const wrapper = mount(AdminCrudView, {
+      global: {
+        directives: {
+          motionPanel: {},
+          motionPop: {},
+        },
+        stubs: {
+          AppIcon: true,
+        },
+      },
+    })
+    await flushPromises()
+
+    const editar = wrapper.findAll('button').find((button) => button.text().includes('Editar') || button.text().includes('Edit'))
+    // si no hay "Editar", abrir el form con Nuevo
+    const trigger = editar || wrapper.findAll('button').find((button) => button.text().includes('Nuevo'))
+    expect(trigger).toBeTruthy()
+    await trigger.trigger('click')
+    await flushPromises()
+
+    const relaciones = wrapper.findAll('button').find((button) => button.text().trim() === 'Relaciones')
+    expect(relaciones).toBeTruthy()
+    await relaciones.trigger('click')
+    await flushPromises()
+
+    const labels = wrapper.findAll('label').map((label) => label.text())
+    expect(labels).toContain('Unidad Principal')
+    expect(labels).toContain('Unidades vinculadas')
+  })
+
+
+  it('honors unidad_ids when filtering moviles available for a business unit', async () => {
+    routeState.params.entity = 'unidades-negocio'
+    api.get.mockImplementation((url) => {
+      const dataByUrl = {
+        '/api/admin/unidades-negocio': [
+          { idUnidadNegocio: 1, nombre: 'COSECHA DELTA', prefijo: 'DELTA', activo: 1 },
+          { idUnidadNegocio: 2, nombre: 'TALLER', prefijo: 'TAL', activo: 1 },
+        ],
+        '/api/admin/personal': [],
+        '/api/admin/moviles': [
+          { idMovil: 12, patente: 'ZZZ999', detalle: 'Zorra Forestal', id_unidad_negocio: 2, unidad_ids: [2] },
+          { idMovil: 10, patente: 'AAA111', detalle: 'Carreton Multi', id_unidad_negocio: 1, unidad_ids: [1, 2] },
+          { idMovil: 11, patente: 'BBB222', detalle: 'Solo Delta', id_unidad_negocio: 1, unidad_ids: [1] },
+        ],
+        '/api/admin/tipos-proceso': [],
+      }
+      return Promise.resolve({ data: dataByUrl[url] || [] })
+    })
+
+    const wrapper = mount(AdminCrudView, {
+      global: {
+        directives: {
+          motionPanel: {},
+          motionPop: {},
+        },
+        stubs: {
+          AppIcon: true,
+        },
+      },
+    })
+    await flushPromises()
+
+    const relaciones = wrapper.findAll('button').find((button) => button.text().includes('Relaciones'))
+    await relaciones.trigger('click')
+    await flushPromises()
+
+    // Relacionados a la unidad 1: solo "Carreton Multi" (porque esta en [1, 2])
+    // y "Solo Delta" (porque esta en [1]).
+    const wrapperText = wrapper.text()
+    expect(wrapperText).toContain('AAA111 - Carreton Multi')
+    expect(wrapperText).toContain('BBB222 - Solo Delta')
+    expect(wrapperText).not.toContain('ZZZ999 - Zorra Forestal')
+
+    const agregarMovil = wrapper.findAll('button[title="Agregar Moviles"]').at(0)
+    await agregarMovil.trigger('click')
+    await flushPromises()
+
+    const input = wrapper.find('input[role="combobox"]')
+    await input.trigger('focus')
+    await flushPromises()
+    const optionLabels = wrapper.findAll('[role="option"]').map((option) => option.text())
+    expect(optionLabels).toEqual(['ZZZ999 - Zorra Forestal'])
+  })
+
   it('exposes a multi-unit selector for lugares de carga and lists every linked unit', async () => {
     routeState.params.entity = 'lugares-carga'
     api.get.mockImplementation((url) => {

--- a/frontend/src/views/admin/AdminCrudView.vue
+++ b/frontend/src/views/admin/AdminCrudView.vue
@@ -679,14 +679,15 @@ const ENTITY_DEFINITIONS = {
       { key: 'idMovil', label: 'ID' },
       { key: 'patente', label: 'Patente' },
       { key: 'detalle', label: 'Detalle' },
-      { key: 'id_unidad_negocio', label: 'Unidad', type: 'lookup', optionsEntity: 'unidades-negocio', optionValue: 'idUnidadNegocio', optionLabel: 'nombre' },
+      { key: 'unidad_ids', label: 'Unidades', type: 'multiLookup', optionsEntity: 'unidades-negocio', optionValue: 'idUnidadNegocio', optionLabel: 'nombre' },
       { key: 'activo', label: 'Estado', type: 'badge', trueText: 'Activo', falseText: 'Inactivo' },
     ],
     fields: [
       { key: 'patente', label: 'Patente', type: 'text', required: true, section: 'principal' },
       { key: 'detalle', label: 'Detalle', type: 'text', required: true, section: 'principal' },
-      { key: 'id_unidad_negocio', label: 'Unidad de Negocio', type: 'autocomplete', optionsEntity: 'unidades-negocio', optionValue: 'idUnidadNegocio', optionLabel: 'nombre', default: 1, section: 'principal' },
       { key: 'activo', label: 'Activo', type: 'checkbox', output: 'int', default: true, section: 'principal' },
+      { key: 'unidad_negocio', label: 'Unidad Principal', type: 'autocomplete', optionsEntity: 'unidades-negocio', optionValue: 'idUnidadNegocio', optionLabel: 'nombre', default: 1, section: 'relaciones' },
+      { key: 'unidad_ids', label: 'Unidades vinculadas', type: 'multiselect', optionsEntity: 'unidades-negocio', optionValue: 'idUnidadNegocio', optionLabel: 'nombre', default: [1], section: 'relaciones' },
       { key: 'tipo_proceso', label: 'Tipo Proceso', type: 'autocomplete', optionsEntity: 'tipos-proceso', optionValue: 'id', optionLabel: 'nombre', output: 'string', default: '1', section: 'tecnico' },
       { key: 'tipo_movil', label: 'Tipo Movil', type: 'autocomplete', optionsEntity: 'tipos-movil', optionValue: 'id', optionLabel: 'detalle', default: 1, section: 'tecnico' },
       { key: 'cant_neumaticos', label: 'Cantidad Neumaticos', type: 'number', default: 0, section: 'tecnico' },
@@ -1152,11 +1153,14 @@ function validateAssignment(payload) {
   const proceso = findReference('tipos-proceso', payload.idProceso, 'id')
   if (!movil || !chofer || !proceso) return 'La asignacion contiene datos no disponibles.'
 
-  const unidadMovil = Number(movil.id_unidad_negocio || 0)
-  if (unidadMovil && Array.isArray(chofer.unidad_ids) && !chofer.unidad_ids.map(Number).includes(unidadMovil)) {
-    return 'El chofer no pertenece a la unidad del movil.'
+  const unidadesMovil = Array.isArray(movil.unidad_ids) ? movil.unidad_ids.map(Number) : [Number(movil.id_unidad_negocio || 0)]
+  const unidadesMovilSet = new Set(unidadesMovil.filter((id) => id > 0))
+  const unidadesChofer = Array.isArray(chofer.unidad_ids) ? chofer.unidad_ids.map(Number) : []
+  if (unidadesMovilSet.size > 0 && unidadesChofer.length > 0 && !unidadesChofer.some((id) => unidadesMovilSet.has(id))) {
+    return 'El chofer no pertenece a ninguna unidad del movil.'
   }
-  if (unidadMovil && Array.isArray(proceso.unidad_ids) && proceso.unidad_ids.length > 0 && !proceso.unidad_ids.map(Number).includes(unidadMovil)) {
+  const unidadesProceso = Array.isArray(proceso.unidad_ids) ? proceso.unidad_ids.map(Number) : []
+  if (unidadesMovilSet.size > 0 && unidadesProceso.length > 0 && !unidadesProceso.some((id) => unidadesMovilSet.has(id))) {
     return 'El tipo de proceso no esta habilitado para la unidad del movil.'
   }
 
@@ -1294,7 +1298,7 @@ function unidadRelations(unidadId) {
     .map((item) => ({ id: item.idPersonal, label: item.nombre }))
     .sort(compareRelationLabels)
   const moviles = (referenceData.moviles || [])
-    .filter((item) => Number(item.id_unidad_negocio) === id)
+    .filter((item) => movilBelongsToUnidad(item, id))
     .map((item) => ({ id: item.idMovil, label: formatOptionLabel(item, { optionsEntity: 'moviles', optionLabel: 'detalle' }) }))
     .sort(compareRelationLabels)
   const procesos = (referenceData['tipos-proceso'] || [])
@@ -1363,7 +1367,7 @@ function relationAddOptions(unidadId, type) {
 
   if (type === 'moviles') {
     return (referenceData.moviles || [])
-      .filter((item) => Number(item.id_unidad_negocio) !== id)
+      .filter((item) => !movilBelongsToUnidad(item, id))
       .map((item) => ({ id: item.idMovil, label: formatOptionLabel(item, { optionsEntity: 'moviles', optionLabel: 'detalle' }) }))
       .sort(compareRelationLabels)
   }
@@ -1376,6 +1380,17 @@ function compareRelationLabels(left, right) {
     sensitivity: 'base',
     numeric: true,
   })
+}
+
+function movilBelongsToUnidad(movil, unidadId) {
+  if (!movil) return false
+  const target = Number(unidadId)
+  if (!target) return false
+  const unidadIds = Array.isArray(movil.unidad_ids) ? movil.unidad_ids.map(Number) : []
+  if (unidadIds.includes(target)) return true
+  if (unidadIds.length > 0) return false
+  // fallback para respuestas legacy que solo traen id_unidad_negocio
+  return Number(movil.id_unidad_negocio) === target
 }
 
 function relationMoveOptions(unidadId) {
@@ -1419,8 +1434,25 @@ async function unlinkPersonalFromUnidad(personalId, unidadId) {
   await updateRelationEntity('personal', personalId, { unidad_ids: unidadIds })
 }
 
+async function linkMovilToUnidad(movilId, unidadId) {
+  const movil = findReference('moviles', movilId, 'idMovil')
+  if (!movil) return
+  const unidadIds = Array.isArray(movil.unidad_ids) ? movil.unidad_ids.map(Number) : [Number(movil.id_unidad_negocio || 0)]
+  const target = Number(unidadId)
+  if (!unidadIds.includes(target)) unidadIds.push(target)
+  await updateRelationEntity('moviles', movilId, { unidad_ids: unidadIds })
+}
+
+async function unlinkMovilFromUnidad(movilId, unidadId) {
+  const movil = findReference('moviles', movilId, 'idMovil')
+  if (!movil) return
+  const unidadIds = (Array.isArray(movil.unidad_ids) ? movil.unidad_ids.map(Number) : [Number(movil.id_unidad_negocio || 0)])
+    .filter((id) => id !== Number(unidadId))
+  await updateRelationEntity('moviles', movilId, { unidad_ids: unidadIds })
+}
+
 async function moveMovilToUnidad(movilId, unidadId) {
-  await updateRelationEntity('moviles', movilId, { id_unidad_negocio: Number(unidadId) })
+  await linkMovilToUnidad(movilId, unidadId)
 }
 
 async function updateRelationEntity(refEntity, id, payload) {
@@ -1479,12 +1511,13 @@ function lookupLabel(value, column) {
 
 function rowUnidadIds(row) {
   if (entity.value === 'personal') return Array.isArray(row.unidad_ids) ? row.unidad_ids.map(Number) : [Number(row.unidad_negocio || 0)]
-  if (entity.value === 'moviles') return [Number(row.id_unidad_negocio || 0)]
+  if (entity.value === 'moviles') return Array.isArray(row.unidad_ids) ? row.unidad_ids.map(Number) : [Number(row.id_unidad_negocio || 0)]
   if (entity.value === 'tipos-proceso') return Array.isArray(row.unidad_ids) ? row.unidad_ids.map(Number) : []
   if (entity.value === 'lugares-carga') return Array.isArray(row.unidad_ids) ? row.unidad_ids.map(Number) : [Number(row.unidad_negocio || 0)]
   if (entity.value === 'asignaciones') {
     const movil = findReference('moviles', row.idMovil, 'idMovil')
-    return movil ? [Number(movil.id_unidad_negocio || 0)] : []
+    if (!movil) return []
+    return Array.isArray(movil.unidad_ids) ? movil.unidad_ids.map(Number) : [Number(movil.id_unidad_negocio || 0)]
   }
   return []
 }
@@ -1513,7 +1546,7 @@ function referenceOptionsForEntity(refEntity, { unidadId = 0 } = {}) {
     .filter((option) => {
       if (!unidadId) return true
       if (refEntity === 'personal') return Array.isArray(option.unidad_ids) && option.unidad_ids.map(Number).includes(Number(unidadId))
-      if (refEntity === 'moviles') return Number(option.id_unidad_negocio) === Number(unidadId)
+      if (refEntity === 'moviles') return movilBelongsToUnidad(option, Number(unidadId))
       if (refEntity === 'tipos-proceso') return Array.isArray(option.unidad_ids) && option.unidad_ids.map(Number).includes(Number(unidadId))
       return true
     })


### PR DESCRIPTION
## Objetivo

Replica el mismo patron que ya existe para `personal` (#65) y `lugares_carga` (#91) y lo aplica a `moviles`: un mismo movil puede trabajar en varias unidades de negocio, y al registrar produccion aparece como opcion en cada una.

- Tabla pivote `movil_unidad_negocio` con backfill desde `moviles.idUnidadNegocio` para no perder la unidad principal historica.
- Pestana **Relaciones** en el modal de edicion de Moviles (igual que Personal), con Unidad Principal + lista de Unidades Vinculadas.
- El endpoint `GET /api/produccion/moviles` ahora filtra por la pivote via JOIN, asi el dropdown de maquinas del formulario de produccion muestra todos los moviles vinculados a la unidad activa.
- La validacion cruzada chofer <-> movil <-> tipo de proceso se hace contra cualquiera de las unidades del movil.

## Cambios

### Backend

- `db_migrations/20260724_movil_unidad_negocio.sql`: tabla pivote, FKs con `ON DELETE CASCADE` y backfill idempotente.
- `backend/app/models/movil_unidad_negocio.py`: modelo nuevo.
- `backend/app/schemas/admin.py`: `MovilCreate`, `MovilUpdate` y `MovilResponse` aceptan/devuelven `unidad_ids: list[int]`.
- `backend/app/api/routes/admin_legacy.py`:
  - Helpers `_movil_unidad_ids`, `_movil_unidad_ids_map`, `_sync_movil_unidades` (espejo de los de `personal`/`lugar_carga`).
  - `_to_movil_response` / `_to_movil_responses` hidratan `unidad_ids` desde la pivote; `id_unidad_negocio` queda como la primera unidad para no romper consumidores legacy.
  - `GET /admin/legacy/moviles` filtra con JOIN a la pivote cuando existe.
  - `POST /admin/legacy/moviles` toma la primera unidad de `unidad_ids` como principal; `PUT` sincroniza la pivote cuando llega `unidad_ids` o cuando cambia `id_unidad_negocio`.
  - `_ensure_asignacion_consistente` valida que el chofer pertenezca a **alguna** de las unidades del movil y que el tipo de proceso este habilitado en **alguna** de esas unidades.
- `backend/app/api/routes/produccion.py`:
  - Importa `MovilUnidadNegocio`.
  - Helpers `_movil_unidad_ids`, `_movil_belongs_to_any_unidad`, `_filter_moviles_by_allowed_unidades` (reusado en los 5 lugares que filtraban por `Movil.idUnidadNegocio.in_(allowed_ids)`).
  - `GET /api/produccion/moviles`, `/movil-by-operador/{id}` y `/asignaciones-por-operador/{id}` ahora hacen JOIN a la pivote cuando existe.
  - Validacion de `data.cod_equipo` en la registracion usa `_movil_belongs_to_any_unidad`.

### Frontend

- `frontend/src/views/admin/AdminCrudView.vue`:
  - Configuracion `moviles`: columna "Unidad" pasa a `unidad_ids` (`multiLookup`); nueva seccion `relaciones` con `unidad_negocio` (autocomplete) + `unidad_ids` (multiselect); se quita `id_unidad_negocio` del principal para no duplicar.
  - Helper `movilBelongsToUnidad` con fallback a `id_unidad_negocio` para respuestas legacy.
  - `linkMovilToUnidad` / `unlinkMovilFromUnidad` para que el panel de Relaciones sume/reste unidades al `unidad_ids` del movil en lugar de pisar la principal.
  - Validacion cruzada en la pantalla de Asignaciones Operativas chequea contra cualquier unidad del movil.

### Tests

- `backend/tests/test_movil_unidades.py` (nuevo, 9 tests): defaults, response con pivote, fallback, bulk hydrate, sync de pivote, update con `unidad_ids`, update con `id_unidad_negocio`, create con `unidad_ids` como principal.
- `frontend/src/views/admin/AdminCrudView.test.js` (2 tests nuevos): filtro de moviles disponibles respeta `unidad_ids`; la pestana Relaciones del form de Moviles muestra Unidad Principal + Unidades vinculadas.

## Archivos principales

- `db_migrations/20260724_movil_unidad_negocio.sql`
- `backend/app/models/movil_unidad_negocio.py`
- `backend/app/schemas/admin.py`
- `backend/app/api/routes/admin_legacy.py`
- `backend/app/api/routes/produccion.py`
- `backend/tests/test_movil_unidades.py`
- `frontend/src/views/admin/AdminCrudView.vue`
- `frontend/src/views/admin/AdminCrudView.test.js`

## Tests / Validaciones

- [x] `git diff --check` (sin warnings)
- [x] `python -m pytest` (67/67 pasan; 9 nuevos en `test_movil_unidades.py`)
- [x] `python -m compileall backend` (sin errores)
- [x] `npx vitest run` (152/152 pasan; 2 nuevos en `AdminCrudView.test.js`)
- [x] `npm run build` (PWA generada OK)

## Evidencia visual

Pendiente: abrir el admin de Moviles en `https://produccion.servinlgsm.com.ar/admin/crud/moviles` despues del deploy para confirmar que la pestana Relaciones se ve como en el screenshot compartido.

## Deploy

1. Correr la migracion en el server de prod antes de deployar el codigo (idempotente, pero el backfill deja la pivote con la unidad principal de cada movil):

   ```bash
   sudo mysql registro_fg < db_migrations/20260724_movil_unidad_negocio.sql
   ```

2. Build + deploy normal con `scripts/build_deploy_package.ps1` y `deploy_produccion_fg.sh` (INTERNAL_CHECK=1).

## Fuera de alcance

- No se toca la pantalla de Produccion mas alla del filtro por unidad; el dropdown ya se hidrata con la respuesta del endpoint, asi que cuando el backend devuelve los moviles vinculados, el usuario los ve automaticamente.
- No se migran datos historicos (no hace falta: la migracion hace el backfill solo).
- No se cambia el endpoint de Combustible ni el de Carga Combustible.
- El campo `moviles.idUnidadNegocio` se conserva para no romper JOINs / reportes legacy.

## Riesgos / pendientes

- **Doble fuente de verdad**: durante la transicion conviven `idUnidadNegocio` (columna) y `unidad_ids` (pivote). `_sync_movil_unidades` mantiene la primera como `ids[0]`, asi que no se desincronizan al escribir desde el admin. Los lectores que tocan la columna directa sin pasar por la pivote van a ver solo la principal. Si aparece algun reporte o vista que dependa de eso, hay que avisar.
- **Backfill**: la migracion usa `INSERT IGNORE`, asi que es seguro correrla mas de una vez. Si un movil tiene `idUnidadNegocio` en 0, queda sin unidades en la pivote — el helper cae al fallback y `_ensure_asignacion_consistente` lo rechaza ("El movil debe tener unidad de negocio").
