### PR TITLE
fix(produccion): setear tipo_mov=E en CargaComb del parte con combustible

### DIFF
--- a/backend/app/api/routes/produccion.py
+++ b/backend/app/api/routes/produccion.py
@@ -714,6 +714,7 @@ async def create_produccion(
                 personal=data.cod_operador or 1,
                 idtabla=str(new_id),
                 tabla="tablero_produccion",
+                tipo_mov="E",  # Egreso: el combustible sale del panol hacia el movil
                 _usuario="web",
                 _fecha=now.date(),
                 _hora=now.strftime("%H:%M:%S"),

--- a/backend/tests/test_produccion_combustible_remitos.py
+++ b/backend/tests/test_produccion_combustible_remitos.py
@@ -143,6 +143,7 @@ def test_create_persists_remitos_in_tablero_and_cargacomb(monkeypatch):
     assert carga.remito2 == "R-0002"
     assert carga.remito3 == "R-0003"
     assert carga.tabla == "tablero_produccion"
+    assert carga.tipo_mov == "E"
     assert carga.Litros == 150
     assert carga.idLugarCarga == 42
     assert carga.idTipoComb == 2


### PR DESCRIPTION
## Objetivo

El `CargaComb` que se crea cuando un operador registra combustible en el parte de produccion (`POST /api/produccion/`) quedaba con `tipo_mov=''` (vacio), y el sistema legado lo mostraba como **ingreso** al inventario. La operacion real es un **egreso** (combustible sale del panol hacia el movil), asi que el valor correcto es `'E'`.

El endpoint `/api/combustible/cargas` (pantalla Carga Combustible separada) ya setea `tipo_mov='E'` desde antes. El parte de produccion lo habia dejado vacio, probablemente porque el default del modelo es `''` y nadie lo cambiaba.

## Cambios

- `backend/app/api/routes/produccion.py`: el `CargaComb` del parte con combustible ahora se crea con `tipo_mov='E'`.
- `backend/tests/test_produccion_combustible_remitos.py`: el test de persistencia valida que `carga.tipo_mov == 'E'`.

## Tests / Validaciones

- [x] `git diff --check`
- [x] `py -3.12 -m pytest` — 86/86 OK
- [x] `py -3.12 -m compileall -q backend/app`

## Archivos modificados

- `backend/app/api/routes/produccion.py` (+1 linea)
- `backend/tests/test_produccion_combustible_remitos.py` (+1 linea)

## Fuera de alcance

- No se cambia el modelo `CargaComb` (el default sigue siendo `''` para no romper clientes legacy).
- No se cambia el endpoint `/api/combustible/cargas` (ya estaba en `'E'`).
- No se tocan pantallas ni seeds.

## Como verificar

1. Mergear este PR a main.
2. SSH a fasa_195, `cd /srv/apps/registro_produccion && git pull`.
3. `docker compose -f docker-compose.yml build produccion_fg`.
4. `docker compose -f docker-compose.yml up -d produccion_fg`.
5. Login con un usuario real, cargar un parte con combustible.
6. En la DB, el `CargaComb` resultante debe tener `tipo_mov='E'` (no `''`).

## Notas

- El PR #70 (en draft) hacia este mismo fix. Este PR es el reemplazo desde main con los merges de #98, #100 y #102 incluidos.
- En la demo actual (`indufor_demo`), los 2 CargaComb de la prueba visual con remito `12345` quedaron con `tipo_mov=''`. Despues de mergear este PR, los nuevos partes tendran `tipo_mov='E'`.
