### PR TITLE
feat(produccion): capturar hasta 3 remitos en parte con combustible (#95)

### DIFF
--- a/backend/app/api/routes/produccion.py
+++ b/backend/app/api/routes/produccion.py
@@ -693,6 +693,9 @@ async def create_produccion(
             tipo_proceso_id=(data.codigo_tabla if data.tabla == "tipo_de_proceso" else None),
             fecha_hora=datetime.now(),
             origen="web",
+            remito=data.remito or "",
+            remito2=data.remito2 or "",
+            remito3=data.remito3 or "",
         )
         db.add(registro)
         db.flush()
@@ -713,6 +716,9 @@ async def create_produccion(
                 _usuario="web",
                 _fecha=now.date(),
                 _hora=now.strftime("%H:%M:%S"),
+                remito=data.remito or "",
+                remito2=data.remito2 or "",
+                remito3=data.remito3 or "",
             )
             db.add(carga)
 

--- a/backend/app/schemas/produccion.py
+++ b/backend/app/schemas/produccion.py
@@ -152,6 +152,9 @@ class TableroProduccionCreate(BaseModel):
     lugar_carga: int = 0
     tabla: str = "tipo_de_proceso"
     codigo_tabla: int = 0
+    remito: str = Field(default="", max_length=12)
+    remito2: str = Field(default="", max_length=12)
+    remito3: str = Field(default="", max_length=12)
 
 
 # --- Mis Registros (vista operador) ---

--- a/backend/tests/test_produccion_combustible_remitos.py
+++ b/backend/tests/test_produccion_combustible_remitos.py
@@ -1,0 +1,186 @@
+"""Tests de regresion para captura de remitos en el parte de produccion.
+
+Issue #95: cuando el operador marca "Se cargo combustible?", ademas de los
+litros tiene que poder cargar hasta 3 remitos. Esos valores se persisten en
+``tablero_produccion.remito/remito2/remito3`` y en el ``cargacomb`` que se
+crea como movimiento relacionado con los mismos 3 valores.
+"""
+import asyncio
+from contextlib import contextmanager
+from datetime import date
+from types import SimpleNamespace
+
+import pytest
+from pydantic import ValidationError
+
+from app.api.routes import produccion
+from app.schemas.produccion import TableroProduccionCreate
+
+
+# ─── Schema ────────────────────────────────────────────────────────────────
+
+
+def test_schema_accepts_remito_fields():
+    payload = TableroProduccionCreate(
+        fecha=date(2026, 7, 28),
+        combustible=150,
+        remito="R-0001",
+        remito2="R-0002",
+        remito3="R-0003",
+    )
+
+    assert payload.remito == "R-0001"
+    assert payload.remito2 == "R-0002"
+    assert payload.remito3 == "R-0003"
+
+
+def test_schema_remito_defaults_to_empty_string():
+    payload = TableroProduccionCreate(
+        fecha=date(2026, 7, 28),
+        combustible=0,
+    )
+
+    assert payload.remito == ""
+    assert payload.remito2 == ""
+    assert payload.remito3 == ""
+
+
+@pytest.mark.parametrize("field", ["remito", "remito2", "remito3"])
+def test_schema_rejects_remito_longer_than_twelve_chars(field):
+    with pytest.raises(ValidationError):
+        TableroProduccionCreate(
+            fecha=date(2026, 7, 28),
+            combustible=0,
+            **{field: "x" * 13},
+        )
+
+
+# ─── Route: persistencia de remitos ────────────────────────────────────────
+
+
+class FakeQuery:
+    """Query en cadena que devuelve ``None`` para first() y 0 para scalar()."""
+
+    def filter(self, *_args, **_kwargs):
+        return self
+
+    def first(self):
+        return None
+
+    def scalar(self):
+        return 0
+
+
+class FakeDb:
+    """Doble de ``Session`` que registra lo agregado y mockea el resto."""
+
+    def __init__(self):
+        self.added = []
+        self.commits = 0
+        self.flushes = 0
+
+    def query(self, *_args, **_kwargs):
+        return FakeQuery()
+
+    def add(self, row):
+        self.added.append(row)
+
+    def flush(self):
+        self.flushes += 1
+
+    def commit(self):
+        self.commits += 1
+
+    def refresh(self, _row):
+        return None
+
+
+def _bypass_external_deps(monkeypatch):
+    monkeypatch.setattr(
+        produccion,
+        "_validate_restricted_payload",
+        lambda *_a, **_k: None,
+    )
+
+    @contextmanager
+    def no_lock(*_a, **_k):
+        yield
+
+    monkeypatch.setattr(produccion, "_form_submission_lock", no_lock)
+
+
+def test_create_persists_remitos_in_tablero_and_cargacomb(monkeypatch):
+    db = FakeDb()
+    _bypass_external_deps(monkeypatch)
+
+    payload = TableroProduccionCreate(
+        fecha=date(2026, 7, 28),
+        UN="BIOMASA FRESA",
+        cod_un=1,
+        cod_equipo=10,
+        cod_operador=5,
+        combustible=150,
+        remito="R-0001",
+        remito2="R-0002",
+        remito3="R-0003",
+    )
+
+    asyncio.run(produccion.create_produccion(payload, db=db, user=SimpleNamespace()))
+
+    assert db.commits == 1
+    assert len(db.added) == 2  # TableroProduccion + CargaComb
+
+    tablero = db.added[0]
+    carga = db.added[1]
+
+    assert tablero.remito == "R-0001"
+    assert tablero.remito2 == "R-0002"
+    assert tablero.remito3 == "R-0003"
+
+    assert carga.remito == "R-0001"
+    assert carga.remito2 == "R-0002"
+    assert carga.remito3 == "R-0003"
+    assert carga.tabla == "tablero_produccion"
+    assert carga.Litros == 150
+
+
+def test_create_does_not_create_cargacomb_when_combustible_is_zero(monkeypatch):
+    db = FakeDb()
+    _bypass_external_deps(monkeypatch)
+
+    payload = TableroProduccionCreate(
+        fecha=date(2026, 7, 28),
+        combustible=0,
+    )
+
+    asyncio.run(produccion.create_produccion(payload, db=db, user=SimpleNamespace()))
+
+    # Solo se persiste el TableroProduccion; no hay CargaComb.
+    assert len(db.added) == 1
+    tablero = db.added[0]
+    assert tablero.combustible == 0
+
+
+def test_create_persists_empty_remitos_when_combustible_without_remito(monkeypatch):
+    db = FakeDb()
+    _bypass_external_deps(monkeypatch)
+
+    payload = TableroProduccionCreate(
+        fecha=date(2026, 7, 28),
+        combustible=80,
+        remito="",
+        remito2="",
+        remito3="",
+    )
+
+    asyncio.run(produccion.create_produccion(payload, db=db, user=SimpleNamespace()))
+
+    tablero = db.added[0]
+    carga = db.added[1]
+
+    assert tablero.remito == ""
+    assert tablero.remito2 == ""
+    assert tablero.remito3 == ""
+    assert carga.remito == ""
+    assert carga.remito2 == ""
+    assert carga.remito3 == ""

--- a/docs/pr_body_issue_95.md
+++ b/docs/pr_body_issue_95.md
@@ -1,0 +1,65 @@
+## Objetivo
+
+Closes #95
+
+Capturar hasta 3 remitos de combustible en el parte de producción. Cuando el operador activa "¿Se cargó combustible?" en el paso 7, el formulario muestra 3 inputs de remito (Remito 1 obligatorio, Remito 2 y 3 opcionales). Al guardar, esos valores se persisten en `tablero_produccion.remito/remito2/remito3` y en el `cargacomb` que se crea como movimiento relacionado, manteniendo consistencia entre ambas tablas.
+
+## Cambios
+
+- **Backend**
+  - `backend/app/schemas/produccion.py`: `TableroProduccionCreate` ahora acepta `remito`, `remito2`, `remito3` (str, max 12, default `""`).
+  - `backend/app/api/routes/produccion.py`: `create_produccion` persiste los 3 remitos tanto en el `TableroProduccion` como en el `CargaComb` que se crea cuando hay combustible (`Litros > 0`).
+- **Backend tests**
+  - `backend/tests/test_produccion_combustible_remitos.py` (nuevo, 8 tests): cubre schema, validación de longitud, persistencia en ambas tablas, y el caso sin combustible.
+- **Frontend**
+  - `frontend/src/components/InputField.vue`: nueva prop opcional `maxlength` que se pasa al `<input>`. Reutilizable.
+  - `frontend/src/views/ProduccionFormView.vue`:
+    - 3 inputs nuevos visibles solo si `cargoCombustible = true`, agrupados en una grilla 3 columnas en pantallas >= `sm`.
+    - Estado `form.remito/remito2/remito3` (default `""`).
+    - Reset de los 3 al desactivar el toggle (junto con `form.combustible`).
+    - `combustibleValido` exige Remito 1 no vacío si hay combustible y litros > 0.
+    - Mensaje de error específico: "ingresá al menos el Remito 1 para poder continuar".
+    - Payload del submit incluye los 3 remitos (vacíos si el toggle está apagado).
+    - `remitoInvalido` (computed) marca el input con estado de error visual.
+
+## Archivos modificados
+
+- `backend/app/schemas/produccion.py`
+- `backend/app/api/routes/produccion.py`
+- `backend/tests/test_produccion_combustible_remitos.py` (nuevo)
+- `frontend/src/components/InputField.vue`
+- `frontend/src/views/ProduccionFormView.vue`
+
+## Tests / Validaciones
+
+- [x] `git diff --check`
+- [x] `git diff --cached --check`
+- [x] `py -3.12 -m pytest` — 79 tests (8 nuevos para remitos)
+- [x] `py -3.12 -m compileall -q backend/app`
+- [x] `npm test` — 152 tests
+- [x] `npm run build` — bundle generado OK
+- [x] Validación visual: pendiente de prueba manual en UI (no hay Computer Use automatizado para esta pantalla todavía)
+
+## Evidencia visual
+
+Pendiente. La validación manual de la pantalla con toggle ON + remito requerido se probará en demo local o en `fasa_195` antes del merge. Sugiero screenshot del paso 7 con:
+1. Toggle ON, Remito 1 vacío, litros > 0 → debe bloquear.
+2. Toggle ON, Remito 1 cargado → habilita "Siguiente".
+
+## Fuera de alcance
+
+- No tocar la pantalla independiente de Carga de Combustible (`CombustibleFormView.vue`).
+- No validar unicidad de remitos entre partes.
+- No mostrar remitos en la pantalla de revisión (paso 9) por ahora.
+- No se tocan las pantallas de admin.
+- No se modifican registros históricos.
+
+## Riesgos / pendientes
+
+- Ningún riesgo funcional: las columnas `remito/remito2/remito3` ya existen en `tablero_produccion` y `cargacomb` desde la estructura legacy (ver `fg_structure.sql` y los modelos en `app/models/produccion.py` y `app/models/carga_comb.py`). El cambio solo completa el wiring que faltaba.
+- El bundle principal mantiene el warning existente de 535 KB (preexistente, no introducido por este PR).
+- Validación visual final en UI queda pendiente hasta que se ejecute en un entorno con la pantalla accesible.
+
+## Notas
+
+- Complementario al PR #70 (draft) que corrige `tipo_mov="E"` en el `cargacomb` relacionado. Este PR no se pisa con #70: #70 corrige el `tipo_mov` que se persiste, este agrega remitos. Si #70 se mergea primero, este PR sigue funcionando; si se mergea este primero, #70 sigue siendo necesario porque remitos y `tipo_mov` son ortogonales.

--- a/frontend/src/components/InputField.vue
+++ b/frontend/src/components/InputField.vue
@@ -16,6 +16,7 @@
         :disabled="disabled"
         :min="min"
         :max="max"
+        :maxlength="maxlength"
         :step="step"
         :inputmode="inputMode"
         :pattern="pattern"
@@ -47,6 +48,7 @@ const props = defineProps({
   disabled: { type: Boolean, default: false },
   min: { type: [String, Number], default: undefined },
   max: { type: [String, Number], default: undefined },
+  maxlength: { type: [String, Number], default: undefined },
   step: { type: [String, Number], default: undefined },
   invalid: { type: Boolean, default: false },
 })

--- a/frontend/src/views/ProduccionFormView.vue
+++ b/frontend/src/views/ProduccionFormView.vue
@@ -594,7 +594,7 @@
           </button>
         </div>
 
-        <div v-if="cargoCombustible" class="mt-3">
+        <div v-if="cargoCombustible" class="mt-3 space-y-3">
           <InputField
             label="Litros de gasoil"
             type="number"
@@ -603,6 +603,28 @@
             min="0"
             required
           />
+          <div class="grid gap-3 sm:grid-cols-3">
+            <InputField
+              label="Remito 1"
+              v-model="form.remito"
+              placeholder="Ej: 0001-00012345"
+              :required="Number(form.combustible) > 0"
+              :invalid="remitoInvalido"
+              maxlength="12"
+            />
+            <InputField
+              label="Remito 2"
+              v-model="form.remito2"
+              placeholder="Opcional"
+              maxlength="12"
+            />
+            <InputField
+              label="Remito 3"
+              v-model="form.remito3"
+              placeholder="Opcional"
+              maxlength="12"
+            />
+          </div>
         </div>
       </SectionCard>
 
@@ -1134,6 +1156,9 @@ const form = reactive({
   hrs_no_op: 0,
   motivo_no_op: '',
   combustible: 0,
+  remito: '',
+  remito2: '',
+  remito3: '',
   aceite_cadena: 0,
   aceite_hidraulico: 0,
   aceite_motor: 0,
@@ -1186,7 +1211,14 @@ const horasValidas = computed(() => {
 
 const combustibleValido = computed(() => {
   if (!cargoCombustible.value) return true
-  return Number(form.combustible) > 0
+  if (Number(form.combustible) <= 0) return false
+  return String(form.remito ?? '').trim().length > 0
+})
+
+const remitoInvalido = computed(() => {
+  if (!cargoCombustible.value) return false
+  if (Number(form.combustible) <= 0) return false
+  return String(form.remito ?? '').trim().length === 0
 })
 
 const produccionValida = computed(() => {
@@ -1297,7 +1329,10 @@ const mensajePasoIncompleto = computed(() => {
     return 'Completá los campos de producción con valores mayores a 0 para continuar.'
   }
   if (pasoActual.value === 6 && !combustibleValido.value) {
-    return 'Marcaste que se cargó combustible, pero los litros están en 0. Ingresá una cantidad mayor a 0 o desactivá el toggle.'
+    if (Number(form.combustible) <= 0) {
+      return 'Marcaste que se cargó combustible, pero los litros están en 0. Ingresá una cantidad mayor a 0 o desactivá el toggle.'
+    }
+    return 'Marcaste que se cargó combustible: ingresá al menos el Remito 1 para poder continuar.'
   }
   if (pasoActual.value === 7 && !ubicacionValida.value) {
     return mensajeUbicacionIncompleta.value
@@ -1527,7 +1562,12 @@ async function onPredioChange() {
 
 // ─── Watch combustible toggle ───
 watch(cargoCombustible, (val) => {
-  if (!val) form.combustible = 0
+  if (!val) {
+    form.combustible = 0
+    form.remito = ''
+    form.remito2 = ''
+    form.remito3 = ''
+  }
 })
 
 watch(() => [form.tipo_de_proceso_id, tipoProcesoNombre.value], () => {
@@ -1730,6 +1770,9 @@ async function handleSubmit() {
       hr_inicio: form.hr_inicio,
       hr_fin: form.hr_fin,
       combustible: form.combustible,
+      remito: cargoCombustible.value ? String(form.remito ?? '').trim() : '',
+      remito2: cargoCombustible.value ? String(form.remito2 ?? '').trim() : '',
+      remito3: cargoCombustible.value ? String(form.remito3 ?? '').trim() : '',
       aceite_cadena: form.aceite_cadena,
       aceite_hidraulico: form.aceite_hidraulico,
       aceite_motor: form.aceite_motor,


### PR DESCRIPTION
## Objetivo

Closes #95

Capturar hasta 3 remitos de combustible en el parte de producción. Cuando el operador activa "¿Se cargó combustible?" en el paso 7, el formulario muestra 3 inputs de remito (Remito 1 obligatorio, Remito 2 y 3 opcionales). Al guardar, esos valores se persisten en `tablero_produccion.remito/remito2/remito3` y en el `cargacomb` que se crea como movimiento relacionado, manteniendo consistencia entre ambas tablas.

## Cambios

- **Backend**
  - `backend/app/schemas/produccion.py`: `TableroProduccionCreate` ahora acepta `remito`, `remito2`, `remito3` (str, max 12, default `""`).
  - `backend/app/api/routes/produccion.py`: `create_produccion` persiste los 3 remitos tanto en el `TableroProduccion` como en el `CargaComb` que se crea cuando hay combustible (`Litros > 0`).
- **Backend tests**
  - `backend/tests/test_produccion_combustible_remitos.py` (nuevo, 8 tests): cubre schema, validación de longitud, persistencia en ambas tablas, y el caso sin combustible.
- **Frontend**
  - `frontend/src/components/InputField.vue`: nueva prop opcional `maxlength` que se pasa al `<input>`. Reutilizable.
  - `frontend/src/views/ProduccionFormView.vue`:
    - 3 inputs nuevos visibles solo si `cargoCombustible = true`, agrupados en una grilla 3 columnas en pantallas >= `sm`.
    - Estado `form.remito/remito2/remito3` (default `""`).
    - Reset de los 3 al desactivar el toggle (junto con `form.combustible`).
    - `combustibleValido` exige Remito 1 no vacío si hay combustible y litros > 0.
    - Mensaje de error específico: "ingresá al menos el Remito 1 para poder continuar".
    - Payload del submit incluye los 3 remitos (vacíos si el toggle está apagado).
    - `remitoInvalido` (computed) marca el input con estado de error visual.

## Archivos modificados

- `backend/app/schemas/produccion.py`
- `backend/app/api/routes/produccion.py`
- `backend/tests/test_produccion_combustible_remitos.py` (nuevo)
- `frontend/src/components/InputField.vue`
- `frontend/src/views/ProduccionFormView.vue`

## Tests / Validaciones

- [x] `git diff --check`
- [x] `git diff --cached --check`
- [x] `py -3.12 -m pytest` — 79 tests (8 nuevos para remitos)
- [x] `py -3.12 -m compileall -q backend/app`
- [x] `npm test` — 152 tests
- [x] `npm run build` — bundle generado OK
- [x] Validación visual: pendiente de prueba manual en UI (no hay Computer Use automatizado para esta pantalla todavía)

## Evidencia visual

Pendiente. La validación manual de la pantalla con toggle ON + remito requerido se probará en demo local o en `fasa_195` antes del merge. Sugiero screenshot del paso 7 con:
1. Toggle ON, Remito 1 vacío, litros > 0 → debe bloquear.
2. Toggle ON, Remito 1 cargado → habilita "Siguiente".

## Fuera de alcance

- No tocar la pantalla independiente de Carga de Combustible (`CombustibleFormView.vue`).
- No validar unicidad de remitos entre partes.
- No mostrar remitos en la pantalla de revisión (paso 9) por ahora.
- No se tocan las pantallas de admin.
- No se modifican registros históricos.

## Riesgos / pendientes

- Ningún riesgo funcional: las columnas `remito/remito2/remito3` ya existen en `tablero_produccion` y `cargacomb` desde la estructura legacy (ver `fg_structure.sql` y los modelos en `app/models/produccion.py` y `app/models/carga_comb.py`). El cambio solo completa el wiring que faltaba.
- El bundle principal mantiene el warning existente de 535 KB (preexistente, no introducido por este PR).
- Validación visual final en UI queda pendiente hasta que se ejecute en un entorno con la pantalla accesible.

## Notas

- Complementario al PR #70 (draft) que corrige `tipo_mov="E"` en el `cargacomb` relacionado. Este PR no se pisa con #70: #70 corrige el `tipo_mov` que se persiste, este agrega remitos. Si #70 se mergea primero, este PR sigue funcionando; si se mergea este primero, #70 sigue siendo necesario porque remitos y `tipo_mov` son ortogonales.
