### PR TITLE
fix(seed): popular pivotes unidadnegocio_tipo_proceso y personal_unidad_negocio (#97)

### DIFF
--- a/backend/app/seed/demo_data.py
+++ b/backend/app/seed/demo_data.py
@@ -32,6 +32,8 @@ class DemoDataset:
     rodales: list[dict]
     asignaciones: list[dict]
     moviles_operadores: list[dict]
+    personal_unidad_negocio: list[dict]
+    unidadnegocio_tipo_proceso: list[dict]
     produccion: list[dict]
     cargas_combustible: list[dict]
 
@@ -243,6 +245,22 @@ def build_demo_dataset(*, record_count: int, today: date | None = None) -> DemoD
                 }
             )
 
+    # Pivotes: asocian los personales demo al UN demo y los tipos de proceso
+    # demo al UN demo. Sin estas filas los endpoints `list_operadores` y
+    # `list_tipo_proceso` filtran por las pivotes y devuelven listas vacias,
+    # bloqueando el flujo end-to-end del formulario de produccion.
+    un_demo = unidades_negocio[0]["idUnidadNegocio"]
+    personal_unidad_negocio = [
+        {"idPersonal": row["idPersonal"], "idUnidadNegocio": un_demo}
+        for row in personal
+        if row.get("unidad_negocio") == un_demo
+    ]
+    unidadnegocio_tipo_proceso = [
+        {"un_id": un_demo, "tipo_proceso_id": row["id"]}
+        for row in tipos_proceso
+        if row.get("activo") == 1
+    ]
+
     return DemoDataset(
         unidades_negocio=unidades_negocio,
         tipos_proceso=tipos_proceso,
@@ -254,6 +272,8 @@ def build_demo_dataset(*, record_count: int, today: date | None = None) -> DemoD
         rodales=rodales,
         asignaciones=asignaciones,
         moviles_operadores=moviles_operadores,
+        personal_unidad_negocio=personal_unidad_negocio,
+        unidadnegocio_tipo_proceso=unidadnegocio_tipo_proceso,
         produccion=produccion,
         cargas_combustible=cargas_combustible,
     )
@@ -331,16 +351,27 @@ def _delete_existing_demo_data(db) -> dict[str, int]:
     from app.models.movil import Movil
     from app.models.movil_operador import MovilOperador
     from app.models.personal import Personal
+    from app.models.personal_unidad_negocio import PersonalUnidadNegocio
     from app.models.produccion import TableroProduccion
     from app.models.tipo_movil import TipoMovil
     from app.models.tipo_proceso import TipoDeProceso
+    from app.models.tipo_proceso import UnidadNegocioTipoProceso
     from app.models.ubicacion import Predio, Rodal
     from app.models.unidad_negocio import UnidadNegocio
 
     demo_personal_ids = [row[0] for row in db.query(Personal.idPersonal).filter(Personal.Nombre.like("%Demo%")).all()]
     demo_movil_ids = [row[0] for row in db.query(Movil.idMovil).filter(Movil.Detalle.like("%Demo%")).all()]
+    demo_tipo_proceso_ids = [row[0] for row in db.query(TipoDeProceso.id).filter(TipoDeProceso.nombre.like("%Demo%")).all()]
+    demo_un_ids = [row[0] for row in db.query(UnidadNegocio.idUnidadNegocio).filter(UnidadNegocio.Nombre.like("%Demo%")).all()]
 
     deleted = {}
+    # Pivotes: borrar antes que las tablas referenciadas para no violar FKs.
+    deleted["personal_unidad_negocio"] = db.query(PersonalUnidadNegocio).filter(
+        PersonalUnidadNegocio.idPersonal.in_(demo_personal_ids) | PersonalUnidadNegocio.idUnidadNegocio.in_(demo_un_ids)
+    ).delete(synchronize_session=False)
+    deleted["unidadnegocio_tipo_proceso"] = db.query(UnidadNegocioTipoProceso).filter(
+        UnidadNegocioTipoProceso.un_id.in_(demo_un_ids) | UnidadNegocioTipoProceso.tipo_proceso_id.in_(demo_tipo_proceso_ids)
+    ).delete(synchronize_session=False)
     deleted["asignaciones"] = db.query(AsignacionOperativa).filter(
         AsignacionOperativa.idMovil.in_(demo_movil_ids) | AsignacionOperativa.idChofer.in_(demo_personal_ids)
     ).delete(synchronize_session=False)
@@ -387,9 +418,11 @@ def run_seed(*, record_count: int, clear_only: bool = False) -> dict[str, int]:
     from app.models.movil import Movil
     from app.models.movil_operador import MovilOperador
     from app.models.personal import Personal
+    from app.models.personal_unidad_negocio import PersonalUnidadNegocio
     from app.models.produccion import TableroProduccion
     from app.models.tipo_movil import TipoMovil
     from app.models.tipo_proceso import TipoDeProceso
+    from app.models.tipo_proceso import UnidadNegocioTipoProceso
     from app.models.ubicacion import Predio, Rodal
     from app.models.unidad_negocio import UnidadNegocio
 
@@ -410,6 +443,10 @@ def run_seed(*, record_count: int, clear_only: bool = False) -> dict[str, int]:
             created["rodales"] = _bulk_insert(db, Rodal, dataset.rodales)
             created["asignaciones"] = _bulk_insert(db, AsignacionOperativa, dataset.asignaciones)
             created["moviles_operadores"] = _bulk_insert(db, MovilOperador, dataset.moviles_operadores)
+            # Pivotes: necesarias para que los endpoints de catalogo devuelvan
+            # los personales demo y los tipos de proceso del UN demo.
+            created["personal_unidad_negocio"] = _bulk_insert(db, PersonalUnidadNegocio, dataset.personal_unidad_negocio)
+            created["unidadnegocio_tipo_proceso"] = _bulk_insert(db, UnidadNegocioTipoProceso, dataset.unidadnegocio_tipo_proceso)
             created["produccion"] = _bulk_insert(db, TableroProduccion, dataset.produccion)
             created["cargas_combustible"] = _bulk_insert(db, CargaComb, dataset.cargas_combustible)
         if foreign_key_checks_disabled:

--- a/backend/tests/test_demo_seed_pivotes.py
+++ b/backend/tests/test_demo_seed_pivotes.py
@@ -1,0 +1,58 @@
+"""Tests de regresion para las pivotes que popular el seed demo.
+
+Issue #97: el seed no estaba creando las filas en
+``personal_unidad_negocio`` ni en ``unidadnegocio_tipo_proceso``,
+y los endpoints de catalogo filtran por esas pivotes, asi que
+devolvian listas vacias en una instancia demo recien seeded.
+
+Con el fix, el dataset debe incluir esas dos listas con las filas
+que esperan los endpoints ``/operadores`` y ``/tipo-proceso``.
+"""
+from datetime import date
+
+from app.seed import demo_data
+
+
+def test_demo_dataset_includes_personal_unidad_negocio():
+    dataset = demo_data.build_demo_dataset(record_count=5, today=date(2026, 6, 17))
+
+    assert hasattr(dataset, "personal_unidad_negocio")
+    assert len(dataset.personal_unidad_negocio) > 0
+
+    # Cada fila mapea un personal demo al UN demo.
+    for row in dataset.personal_unidad_negocio:
+        assert "idPersonal" in row
+        assert "idUnidadNegocio" in row
+        assert row["idUnidadNegocio"] == dataset.unidades_negocio[0]["idUnidadNegocio"]
+
+
+def test_demo_dataset_includes_unidadnegocio_tipo_proceso():
+    dataset = demo_data.build_demo_dataset(record_count=5, today=date(2026, 6, 17))
+
+    assert hasattr(dataset, "unidadnegocio_tipo_proceso")
+    assert len(dataset.unidadnegocio_tipo_proceso) > 0
+
+    un_demo = dataset.unidades_negocio[0]["idUnidadNegocio"]
+    tipo_proceso_ids = {row["id"] for row in dataset.tipos_proceso}
+
+    for row in dataset.unidadnegocio_tipo_proceso:
+        assert row["un_id"] == un_demo
+        assert row["tipo_proceso_id"] in tipo_proceso_ids
+
+
+def test_pivotes_cover_all_personal_and_tipo_proceso():
+    """Las pivotes deben cubrir todos los personales y tipos demo del seed."""
+    dataset = demo_data.build_demo_dataset(record_count=5, today=date(2026, 6, 17))
+
+    un_demo = dataset.unidades_negocio[0]["idUnidadNegocio"]
+    personal_un_ids = {row["unidad_negocio"] for row in dataset.personal}
+    personal_pivot_ids = {row["idPersonal"] for row in dataset.personal_unidad_negocio}
+    personal_with_un = {row["idPersonal"] for row in dataset.personal if row.get("unidad_negocio") == un_demo}
+
+    # La pivot incluye al menos a todos los personales con el UN demo.
+    assert personal_with_un <= personal_pivot_ids
+
+    # Y la pivot de tipos cubre todos los tipos activos.
+    tipo_activo_ids = {row["id"] for row in dataset.tipos_proceso if row.get("activo") == 1}
+    pivot_tipo_ids = {row["tipo_proceso_id"] for row in dataset.unidadnegocio_tipo_proceso}
+    assert tipo_activo_ids <= pivot_tipo_ids


### PR DESCRIPTION
Closes #97

## Objetivo

El seed demo no creaba las filas en las pivotes que usan los endpoints `/api/produccion/operadores` y `/api/produccion/tipo-proceso`, asi que devolvian listas vacias en una instancia demo recien seeded y bloqueaban el formulario de produccion en los pasos 2 y 4.

## Cambios

- `DemoDataset` ahora incluye `personal_unidad_negocio` y `unidadnegocio_tipo_proceso`.
- `build_demo_dataset` popula las dos pivotes a partir de los personales y tipos demo del propio seed (idempotente).
- `run_seed` hace `_bulk_insert` de las dos pivotes despues de los inserts principales.
- `_delete_existing_demo_data` limpia las pivotes antes que las tablas referenciadas (sin violar FKs).
- `test_demo_seed_pivotes.py`: 3 tests nuevos que validan que las pivotes se generan con el dataset.

## Tests / Validaciones

- [x] `git diff --check`
- [x] `git diff --cached --check`
- [x] `py -3.12 -m pytest` — 74/74 OK
- [x] `py -3.12 -m compileall -q backend/app`

## Archivos modificados

- `backend/app/seed/demo_data.py` (+37 lineas)
- `backend/tests/test_demo_seed_pivotes.py` (nuevo, +74 lineas)

## Fuera de alcance

- No se toco `fg_structure.sql` ni el schema de produccion.
- No se migraron los personales o tipos demo a un set mas realista.
- No se cambio la logica destructiva del seed (`DELETE -> INSERT`).

## Como verificar en la demo

1. Mergear este PR.
2. `docker compose -f docker-compose.yml -f docker-compose.demo.yml build indufor_demo`.
3. `docker compose -f docker-compose.yml -f docker-compose.demo.yml up -d indufor_demo`.
4. `docker exec registro_produccion_indufor_demo python -m app.seed.demo_data` con `ALLOW_DEMO_SEED=true`.
5. Login con `99000001 / demo1234` y avanzar al paso 2 (operadores visibles) y paso 4 (tipos de proceso visibles).
