### PR TITLE
fix(produccion): exigir litros > 0 cuando toggle 'Se cargo combustible' esta activo

### DIFF
--- a/frontend/src/views/ProduccionFormView.vue
+++ b/frontend/src/views/ProduccionFormView.vue
@@ -599,7 +599,7 @@
             label="Litros de gasoil"
             type="number"
             v-model.number="form.combustible"
-            placeholder="Ej: 150"
+            :placeholder="cargoCombustible ? 'Cantidad cargada (obligatorio)' : 'Ej: 150'"
             min="0"
             required
           />
@@ -1002,7 +1002,7 @@ const puedeAvanzar = computed(() => {
     case 3: return !!form.tipo_de_proceso_id
     case 4: return horasValidas.value
     case 5: return produccionValida.value
-    case 6: return true
+    case 6: return combustibleValido.value
     case 7: return ubicacionValida.value
     case 8: return true
     default: return true
@@ -1184,6 +1184,11 @@ const horasValidas = computed(() => {
   return true
 })
 
+const combustibleValido = computed(() => {
+  if (!cargoCombustible.value) return true
+  return Number(form.combustible) > 0
+})
+
 const produccionValida = computed(() => {
   if (!form.tipo_de_proceso_id || camposActivos.value.length === 0) return true
 
@@ -1258,7 +1263,7 @@ const stepComplete = computed(() => [
   !!form.tipo_de_proceso_id,
   horasValidas.value,
   produccionValida.value,
-  true,
+  combustibleValido.value,
   ubicacionValida.value,
   puedeAvanzar.value,
 ])
@@ -1290,6 +1295,9 @@ const mensajePasoIncompleto = computed(() => {
   }
   if (pasoActual.value === 5 && !produccionValida.value) {
     return 'Completá los campos de producción con valores mayores a 0 para continuar.'
+  }
+  if (pasoActual.value === 6 && !combustibleValido.value) {
+    return 'Marcaste que se cargó combustible, pero los litros están en 0. Ingresá una cantidad mayor a 0 o desactivá el toggle.'
   }
   if (pasoActual.value === 7 && !ubicacionValida.value) {
     return mensajeUbicacionIncompleta.value


### PR DESCRIPTION
Closes #92

## Objetivo

Bloquear el avance del wizard de Carga de Produccion (paso 7 Consumos) cuando el operador marca el toggle "Se cargo combustible" pero deja los litros en 0. Asi no se guardan registros inconsistentes que ensucian los reportes de combustible.

## Cambios

- `frontend/src/views/ProduccionFormView.vue`:
  - Nuevo computed `combustibleValido`: `true` cuando el toggle esta apagado, o cuando esta prendido y `form.combustible > 0`.
  - `puedeAvanzar` (case 6): antes `return true`, ahora `return combustibleValido.value`.
  - `stepComplete` (indice 6): antes hardcodeado `true`, ahora `combustibleValido.value` para que el stepper lateral muestre OK cuando se valida.
  - `mensajePasoIncompleto`: nuevo caso para paso 6 con texto explicativo (se muestra en el footer del wizard).
  - Placeholder del input "Litros de gasoil" pasa a "Cantidad cargada (obligatorio)" cuando el toggle esta activo.

## Patron seguido

Mismo patron que `horasValidas` y `produccionValida`. Logica centralizada en un computed, conectada en los 3 lugares donde hoy estaba hardcodeado `true` para el paso 6.

## Tests / Validaciones

- [x] `npm test` — 19 archivos, 152 tests, todos passing.
- [x] `npm run build` — vite build OK (1876 modules, PWA generado). Warnings preexistentes (chunk > 500kb, dynamic import del toast) no son del fix.
- [ ] Validacion visual manual pendiente (lo hace Oscar en su entorno).

## Fuera de alcance

- No se agrega validacion server-side (la API ya acepta `combustible: 0`).
- No se modifican reportes historicos ni Aceite/Consumos.
- No se agrega un test de unidad para `ProduccionFormView.vue` (no existe patron de tests para este componente; el alcance del issue es UI). Si queres, lo agrego en un PR aparte.

## Riesgos

- Bajo. Solo cambia UI. Si el operador deja toggle prendido y carga 0, antes pasaba; ahora no. Eso es exactamente lo pedido.
- El placeholder cambia, pero `form.combustible` sigue siendo `0` por default. No afecta submits existentes porque `cargoCombustible` queda en `false` por default.
