### PR TITLE
fix(combustible): evita egresos duplicados y restaura panel admin

### DIFF
--- a/backend/app/api/routes/combustible.py
+++ b/backend/app/api/routes/combustible.py
@@ -1,11 +1,14 @@
 from datetime import datetime
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
-from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy import inspect
+from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 from sqlalchemy.orm import Session
 
 from app.api.deps import get_current_user, get_db
 from app.models.carga_comb import CargaComb
+from app.models.lugar_carga import LugarCarga
+from app.models.lugar_carga_unidad_negocio import LugarCargaUnidadNegocio
 from app.models.movil import Movil
 from app.models.personal import Personal
 from app.models.personal_unidad_negocio import PersonalUnidadNegocio
@@ -41,6 +44,41 @@ def _user_unidad_ids(db: Session, user: Personal) -> list[int]:
     return ids
 
 
+def _table_exists(db: Session, table_name: str) -> bool:
+    try:
+        return inspect(db.get_bind()).has_table(table_name)
+    except SQLAlchemyError:
+        return False
+
+
+def _lugar_carga_habilitado(db: Session, lugar_id: int, unidad_id: int) -> bool:
+    lugar = (
+        db.query(LugarCarga)
+        .filter(
+            LugarCarga.idLugarCarga == lugar_id,
+            LugarCarga.activo == 1,
+        )
+        .first()
+    )
+    if not lugar:
+        return False
+
+    if _table_exists(db, "lugar_carga_unidad_negocio"):
+        vinculo = (
+            db.query(LugarCargaUnidadNegocio)
+            .filter(
+                LugarCargaUnidadNegocio.idLugarCarga == lugar_id,
+                LugarCargaUnidadNegocio.unidad_negocio == unidad_id,
+                LugarCargaUnidadNegocio.activo.is_(True),
+            )
+            .first()
+        )
+        if vinculo:
+            return True
+
+    return int(lugar.unidad_negocio or 0) == unidad_id
+
+
 def _to_movil_response(row: Movil) -> CombustibleMovilResponse:
     return CombustibleMovilResponse(
         idMovil=row.idMovil,
@@ -62,6 +100,12 @@ def _to_carga_response(row: CargaComb, movil: Movil, user: Personal) -> CargaCom
         unidad_negocio=int(row.UnidadNegocio or 0),
         litros=float(row.Litros or 0),
         km=int(row.KM or 0),
+        id_lugar_carga=int(row.idLugarCarga or 0),
+        id_tipo_comb=int(row.idTipoComb or 0),
+        remito=row.remito or "",
+        remito2=row.remito2 or "",
+        remito3=row.remito3 or "",
+        form_uuid=row.form_uuid or "",
         observaciones=row.observaciones,
     )
 
@@ -104,13 +148,36 @@ async def create_carga_combustible(
             detail="No podes registrar combustible para un movil de otra unidad de negocio",
         )
 
+    existing = (
+        db.query(CargaComb)
+        .filter(
+            CargaComb.personal == user.idPersonal,
+            CargaComb.form_uuid == payload.form_uuid,
+        )
+        .first()
+    )
+    if existing:
+        existing_movil = (
+            db.query(Movil)
+            .filter(Movil.idMovil == existing.idMovil)
+            .first()
+        )
+        return _to_carga_response(existing, existing_movil or movil, user)
+
+    if not _lugar_carga_habilitado(db, payload.id_lugar_carga, movil_unidad):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Lugar de carga no encontrado o no habilitado para la unidad de negocio",
+        )
+
     now = datetime.now()
     row = CargaComb(
         idMovil=payload.id_movil,
-        idTipoComb=1,
+        idTipoComb=payload.id_tipo_comb,
         Fecha=payload.fecha,
         KM=payload.km,
         Litros=payload.litros,
+        idLugarCarga=payload.id_lugar_carga,
         UnidadNegocio=movil_unidad,
         personal=user.idPersonal,
         tipo_mov="E",
@@ -118,9 +185,32 @@ async def create_carga_combustible(
         _usuario="web",
         _fecha=now.date(),
         _hora=now.strftime("%H:%M:%S"),
+        remito=payload.remito.strip(),
+        remito2=payload.remito2.strip(),
+        remito3=payload.remito3.strip(),
+        form_uuid=payload.form_uuid,
         observaciones=(payload.observaciones or "").strip(),
     )
     db.add(row)
-    db.commit()
+    try:
+        db.commit()
+    except IntegrityError:
+        db.rollback()
+        existing = (
+            db.query(CargaComb)
+            .filter(
+                CargaComb.personal == user.idPersonal,
+                CargaComb.form_uuid == payload.form_uuid,
+            )
+            .first()
+        )
+        if existing:
+            existing_movil = (
+                db.query(Movil)
+                .filter(Movil.idMovil == existing.idMovil)
+                .first()
+            )
+            return _to_carga_response(existing, existing_movil or movil, user)
+        raise
     db.refresh(row)
     return _to_carga_response(row, movil, user)

--- a/backend/app/api/routes/produccion.py
+++ b/backend/app/api/routes/produccion.py
@@ -700,27 +700,29 @@ async def create_produccion(
         db.add(registro)
         db.flush()
 
-        # Si se cargó combustible, crear registro en cargacomb
-        if data.combustible and data.combustible > 0:
+        # El abastecimiento asociado al parte se registra en la misma
+        # transaccion: el parte y el egreso de stock nacen o fallan juntos.
+        if data.combustible > 0:
             now = datetime.now()
             carga = CargaComb(
-                idMovil=data.cod_equipo or 0,
-                idTipoComb=data.id_tipo_comb or 1,
+                idMovil=data.cod_equipo,
+                idTipoComb=data.id_tipo_comb,
                 Fecha=data.fecha,
-                KM=0,
+                KM=data.km_combustible,
                 Litros=data.combustible,
-                idLugarCarga=data.lugar_carga or 1,
+                idLugarCarga=data.lugar_carga,
                 UnidadNegocio=data.cod_un or 1,
-                personal=data.cod_operador or 1,
+                personal=data.cod_operador,
                 idtabla=str(new_id),
                 tabla="tablero_produccion",
-                tipo_mov="E",  # Egreso: el combustible sale del panol hacia el movil
+                tipo_mov="E",
                 _usuario="web",
                 _fecha=now.date(),
                 _hora=now.strftime("%H:%M:%S"),
-                remito=data.remito or "",
-                remito2=data.remito2 or "",
-                remito3=data.remito3 or "",
+                remito=data.remito.strip(),
+                remito2=data.remito2.strip(),
+                remito3=data.remito3.strip(),
+                form_uuid=data.form_uuid,
             )
             db.add(carga)
 

--- a/backend/app/models/carga_comb.py
+++ b/backend/app/models/carga_comb.py
@@ -1,9 +1,16 @@
-from sqlalchemy import Column, Integer, String, Date, Numeric, SmallInteger
+from sqlalchemy import Column, Integer, String, Date, Numeric, SmallInteger, UniqueConstraint
 from app.core.database import Base
 
 
 class CargaComb(Base):
     __tablename__ = "cargacomb"
+    __table_args__ = (
+        UniqueConstraint(
+            "personal",
+            "form_uuid",
+            name="uq_cargacomb_personal_form_uuid",
+        ),
+    )
 
     idCargaComb = Column(Integer, primary_key=True, autoincrement=True)
     idMovil = Column(Integer, nullable=False, default=0)
@@ -30,3 +37,4 @@ class CargaComb(Base):
     remito3 = Column(String(12), nullable=True)
     observaciones = Column(String(200), nullable=True, default="")
     ajuste_stock = Column(SmallInteger, nullable=True, default=0)
+    form_uuid = Column(String(36), nullable=True)

--- a/backend/app/schemas/combustible.py
+++ b/backend/app/schemas/combustible.py
@@ -1,5 +1,5 @@
 from datetime import date
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 
 class CombustibleMovilResponse(BaseModel):
@@ -10,11 +10,25 @@ class CombustibleMovilResponse(BaseModel):
 
 
 class CargaCombustibleCreate(BaseModel):
+    form_uuid: str = Field(min_length=1, max_length=36)
     fecha: date
     id_movil: int
     litros: float = Field(gt=0)
-    km: int = Field(ge=0)
+    km: int = Field(gt=0)
+    id_lugar_carga: int = Field(ge=1)
+    id_tipo_comb: int = Field(default=1, ge=1)
+    remito: str = Field(min_length=1, max_length=12)
+    remito2: str = Field(default="", max_length=12)
+    remito3: str = Field(default="", max_length=12)
     observaciones: str | None = None
+
+    @field_validator("form_uuid", "remito")
+    @classmethod
+    def validate_required_text(cls, value: str) -> str:
+        normalized = value.strip()
+        if not normalized:
+            raise ValueError("El valor no puede estar vacío")
+        return normalized
 
 
 class CargaCombustibleResponse(BaseModel):
@@ -28,4 +42,10 @@ class CargaCombustibleResponse(BaseModel):
     unidad_negocio: int
     litros: float
     km: int
+    id_lugar_carga: int
+    id_tipo_comb: int
+    remito: str
+    remito2: str
+    remito3: str
+    form_uuid: str
     observaciones: str | None = None

--- a/backend/app/schemas/produccion.py
+++ b/backend/app/schemas/produccion.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 from datetime import date
 
 
@@ -117,6 +117,7 @@ class TableroProduccionCreate(BaseModel):
     hr_inicio: float = 0
     hr_fin: float = 0
     combustible: int = 0
+    km_combustible: int = Field(default=0, ge=0)
     aceite_cadena: int = 0
     aceite_hidraulico: int = 0
     aceite_motor: int = 0
@@ -156,6 +157,21 @@ class TableroProduccionCreate(BaseModel):
     remito: str = Field(default="", max_length=12)
     remito2: str = Field(default="", max_length=12)
     remito3: str = Field(default="", max_length=12)
+
+    @model_validator(mode="after")
+    def validate_combustible_movement(self):
+        if self.combustible <= 0:
+            return self
+
+        if not self.form_uuid.strip():
+            raise ValueError("El combustible requiere una identidad estable del formulario")
+        if self.km_combustible <= 0:
+            raise ValueError("El combustible requiere un kilometraje u horometro mayor a cero")
+        if self.lugar_carga <= 0:
+            raise ValueError("El combustible requiere un lugar de carga")
+        if not self.remito.strip():
+            raise ValueError("El combustible requiere al menos el Remito 1")
+        return self
 
 
 # --- Mis Registros (vista operador) ---

--- a/backend/tests/test_combustible_fuente_verdad.py
+++ b/backend/tests/test_combustible_fuente_verdad.py
@@ -1,0 +1,228 @@
+import asyncio
+from contextlib import contextmanager
+from datetime import date
+from types import SimpleNamespace
+
+import pytest
+from pydantic import ValidationError
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.api.routes import combustible, produccion
+from app.core.database import Base
+from app.models.carga_comb import CargaComb
+from app.models.lugar_carga import LugarCarga
+from app.models.lugar_carga_unidad_negocio import LugarCargaUnidadNegocio
+from app.models.movil import Movil
+from app.models.personal_unidad_negocio import PersonalUnidadNegocio
+from app.models.produccion import TableroProduccion
+from app.schemas.combustible import CargaCombustibleCreate
+from app.schemas.produccion import TableroProduccionCreate
+
+
+@pytest.fixture
+def db():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(
+        engine,
+        tables=[
+            Movil.__table__,
+            PersonalUnidadNegocio.__table__,
+            LugarCarga.__table__,
+            LugarCargaUnidadNegocio.__table__,
+            TableroProduccion.__table__,
+            CargaComb.__table__,
+        ],
+    )
+    session = sessionmaker(bind=engine)()
+    session.add(
+        Movil(
+            idMovil=10,
+            Patente="TEST-10",
+            Detalle="FORWA-N°2",
+            idUnidadNegocio=1,
+            activo=1,
+        )
+    )
+    session.add(PersonalUnidadNegocio(idPersonal=5, idUnidadNegocio=1))
+    session.add(
+        LugarCarga(
+            idLugarCarga=42,
+            Detalle="Pañol COSECHA CTL",
+            activo=1,
+            unidad_negocio=1,
+        )
+    )
+    session.add(
+        LugarCargaUnidadNegocio(
+            idLugarCarga=42,
+            unidad_negocio=1,
+            activo=True,
+        )
+    )
+    session.commit()
+    try:
+        yield session
+    finally:
+        session.close()
+        engine.dispose()
+
+
+def _user():
+    return SimpleNamespace(
+        idPersonal=5,
+        Nombre="Operador Test",
+        unidad_negocio=1,
+    )
+
+
+def _payload(form_uuid: str) -> CargaCombustibleCreate:
+    return CargaCombustibleCreate(
+        form_uuid=form_uuid,
+        fecha=date(2026, 7, 29),
+        id_movil=10,
+        litros=160,
+        km=14855,
+        id_lugar_carga=42,
+        id_tipo_comb=1,
+        remito="R-0001",
+        remito2="R-0002",
+        remito3="R-0003",
+        observaciones="Carga real de prueba",
+    )
+
+
+def test_schema_requires_a_real_km_or_hour_meter_reading():
+    with pytest.raises(ValidationError):
+        CargaCombustibleCreate(
+            form_uuid="carga-1",
+            fecha=date(2026, 7, 29),
+            id_movil=10,
+            litros=160,
+            km=0,
+            id_lugar_carga=42,
+            remito="R-0001",
+        )
+
+
+def test_combustible_endpoint_writes_a_standalone_inventory_movement(db):
+    result = asyncio.run(
+        combustible.create_carga_combustible(
+            _payload("carga-fisica-1"),
+            db=db,
+            user=_user(),
+        )
+    )
+
+    rows = db.query(CargaComb).all()
+    assert len(rows) == 1
+    row = rows[0]
+    assert result.id_carga == row.idCargaComb
+    assert row.tipo_mov == "E"
+    assert row.tabla == "carga_combustible"
+    assert row.KM == 14855
+    assert float(row.Litros) == 160
+    assert row.idLugarCarga == 42
+    assert row.idTipoComb == 1
+    assert row.remito == "R-0001"
+    assert row.remito2 == "R-0002"
+    assert row.remito3 == "R-0003"
+    assert row.form_uuid == "carga-fisica-1"
+
+
+def test_retrying_the_same_form_uuid_is_idempotent(db):
+    first = asyncio.run(
+        combustible.create_carga_combustible(
+            _payload("carga-fisica-reintentada"),
+            db=db,
+            user=_user(),
+        )
+    )
+    second = asyncio.run(
+        combustible.create_carga_combustible(
+            _payload("carga-fisica-reintentada"),
+            db=db,
+            user=_user(),
+        )
+    )
+
+    assert second.id_carga == first.id_carga
+    assert db.query(CargaComb).count() == 1
+
+
+def test_same_explicit_event_id_cannot_be_written_again_from_the_other_flow(
+    db,
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        produccion,
+        "_validate_restricted_payload",
+        lambda *_args, **_kwargs: None,
+    )
+
+    @contextmanager
+    def no_lock(*_args, **_kwargs):
+        yield
+
+    monkeypatch.setattr(produccion, "_form_submission_lock", no_lock)
+
+    production_payload = TableroProduccionCreate(
+        fecha=date(2026, 7, 29),
+        form_uuid="abastecimiento-compartido",
+        cod_operador=5,
+        cod_equipo=10,
+        cod_un=1,
+        combustible=160,
+        km_combustible=14855,
+        lugar_carga=42,
+        remito="R-0001",
+    )
+    asyncio.run(
+        produccion.create_produccion(
+            production_payload,
+            db=db,
+            user=_user(),
+        )
+    )
+
+    result = asyncio.run(
+        combustible.create_carga_combustible(
+            _payload("abastecimiento-compartido"),
+            db=db,
+            user=_user(),
+        )
+    )
+
+    rows = db.query(CargaComb).all()
+    assert len(rows) == 1
+    assert rows[0].tabla == "tablero_produccion"
+    assert result.id_carga == rows[0].idCargaComb
+
+
+def test_identical_real_loads_with_different_ids_are_allowed(db):
+    first = asyncio.run(
+        combustible.create_carga_combustible(
+            _payload("carga-fisica-a"),
+            db=db,
+            user=_user(),
+        )
+    )
+    second = asyncio.run(
+        combustible.create_carga_combustible(
+            _payload("carga-fisica-b"),
+            db=db,
+            user=_user(),
+        )
+    )
+
+    assert second.id_carga != first.id_carga
+    assert db.query(CargaComb).count() == 2
+
+
+def test_form_uuid_matches_the_database_contract():
+    assert CargaComb.__table__.c.form_uuid.type.length == 36
+    constraint_names = {
+        constraint.name
+        for constraint in CargaComb.__table__.constraints
+    }
+    assert "uq_cargacomb_personal_form_uuid" in constraint_names

--- a/backend/tests/test_deploy_scripts_contract.py
+++ b/backend/tests/test_deploy_scripts_contract.py
@@ -133,6 +133,23 @@ def test_production_deploy_package_applies_idempotent_db_migrations():
     assert missing == []
 
 
+def test_combustible_idempotency_migration_is_packaged_and_repeatable():
+    package_script = read("scripts/build_deploy_package.ps1")
+    migration = read("db_migrations/20260730_cargacomb_form_uuid.sql")
+
+    required_fragments = [
+        "information_schema.COLUMNS",
+        "information_schema.STATISTICS",
+        "ADD COLUMN form_uuid VARCHAR(36) NULL",
+        "uq_cargacomb_personal_form_uuid",
+        "UNIQUE INDEX",
+        "personal, form_uuid",
+    ]
+
+    assert "db_migrations\\*.sql" in package_script
+    assert [fragment for fragment in required_fragments if fragment not in migration] == []
+
+
 def test_admin_actas_crud_contract_is_registered():
     schemas = read("backend/app/schemas/admin.py")
     admin_routes = read("backend/app/api/routes/admin_legacy.py")

--- a/backend/tests/test_produccion_combustible_remitos.py
+++ b/backend/tests/test_produccion_combustible_remitos.py
@@ -1,9 +1,12 @@
-"""Tests de regresion para captura de remitos en el parte de produccion.
+"""Tests de regresion para el combustible asociado a un parte.
 
 Issue #95: cuando el operador marca "Se cargo combustible?", ademas de los
 litros tiene que poder cargar hasta 3 remitos. Esos valores se persisten en
-``tablero_produccion.remito/remito2/remito3`` y en el ``cargacomb`` que se
-crea como movimiento relacionado con los mismos 3 valores.
+``tablero_produccion.remito/remito2/remito3``.
+
+Issue #105: una carga informada en Produccion crea exactamente un egreso en
+``cargacomb`` dentro de la misma transaccion. El endpoint de Combustible queda
+para abastecimientos que no tienen parte de produccion.
 """
 import asyncio
 from contextlib import contextmanager
@@ -23,7 +26,10 @@ from app.schemas.produccion import TableroProduccionCreate
 def test_schema_accepts_remito_fields():
     payload = TableroProduccionCreate(
         fecha=date(2026, 7, 28),
+        form_uuid="parte-combustible-1",
         combustible=150,
+        km_combustible=14855,
+        lugar_carga=42,
         remito="R-0001",
         remito2="R-0002",
         remito3="R-0003",
@@ -32,6 +38,7 @@ def test_schema_accepts_remito_fields():
     assert payload.remito == "R-0001"
     assert payload.remito2 == "R-0002"
     assert payload.remito3 == "R-0003"
+    assert payload.km_combustible == 14855
 
 
 def test_schema_remito_defaults_to_empty_string():
@@ -43,6 +50,33 @@ def test_schema_remito_defaults_to_empty_string():
     assert payload.remito == ""
     assert payload.remito2 == ""
     assert payload.remito3 == ""
+
+
+@pytest.mark.parametrize(
+    ("overrides", "expected_message"),
+    [
+        ({"form_uuid": ""}, "identidad estable"),
+        ({"km_combustible": 0}, "kilometraje u horometro"),
+        ({"lugar_carga": 0}, "lugar de carga"),
+        ({"remito": ""}, "Remito 1"),
+    ],
+)
+def test_schema_requires_complete_stock_data_when_fuel_is_loaded(
+    overrides,
+    expected_message,
+):
+    data = {
+        "fecha": date(2026, 7, 28),
+        "form_uuid": "parte-combustible-completo",
+        "combustible": 80,
+        "km_combustible": 14855,
+        "lugar_carga": 42,
+        "remito": "R-0001",
+    }
+    data.update(overrides)
+
+    with pytest.raises(ValidationError, match=expected_message):
+        TableroProduccionCreate(**data)
 
 
 @pytest.mark.parametrize("field", ["remito", "remito2", "remito3"])
@@ -109,17 +143,19 @@ def _bypass_external_deps(monkeypatch):
     monkeypatch.setattr(produccion, "_form_submission_lock", no_lock)
 
 
-def test_create_persists_remitos_in_tablero_and_cargacomb(monkeypatch):
+def test_create_persists_part_and_stock_movement_in_one_transaction(monkeypatch):
     db = FakeDb()
     _bypass_external_deps(monkeypatch)
 
     payload = TableroProduccionCreate(
         fecha=date(2026, 7, 28),
+        form_uuid="parte-combustible-atomic",
         UN="BIOMASA FRESA",
         cod_un=1,
         cod_equipo=10,
         cod_operador=5,
         combustible=150,
+        km_combustible=14855,
         lugar_carga=42,
         id_tipo_comb=2,
         remito="R-0001",
@@ -130,7 +166,7 @@ def test_create_persists_remitos_in_tablero_and_cargacomb(monkeypatch):
     asyncio.run(produccion.create_produccion(payload, db=db, user=SimpleNamespace()))
 
     assert db.commits == 1
-    assert len(db.added) == 2  # TableroProduccion + CargaComb
+    assert len(db.added) == 2
 
     tablero = db.added[0]
     carga = db.added[1]
@@ -138,35 +174,23 @@ def test_create_persists_remitos_in_tablero_and_cargacomb(monkeypatch):
     assert tablero.remito == "R-0001"
     assert tablero.remito2 == "R-0002"
     assert tablero.remito3 == "R-0003"
-
+    assert tablero.combustible == 150
+    assert tablero.lugar_carga == 42
+    assert carga.idMovil == 10
+    assert carga.idTipoComb == 2
+    assert carga.Fecha == date(2026, 7, 28)
+    assert carga.KM == 14855
+    assert carga.Litros == 150
+    assert carga.idLugarCarga == 42
+    assert carga.UnidadNegocio == 1
+    assert carga.personal == 5
+    assert carga.idtabla == "1"
+    assert carga.tabla == "tablero_produccion"
+    assert carga.tipo_mov == "E"
     assert carga.remito == "R-0001"
     assert carga.remito2 == "R-0002"
     assert carga.remito3 == "R-0003"
-    assert carga.tabla == "tablero_produccion"
-    assert carga.tipo_mov == "E"
-    assert carga.Litros == 150
-    assert carga.idLugarCarga == 42
-    assert carga.idTipoComb == 2
-
-
-def test_create_falls_back_to_defaults_when_lugar_carga_and_tipo_comb_missing(monkeypatch):
-    """Si el cliente no manda lugar_carga o id_tipo_comb, el backend usa 1 (Gasoil default)."""
-    db = FakeDb()
-    _bypass_external_deps(monkeypatch)
-
-    payload = TableroProduccionCreate(
-        fecha=date(2026, 7, 28),
-        cod_equipo=10,
-        cod_operador=5,
-        combustible=80,
-        # Sin lugar_carga, sin id_tipo_comb
-    )
-
-    asyncio.run(produccion.create_produccion(payload, db=db, user=SimpleNamespace()))
-
-    carga = db.added[1]
-    assert carga.idLugarCarga == 1  # fallback del schema
-    assert carga.idTipoComb == 1    # fallback Gasoil
+    assert carga.form_uuid == "parte-combustible-atomic"
 
 
 def test_create_does_not_create_cargacomb_when_combustible_is_zero(monkeypatch):
@@ -180,32 +204,18 @@ def test_create_does_not_create_cargacomb_when_combustible_is_zero(monkeypatch):
 
     asyncio.run(produccion.create_produccion(payload, db=db, user=SimpleNamespace()))
 
-    # Solo se persiste el TableroProduccion; no hay CargaComb.
     assert len(db.added) == 1
     tablero = db.added[0]
     assert tablero.combustible == 0
 
 
-def test_create_persists_empty_remitos_when_combustible_without_remito(monkeypatch):
-    db = FakeDb()
-    _bypass_external_deps(monkeypatch)
-
-    payload = TableroProduccionCreate(
-        fecha=date(2026, 7, 28),
-        combustible=80,
-        remito="",
-        remito2="",
-        remito3="",
-    )
-
-    asyncio.run(produccion.create_produccion(payload, db=db, user=SimpleNamespace()))
-
-    tablero = db.added[0]
-    carga = db.added[1]
-
-    assert tablero.remito == ""
-    assert tablero.remito2 == ""
-    assert tablero.remito3 == ""
-    assert carga.remito == ""
-    assert carga.remito2 == ""
-    assert carga.remito3 == ""
+def test_schema_rejects_fuel_without_remito():
+    with pytest.raises(ValidationError, match="Remito 1"):
+        TableroProduccionCreate(
+            fecha=date(2026, 7, 28),
+            form_uuid="parte-sin-remito",
+            combustible=80,
+            km_combustible=14855,
+            lugar_carga=42,
+            remito="",
+        )

--- a/db_migrations/20260730_cargacomb_form_uuid.sql
+++ b/db_migrations/20260730_cargacomb_form_uuid.sql
@@ -1,0 +1,42 @@
+-- Issue #105: idempotencia explicita para cada egreso de combustible.
+--
+-- Los movimientos historicos quedan con form_uuid NULL. Los nuevos registros
+-- creados desde Produccion o desde Carga de Combustible reciben una identidad
+-- por formulario. La unicidad se limita al operador para aceptar dos cargas
+-- reales con los mismos movil, fecha y litros cuando sus identidades difieren.
+
+SET @schema_name = DATABASE();
+
+SET @column_exists = (
+  SELECT COUNT(*)
+  FROM information_schema.COLUMNS
+  WHERE TABLE_SCHEMA = @schema_name
+    AND TABLE_NAME = 'cargacomb'
+    AND COLUMN_NAME = 'form_uuid'
+);
+
+SET @add_column_sql = IF(
+  @column_exists = 0,
+  'ALTER TABLE cargacomb ADD COLUMN form_uuid VARCHAR(36) NULL',
+  'SELECT 1'
+);
+PREPARE add_column_stmt FROM @add_column_sql;
+EXECUTE add_column_stmt;
+DEALLOCATE PREPARE add_column_stmt;
+
+SET @index_exists = (
+  SELECT COUNT(*)
+  FROM information_schema.STATISTICS
+  WHERE TABLE_SCHEMA = @schema_name
+    AND TABLE_NAME = 'cargacomb'
+    AND INDEX_NAME = 'uq_cargacomb_personal_form_uuid'
+);
+
+SET @add_index_sql = IF(
+  @index_exists = 0,
+  'CREATE UNIQUE INDEX uq_cargacomb_personal_form_uuid ON cargacomb (personal, form_uuid)',
+  'SELECT 1'
+);
+PREPARE add_index_stmt FROM @add_index_sql;
+EXECUTE add_index_stmt;
+DEALLOCATE PREPARE add_index_stmt;

--- a/docs/COMBUSTIBLE_MOVIMIENTO_UNICO.md
+++ b/docs/COMBUSTIBLE_MOVIMIENTO_UNICO.md
@@ -1,0 +1,39 @@
+# Movimiento único de combustible
+
+## Decisión
+
+Desde la corrección de la issue #105, cada abastecimiento físico crea un solo
+movimiento de egreso en `cargacomb`, desde el flujo donde se origina:
+
+- `POST /api/produccion/` registra el parte y su egreso de combustible en la
+  misma transacción cuando los litros son mayores que cero. El movimiento queda
+  vinculado con `tabla = tablero_produccion` e `idtabla = <id del parte>`.
+- `POST /api/combustible/cargas` registra abastecimientos sin parte de
+  producción y usa `tabla = carga_combustible`.
+
+La misma carga física no debe ingresarse en ambos formularios.
+
+## Contrato del movimiento
+
+- Identidad estable `form_uuid`, reutilizada en los reintentos.
+- Equipo, fecha y litros.
+- Kilometraje u horómetro real, mayor que cero.
+- `id_lugar_carga` e `id_tipo_comb`.
+- `remito` obligatorio y hasta dos remitos adicionales.
+
+En Producción, la identidad del parte evita recrear tanto el parte como su
+movimiento en un reintento. En cargas independientes, la combinación
+`(personal, form_uuid)` es única. Dos cargas reales con igual equipo, fecha y
+litros deben usar identidades distintas y se guardan como movimientos separados.
+
+Si una integración transfiere un abastecimiento entre ambos endpoints, debe
+conservar el mismo `form_uuid`: el segundo envío recupera el movimiento
+existente y no crea otro. La interfaz normal no transfiere cargas; dirige cada
+evento al formulario correspondiente según tenga o no un parte de producción.
+
+## Datos históricos
+
+La migración `20260730_cargacomb_form_uuid.sql` agrega solamente la identidad
+idempotente para movimientos nuevos. No modifica, combina ni elimina registros
+históricos. Cualquier saneamiento de duplicados existentes requiere una tarea
+separada, una consulta previa de sólo lectura y aprobación explícita.

--- a/docs/manuales/manual-admin.md
+++ b/docs/manuales/manual-admin.md
@@ -53,8 +53,9 @@ Secciones de menu disponibles:
 | Seccion | Pantallas |
 | --- | --- |
 | `Inicio` | Panel operativo general y accesos rapidos. |
-| `Operacion` | `Dashboard Operativo`, `Personal`, `Moviles`, `Asignaciones Operativas`. |
-| `Catalogos` | `Unidades de Negocio`, `Tipos de Proceso`, `Lugares de Carga`, `Predios`, `Rodales`, `Configuracion de Acceso`. |
+| `Administracion` | Centro administrativo para personas, equipos, catalogos y accesos. |
+| `Operacion` | `Dashboard Operativo` y `Dashboard Produccion`. |
+| `Combustible` | Cargas de combustible sin parte de produccion. |
 | `Produccion` | `Carga de Produccion`, `Pendientes`, `Mis Registros`. |
 | `Configuracion` | Instalacion de app y cierre de sesion. |
 
@@ -120,6 +121,9 @@ El dashboard admin incluye:
 Si no hay datos, ampliar el rango de fechas o revisar que existan registros cargados.
 
 ## 5. Gestion operativa y catalogos
+
+Entrar desde `Administracion`. El centro administrativo agrupa personas,
+equipos, asignaciones, catalogos productivos y configuracion de acceso.
 
 Las pantallas de gestion comparten una estructura:
 
@@ -235,7 +239,7 @@ Los rodales se usan al completar `Ubicacion y Referencia` en la carga de producc
 
 ## 6. Asignaciones operativas
 
-Entrar desde `Operacion > Asignaciones Operativas`.
+Entrar desde `Administracion > Asignaciones operativas`.
 
 La pantalla incluye un panel rapido para asignar:
 
@@ -258,7 +262,7 @@ Tambien se puede editar o eliminar asignaciones existentes desde la tabla.
 
 ## 7. Configuracion de acceso
 
-Entrar desde `Catalogos > Configuracion de Acceso`.
+Entrar desde `Administracion > Configuracion de acceso`.
 
 Esta pantalla permite habilitar o deshabilitar `Acceso Admin` para otros usuarios.
 
@@ -292,6 +296,10 @@ El formulario mantiene los mismos 9 pasos:
 9. Revision.
 
 Como admin, revisar especialmente unidad, operador, equipo y proceso antes de guardar, ya que una carga manual puede afectar reportes globales.
+
+Si el parte incluye combustible, completar litros, KM u horometro real, lugar
+de carga y al menos el Remito 1. Ese parte ya genera el egreso de stock; la
+seccion `Carga de Combustible` queda solo para abastecimientos sin parte.
 
 ### Pendientes
 

--- a/docs/manuales/manual-encargado.md
+++ b/docs/manuales/manual-encargado.md
@@ -153,13 +153,17 @@ Los campos requeridos deben tener valores mayores a 0.
 
 Registrar combustible y aceites cuando correspondan.
 
+Cuando se carga combustible, completar litros, KM u horometro real y al menos
+el Remito 1. El parte crea el egreso de stock; no repetir el abastecimiento en
+`Carga de Combustible`.
+
 Si el proceso incluye sistema de corte, completar los datos solicitados de espada, puntera, cadena, pinon o cantidad de cadenas segun aplique.
 
 ### Paso 8: Ubicacion y Referencia
 
 Completar:
 
-- `Lugar de Carga`, si existe para la unidad.
+- `Lugar de Carga`, obligatorio cuando el parte incluye combustible.
 - `Acta`.
 - `Predio`.
 - `Rodal` o `Rodal manual`.

--- a/docs/manuales/manual-operador.md
+++ b/docs/manuales/manual-operador.md
@@ -140,7 +140,9 @@ Usar este paso para registrar combustible y consumos asociados cuando correspond
 
 Campos habituales:
 
-- `Combustible`.
+- `Combustible` en litros.
+- `KM / Horometro al cargar`.
+- `Remito 1` obligatorio y hasta dos remitos adicionales.
 - `Aceite cadena`.
 - `Aceite hidraulico`.
 - `Aceite motor`.
@@ -148,13 +150,15 @@ Campos habituales:
 - `Aceite embrague`.
 - Datos del sistema de corte, cuando el proceso lo solicita.
 
-Si no se cargo combustible, dejar el control desactivado o en 0.
+Si se informa combustible, el parte genera tambien el egreso de stock. No se
+debe repetir ese abastecimiento en `Carga de Combustible`. Si no se cargo
+combustible, dejar el control desactivado o en 0.
 
 ### Paso 8: Ubicacion y Referencia
 
 Completar:
 
-- `Lugar de Carga`, si esta disponible para la unidad.
+- `Lugar de Carga`, obligatorio cuando el parte incluye combustible.
 - `Acta`.
 - `Predio`.
 - `Rodal` desde la lista o `Rodal manual`.

--- a/frontend/public/manuales/manual-admin.md
+++ b/frontend/public/manuales/manual-admin.md
@@ -53,8 +53,9 @@ Secciones de menu disponibles:
 | Seccion | Pantallas |
 | --- | --- |
 | `Inicio` | Panel operativo general y accesos rapidos. |
-| `Operacion` | `Dashboard Operativo`, `Personal`, `Moviles`, `Asignaciones Operativas`. |
-| `Catalogos` | `Unidades de Negocio`, `Tipos de Proceso`, `Lugares de Carga`, `Predios`, `Rodales`, `Configuracion de Acceso`. |
+| `Administracion` | Centro administrativo para personas, equipos, catalogos y accesos. |
+| `Operacion` | `Dashboard Operativo` y `Dashboard Produccion`. |
+| `Combustible` | Cargas de combustible sin parte de produccion. |
 | `Produccion` | `Carga de Produccion`, `Pendientes`, `Mis Registros`. |
 | `Configuracion` | Instalacion de app y cierre de sesion. |
 
@@ -120,6 +121,9 @@ El dashboard admin incluye:
 Si no hay datos, ampliar el rango de fechas o revisar que existan registros cargados.
 
 ## 5. Gestion operativa y catalogos
+
+Entrar desde `Administracion`. El centro administrativo agrupa personas,
+equipos, asignaciones, catalogos productivos y configuracion de acceso.
 
 Las pantallas de gestion comparten una estructura:
 
@@ -235,7 +239,7 @@ Los rodales se usan al completar `Ubicacion y Referencia` en la carga de producc
 
 ## 6. Asignaciones operativas
 
-Entrar desde `Operacion > Asignaciones Operativas`.
+Entrar desde `Administracion > Asignaciones operativas`.
 
 La pantalla incluye un panel rapido para asignar:
 
@@ -258,7 +262,7 @@ Tambien se puede editar o eliminar asignaciones existentes desde la tabla.
 
 ## 7. Configuracion de acceso
 
-Entrar desde `Catalogos > Configuracion de Acceso`.
+Entrar desde `Administracion > Configuracion de acceso`.
 
 Esta pantalla permite habilitar o deshabilitar `Acceso Admin` para otros usuarios.
 
@@ -292,6 +296,10 @@ El formulario mantiene los mismos 9 pasos:
 9. Revision.
 
 Como admin, revisar especialmente unidad, operador, equipo y proceso antes de guardar, ya que una carga manual puede afectar reportes globales.
+
+Si el parte incluye combustible, completar litros, KM u horometro real, lugar
+de carga y al menos el Remito 1. Ese parte ya genera el egreso de stock; la
+seccion `Carga de Combustible` queda solo para abastecimientos sin parte.
 
 ### Pendientes
 

--- a/frontend/public/manuales/manual-encargado.md
+++ b/frontend/public/manuales/manual-encargado.md
@@ -153,13 +153,17 @@ Los campos requeridos deben tener valores mayores a 0.
 
 Registrar combustible y aceites cuando correspondan.
 
+Cuando se carga combustible, completar litros, KM u horometro real y al menos
+el Remito 1. El parte crea el egreso de stock; no repetir el abastecimiento en
+`Carga de Combustible`.
+
 Si el proceso incluye sistema de corte, completar los datos solicitados de espada, puntera, cadena, pinon o cantidad de cadenas segun aplique.
 
 ### Paso 8: Ubicacion y Referencia
 
 Completar:
 
-- `Lugar de Carga`, si existe para la unidad.
+- `Lugar de Carga`, obligatorio cuando el parte incluye combustible.
 - `Acta`.
 - `Predio`.
 - `Rodal` o `Rodal manual`.

--- a/frontend/public/manuales/manual-operador.md
+++ b/frontend/public/manuales/manual-operador.md
@@ -140,7 +140,9 @@ Usar este paso para registrar combustible y consumos asociados cuando correspond
 
 Campos habituales:
 
-- `Combustible`.
+- `Combustible` en litros.
+- `KM / Horometro al cargar`.
+- `Remito 1` obligatorio y hasta dos remitos adicionales.
 - `Aceite cadena`.
 - `Aceite hidraulico`.
 - `Aceite motor`.
@@ -148,13 +150,15 @@ Campos habituales:
 - `Aceite embrague`.
 - Datos del sistema de corte, cuando el proceso lo solicita.
 
-Si no se cargo combustible, dejar el control desactivado o en 0.
+Si se informa combustible, el parte genera tambien el egreso de stock. No se
+debe repetir ese abastecimiento en `Carga de Combustible`. Si no se cargo
+combustible, dejar el control desactivado o en 0.
 
 ### Paso 8: Ubicacion y Referencia
 
 Completar:
 
-- `Lugar de Carga`, si esta disponible para la unidad.
+- `Lugar de Carga`, obligatorio cuando el parte incluye combustible.
 - `Acta`.
 - `Predio`.
 - `Rodal` desde la lista o `Rodal manual`.

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -158,6 +158,21 @@
                   </div>
                 </Transition>
               </section>
+
+              <router-link
+                v-for="item in trailingItems"
+                :key="item.key"
+                :to="item.to"
+                :class="navItemClass(isItemActive(item))"
+                :title="sidebarCollapsed ? item.label : undefined"
+                exact-active-class="!border-[#10B981]/45 !bg-[#0F2A1E] !text-white"
+                @click="mobileMenuOpen = false"
+              >
+                <span :class="['flex min-w-0 items-center', sidebarCollapsed ? 'md:justify-center md:gap-0 gap-3' : 'gap-3']">
+                  <AppIcon :name="item.icon" size="sm" class="shrink-0" />
+                  <span :class="['truncate', sidebarCollapsed ? 'md:hidden' : '']">{{ item.label }}</span>
+                </span>
+              </router-link>
             </div>
           </nav>
 
@@ -250,6 +265,7 @@ import { useTheme } from '@/composables/useTheme'
 import OfflineBanner from '@/components/ui/OfflineBanner.vue'
 import ToastHost from '@/components/ToastHost.vue'
 import AppIcon from '@/components/ui/AppIcon.vue'
+import { createSidebarNavigation } from '@/config/navigation'
 
 const router = useRouter()
 const route = useRoute()
@@ -261,14 +277,12 @@ const mobileMenuOpen = ref(false)
 const sidebarCollapsed = ref(localStorage.getItem('sidebarCollapsed') === '1')
 const openSections = reactive({
   operacion: false,
-  catalogos: false,
   combustible: false,
   produccion: false,
 })
 
 const isAdmin = computed(() => authStore.isAdmin)
 const isEncargado = computed(() => authStore.user?.encargado === 1)
-const canViewDashboard = computed(() => isAdmin.value || isEncargado.value)
 const backendConnectionLabel = computed(() => {
   if (!connectivityStore.isOnline) return 'Sin conexión'
   if (connectivityStore.pendingInitialHealthCheck) return 'Verificando servidor'
@@ -296,66 +310,14 @@ const userInitials = computed(() => {
 const themeToggleLabel = computed(() => (isDark.value ? 'Cambiar a modo claro' : 'Cambiar a modo oscuro'))
 const themeStatusLabel = computed(() => (isDark.value ? 'Modo oscuro' : 'Modo claro'))
 
-const primaryItems = computed(() => [
-  { key: 'home', label: 'Inicio', icon: 'home', to: { name: 'home' } },
-  { key: 'manuales', label: 'Manuales', icon: 'manual', to: { name: 'manuales' } },
-])
-
-const navSections = computed(() => {
-  const sections = []
-
-  if (canViewDashboard.value || isAdmin.value) {
-    const operacionItems = []
-    if (canViewDashboard.value) {
-      operacionItems.push({ key: 'dashboard', label: 'Dashboard Operativo', icon: 'dashboard', to: { name: 'dashboard' } })
-    }
-    if (isAdmin.value) {
-      operacionItems.push(
-        { key: 'admin-dashboard', label: 'Dashboard Producción', icon: 'dashboard', to: { name: 'admin-dashboard' } },
-        { key: 'personal', label: 'Personal', icon: 'personnel', to: { name: 'admin-crud', params: { entity: 'personal' } } },
-        { key: 'moviles', label: 'Moviles', icon: 'machine', to: { name: 'admin-crud', params: { entity: 'moviles' } } },
-        { key: 'asignaciones', label: 'Asignaciones Operativas', icon: 'assignment', to: { name: 'admin-crud', params: { entity: 'asignaciones' } } },
-      )
-    }
-    sections.push({ key: 'operacion', label: 'Operacion', items: operacionItems })
-  }
-
-  if (isAdmin.value) {
-    sections.push({
-      key: 'catalogos',
-      label: 'Catálogos',
-      items: [
-        { key: 'unidades', label: 'Unidades de Negocio', icon: 'unit', to: { name: 'admin-crud', params: { entity: 'unidades-negocio' } } },
-        { key: 'tipos', label: 'Tipos de Proceso', icon: 'process', to: { name: 'admin-crud', params: { entity: 'tipos-proceso' } } },
-        { key: 'lugares', label: 'Lugares de Carga', icon: 'location', to: { name: 'admin-crud', params: { entity: 'lugares-carga' } } },
-        { key: 'predios', label: 'Predios', icon: 'field', to: { name: 'admin-crud', params: { entity: 'predios' } } },
-        { key: 'rodales', label: 'Rodales', icon: 'plot', to: { name: 'admin-crud', params: { entity: 'rodales' } } },
-        { key: 'actas', label: 'Actas', icon: 'records', to: { name: 'admin-crud', params: { entity: 'actas' } } },
-        { key: 'acceso', label: 'Configuración de Acceso', icon: 'settings', to: { name: 'admin-configuracion' } },
-      ],
-    })
-  }
-
-  sections.push({
-    key: 'combustible',
-    label: 'Combustible',
-    items: [
-      { key: 'carga-combustible', label: 'Carga de Combustible', icon: 'fuel', to: { name: 'combustible' } },
-    ],
-  })
-
-  const produccionItems = [
-    { key: 'carga-produccion', label: 'Carga de Producción', icon: 'production', to: { name: 'produccion' } },
-    { key: 'pendientes', label: 'Pendientes', icon: 'pending', to: { name: 'pendientes' }, badge: produccionStore.pendingCount },
-  ]
-
-  if (!isEncargado.value || isAdmin.value) {
-    produccionItems.push({ key: 'mis-registros', label: 'Mis Registros', icon: 'records', to: { name: 'mis-registros' } })
-  }
-
-  sections.push({ key: 'produccion', label: 'Producción', items: produccionItems })
-  return sections
-})
+const sidebarNavigation = computed(() => createSidebarNavigation({
+  isAdmin: isAdmin.value,
+  isEncargado: isEncargado.value,
+  pendingCount: produccionStore.pendingCount,
+}))
+const primaryItems = computed(() => sidebarNavigation.value.primaryItems)
+const navSections = computed(() => sidebarNavigation.value.sections)
+const trailingItems = computed(() => sidebarNavigation.value.trailingItems)
 
 function toggleSection(key) {
   openSections[key] = !openSections[key]
@@ -395,6 +357,7 @@ function isSectionActive(section) {
 }
 
 function isItemActive(item) {
+  if (item.activeRoutes?.includes(route.name)) return true
   if (item.to.name === 'admin-crud') {
     return route.name === 'admin-crud' && route.params.entity === item.to.params.entity
   }

--- a/frontend/src/config/navigation.js
+++ b/frontend/src/config/navigation.js
@@ -1,0 +1,77 @@
+function link(key, label, icon, to, extra = {}) {
+  return { key, label, icon, to, ...extra }
+}
+
+function section(key, label, items) {
+  return { key, label, items }
+}
+
+export function createSidebarNavigation({
+  isAdmin = false,
+  isEncargado = false,
+  pendingCount = 0,
+} = {}) {
+  const primaryItems = [
+    link('home', 'Inicio', 'home', { name: 'home' }),
+    link('manuales', 'Manuales', 'manual', { name: 'manuales' }),
+  ]
+
+  const trailingItems = []
+  if (isAdmin) {
+    trailingItems.push(link(
+      'admin-center',
+      'Administración',
+      'admin',
+      { name: 'admin-center' },
+      { activeRoutes: ['admin-center', 'admin-crud', 'admin-configuracion'] },
+    ))
+  }
+
+  const sections = []
+  if (isAdmin || isEncargado) {
+    const operationItems = [
+      link('dashboard', 'Dashboard Operativo', 'dashboard', { name: 'dashboard' }),
+    ]
+    if (isAdmin) {
+      operationItems.push(
+        link('admin-dashboard', 'Dashboard Producción', 'dashboard', { name: 'admin-dashboard' }),
+      )
+    }
+    sections.push(section('operacion', 'Operación', operationItems))
+  }
+
+  sections.push(section('combustible', 'Combustible', [
+    link('carga-combustible', 'Carga de Combustible', 'fuel', { name: 'combustible' }),
+  ]))
+
+  const productionItems = [
+    link('carga-produccion', 'Carga de Producción', 'production', { name: 'produccion' }),
+    link(
+      'pendientes',
+      'Pendientes',
+      'pending',
+      { name: 'pendientes' },
+      { badge: Number(pendingCount || 0) },
+    ),
+  ]
+  if (!isEncargado || isAdmin) {
+    productionItems.push(
+      link('mis-registros', 'Mis Registros', 'records', { name: 'mis-registros' }),
+    )
+  }
+  sections.push(section('produccion', 'Producción', productionItems))
+
+  return { primaryItems, sections, trailingItems }
+}
+
+export function flattenNavigation({
+  primaryItems = [],
+  sections = [],
+  trailingItems = [],
+}) {
+  return [
+    ...primaryItems,
+    ...sections.flatMap((navigationSection) => navigationSection.items),
+    ...trailingItems,
+  ]
+}

--- a/frontend/src/config/navigation.test.js
+++ b/frontend/src/config/navigation.test.js
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+
+import { createSidebarNavigation, flattenNavigation } from './navigation'
+
+function routeNames(navigation) {
+  return flattenNavigation(navigation).map((item) => item.to.name)
+}
+
+describe('role-aware sidebar navigation', () => {
+  it('keeps operator navigation compact and without administrative routes', () => {
+    const navigation = createSidebarNavigation({ pendingCount: 3 })
+
+    expect(navigation.primaryItems.map((item) => item.key)).toEqual(['home', 'manuales'])
+    expect(navigation.sections.map((section) => section.key)).toEqual(['combustible', 'produccion'])
+    expect(routeNames(navigation)).not.toContain('admin-center')
+    expect(routeNames(navigation)).not.toContain('admin-crud')
+    expect(navigation.sections[1].items[1].badge).toBe(3)
+  })
+
+  it('shows the operational dashboard but not personal records to an encargado', () => {
+    const navigation = createSidebarNavigation({ isEncargado: true })
+
+    expect(navigation.sections.map((section) => section.key)).toEqual([
+      'operacion',
+      'combustible',
+      'produccion',
+    ])
+    expect(routeNames(navigation)).toContain('dashboard')
+    expect(routeNames(navigation)).not.toContain('mis-registros')
+  })
+
+  it('routes administrative management through one center without duplicated CRUD links', () => {
+    const navigation = createSidebarNavigation({ isAdmin: true, isEncargado: true })
+    const names = routeNames(navigation)
+    const adminItem = navigation.trailingItems.find((item) => item.key === 'admin-center')
+
+    expect(adminItem.to.name).toBe('admin-center')
+    expect(navigation.primaryItems.map((item) => item.key)).toEqual(['home', 'manuales'])
+    expect(navigation.trailingItems.map((item) => item.key)).toEqual(['admin-center'])
+    expect(adminItem.activeRoutes).toEqual([
+      'admin-center',
+      'admin-crud',
+      'admin-configuracion',
+    ])
+    expect(names).toContain('admin-dashboard')
+    expect(names).not.toContain('admin-crud')
+    expect(new Set(names).size).toBe(names.length)
+  })
+})

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -58,7 +58,13 @@ const routes = [
     children: [
       {
         path: '',
-        redirect: { name: 'admin-dashboard' },
+        redirect: { name: 'admin-center' },
+      },
+      {
+        path: 'gestion',
+        name: 'admin-center',
+        component: () => import('../views/admin/AdminCenterView.vue'),
+        meta: { requiresAuth: true, requiresAdmin: true },
       },
       {
         path: 'dashboard',
@@ -87,22 +93,27 @@ const router = createRouter({
   routes,
 })
 
-router.beforeEach((to, from, next) => {
-  const authStore = useAuthStore()
+export function authorizeRoute(to, authStore) {
   const authenticated =
     authStore.isAuthenticated || authStore.isAuthenticatedOffline
 
   if (to.meta.requiresAuth && !authenticated) {
-    next({ name: 'login' })
+    return { name: 'login' }
   } else if (to.meta.requiresAdmin && authStore.user?.is_admin !== 1) {
-    next({ name: 'home' })
+    return { name: 'home' }
   } else if (to.meta.requiresEncargado && authStore.user?.encargado !== 1 && authStore.user?.is_admin !== 1) {
-    next({ name: 'home' })
+    return { name: 'home' }
   } else if (to.name === 'login' && authenticated) {
-    next({ name: 'home' })
-  } else {
-    next()
+    return { name: 'home' }
   }
+
+  return true
+}
+
+router.beforeEach((to, from, next) => {
+  const result = authorizeRoute(to, useAuthStore())
+  if (result === true) next()
+  else next(result)
 })
 
 export default router

--- a/frontend/src/router/index.test.js
+++ b/frontend/src/router/index.test.js
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+
+import router, { authorizeRoute } from './index'
+
+describe('admin center route', () => {
+  it('is registered as the administrator-only default route', () => {
+    const resolved = router.resolve({ name: 'admin-center' })
+    const adminRoot = router.getRoutes().find((route) => route.path === '/admin')
+
+    expect(resolved.path).toBe('/admin/gestion')
+    expect(resolved.meta.requiresAuth).toBe(true)
+    expect(resolved.meta.requiresAdmin).toBe(true)
+    expect(adminRoot.redirect).toEqual({ name: 'admin-center' })
+  })
+
+  it('redirects a non-admin user away from the admin center', () => {
+    const to = router.resolve({ name: 'admin-center' })
+    const authStore = {
+      isAuthenticated: true,
+      isAuthenticatedOffline: false,
+      user: { is_admin: 0, encargado: 0 },
+    }
+
+    expect(authorizeRoute(to, authStore)).toEqual({ name: 'home' })
+  })
+
+  it('allows an authenticated administrator into the admin center', () => {
+    const to = router.resolve({ name: 'admin-center' })
+    const authStore = {
+      isAuthenticated: true,
+      isAuthenticatedOffline: false,
+      user: { is_admin: 1, encargado: 0 },
+    }
+
+    expect(authorizeRoute(to, authStore)).toBe(true)
+  })
+})

--- a/frontend/src/stores/combustible.js
+++ b/frontend/src/stores/combustible.js
@@ -4,7 +4,9 @@ import api from '@/services/api'
 export const useCombustibleStore = defineStore('combustible', {
   state: () => ({
     moviles: [],
+    lugaresCarga: [],
     loadingMoviles: false,
+    loadingLugares: false,
     saving: false,
     error: null,
     lastCarga: null,
@@ -24,6 +26,28 @@ export const useCombustibleStore = defineStore('combustible', {
         this.moviles = []
       } finally {
         this.loadingMoviles = false
+      }
+    },
+
+    async fetchLugaresCarga(unidadId) {
+      this.lugaresCarga = []
+      if (!unidadId) return []
+
+      this.loadingLugares = true
+      this.error = null
+      try {
+        const { data } = await api.get('/api/produccion/lugares-carga', {
+          params: { un_id: unidadId },
+          _suppressErrorToast: true,
+        })
+        this.lugaresCarga = Array.isArray(data) ? data : []
+        return this.lugaresCarga
+      } catch (error) {
+        this.error = error.response?.data?.detail || 'No se pudieron cargar los lugares de carga'
+        this.lugaresCarga = []
+        return []
+      } finally {
+        this.loadingLugares = false
       }
     },
 

--- a/frontend/src/stores/combustible.test.js
+++ b/frontend/src/stores/combustible.test.js
@@ -1,0 +1,66 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createPinia, setActivePinia } from 'pinia'
+
+vi.mock('@/services/api', () => ({
+  default: {
+    get: vi.fn(),
+    post: vi.fn(),
+  },
+}))
+
+import api from '@/services/api'
+import { useCombustibleStore } from './combustible'
+
+
+describe('combustible store', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+  })
+
+  it('loads places for the selected equipment business unit', async () => {
+    api.get.mockResolvedValueOnce({
+      data: [{ idLugarCarga: 42, detalle: 'Pañol COSECHA CTL' }],
+    })
+    const store = useCombustibleStore()
+
+    await store.fetchLugaresCarga(7)
+
+    expect(api.get).toHaveBeenCalledWith(
+      '/api/produccion/lugares-carga',
+      expect.objectContaining({
+        params: { un_id: 7 },
+        _suppressErrorToast: true,
+      }),
+    )
+    expect(store.lugaresCarga).toEqual([
+      { idLugarCarga: 42, detalle: 'Pañol COSECHA CTL' },
+    ])
+  })
+
+  it('forwards the stable identity and complete inventory payload', async () => {
+    const payload = {
+      form_uuid: 'carga-fisica-1',
+      fecha: '2026-07-29',
+      id_movil: 10,
+      litros: 160,
+      km: 14855,
+      id_lugar_carga: 42,
+      id_tipo_comb: 1,
+      remito: 'R-0001',
+      remito2: '',
+      remito3: '',
+      observaciones: null,
+    }
+    api.post.mockResolvedValueOnce({
+      data: { id_carga: 99, movil: 'FORWA-N°2', ...payload },
+    })
+    const store = useCombustibleStore()
+
+    const result = await store.createCarga(payload)
+
+    expect(api.post).toHaveBeenCalledWith('/api/combustible/cargas', payload)
+    expect(result.id_carga).toBe(99)
+    expect(store.lastCarga.form_uuid).toBe('carga-fisica-1')
+  })
+})

--- a/frontend/src/stores/produccion.test.js
+++ b/frontend/src/stores/produccion.test.js
@@ -225,11 +225,23 @@ describe('produccion sync offline', () => {
     api.post.mockRejectedValueOnce(new Error('connection reset after commit'))
     const store = useProduccionStore()
 
-    const result = await store.submitProduccion({ fecha: '2026-07-21' })
+    const result = await store.submitProduccion({
+      fecha: '2026-07-21',
+      combustible: 160,
+      km_combustible: 14855,
+      lugar_carga: 42,
+      remito: 'R-0001',
+    })
 
     const postedPayload = api.post.mock.calls[0][1]
     expect(api.post.mock.calls[0][0]).toBe('/api/produccion/')
     expect(postedPayload.form_uuid).toBeTruthy()
+    expect(postedPayload).toEqual(expect.objectContaining({
+      combustible: 160,
+      km_combustible: 14855,
+      lugar_carga: 42,
+      remito: 'R-0001',
+    }))
     expect(queuePendingProductionRecord).toHaveBeenCalledWith(postedPayload)
     expect(result).toEqual({ offline: true })
   })

--- a/frontend/src/views/CombustibleFormView.vue
+++ b/frontend/src/views/CombustibleFormView.vue
@@ -2,7 +2,7 @@
   <div class="mx-auto max-w-6xl px-3 py-3 pb-20 md:px-4 md:pt-4">
     <PageHeader
       title="Carga de Combustible"
-      description="Registro independiente de cargas por movil y operador."
+      description="Abastecimientos sin parte de producción, con lectura real del equipo."
     >
       <template #kicker>
         <span class="rounded-full bg-warning-light/60 px-3 py-1 text-xs font-extrabold uppercase tracking-wide text-warning-dark">
@@ -23,6 +23,10 @@
 
           <div v-if="successMessage" class="rounded-lg border border-success/30 bg-success-light/40 p-3 text-sm font-semibold text-success-dark">
             {{ successMessage }}
+          </div>
+
+          <div class="rounded-lg border border-info/30 bg-info-light/40 p-3 text-sm text-info-dark">
+            Usá esta sección sólo cuando el abastecimiento no esté asociado a un parte de producción. Si lo registraste en Producción, no lo repitas aquí.
           </div>
 
           <div class="grid gap-3 md:grid-cols-2">
@@ -54,6 +58,8 @@
               v-model.number="form.litros"
               label="Litros"
               type="number"
+              min="0.01"
+              step="0.01"
               required
             />
 
@@ -61,7 +67,47 @@
               v-model.number="form.km"
               label="Kilometraje / horometro"
               type="number"
+              min="1"
               required
+            />
+
+            <div class="md:col-span-2">
+              <AutocompleteField
+                v-model="form.id_lugar_carga"
+                :items="store.lugaresCarga"
+                label="Lugar de carga"
+                labelKey="detalle"
+                valueKey="idLugarCarga"
+                placeholder="Seleccionar lugar"
+                selectedDisplay="input"
+                :disabled="!form.id_movil || store.loadingLugares"
+                :loading="store.loadingLugares"
+                :invalid="Boolean(formError && !form.id_lugar_carga)"
+                emptyMessage="Sin lugares habilitados para la unidad del equipo"
+              />
+            </div>
+          </div>
+
+          <div class="grid gap-3 sm:grid-cols-3">
+            <InputField
+              v-model="form.remito"
+              label="Remito 1"
+              placeholder="Obligatorio"
+              maxlength="12"
+              required
+              :invalid="Boolean(formError && !form.remito.trim())"
+            />
+            <InputField
+              v-model="form.remito2"
+              label="Remito 2"
+              placeholder="Opcional"
+              maxlength="12"
+            />
+            <InputField
+              v-model="form.remito3"
+              label="Remito 3"
+              placeholder="Opcional"
+              maxlength="12"
             />
           </div>
 
@@ -115,7 +161,7 @@
 </template>
 
 <script setup>
-import { computed, onMounted, reactive, ref } from 'vue'
+import { computed, onMounted, reactive, ref, watch } from 'vue'
 import { useAuthStore } from '@/stores/auth'
 import { useCombustibleStore } from '@/stores/combustible'
 import AutocompleteField from '@/components/AutocompleteField.vue'
@@ -131,11 +177,19 @@ const formError = ref('')
 const successMessage = ref('')
 
 const today = new Date().toISOString().slice(0, 10)
+const createFormUuid = () => (
+  globalThis.crypto?.randomUUID?.() || `${Date.now()}-${Math.random()}`
+)
 const form = reactive({
+  form_uuid: createFormUuid(),
   fecha: today,
   id_movil: '',
   litros: '',
   km: '',
+  id_lugar_carga: '',
+  remito: '',
+  remito2: '',
+  remito3: '',
   observaciones: '',
 })
 
@@ -151,24 +205,44 @@ const movilOptions = computed(() => store.moviles.map((movil) => ({
   _label: [movil.patente, movil.detalle].filter(Boolean).join(' - '),
 })))
 
+const movilSeleccionado = computed(() => (
+  store.moviles.find((movil) => String(movil.idMovil) === String(form.id_movil))
+))
+
 onMounted(() => {
   store.fetchMoviles()
+})
+
+watch(() => form.id_movil, async () => {
+  form.id_lugar_carga = ''
+  await store.fetchLugaresCarga(movilSeleccionado.value?.id_unidad_negocio)
 })
 
 function validateForm() {
   if (!form.fecha) return 'Selecciona la fecha de carga.'
   if (!form.id_movil) return 'Selecciona un equipo o movil.'
   if (!Number(form.litros) || Number(form.litros) <= 0) return 'Ingresa una cantidad de litros mayor a cero.'
-  if (form.km === '' || Number(form.km) < 0) return 'Ingresa kilometraje u horometro valido.'
+  if (!Number(form.km) || Number(form.km) <= 0) return 'Ingresa un kilometraje u horometro mayor a cero.'
+  if (!form.id_lugar_carga) return 'Selecciona el lugar de carga.'
+  if (!form.remito.trim()) return 'Ingresa el Remito 1.'
   return ''
 }
 
-function resetForm() {
+function clearFormFields() {
+  form.form_uuid = createFormUuid()
   form.fecha = today
   form.id_movil = ''
   form.litros = ''
   form.km = ''
+  form.id_lugar_carga = ''
+  form.remito = ''
+  form.remito2 = ''
+  form.remito3 = ''
   form.observaciones = ''
+}
+
+function resetForm() {
+  clearFormFields()
   formError.value = ''
   successMessage.value = ''
 }
@@ -180,17 +254,20 @@ async function submit() {
 
   try {
     const carga = await store.createCarga({
+      form_uuid: form.form_uuid,
       fecha: form.fecha,
       id_movil: Number(form.id_movil),
       litros: Number(form.litros),
       km: Number(form.km),
+      id_lugar_carga: Number(form.id_lugar_carga),
+      id_tipo_comb: 1,
+      remito: form.remito.trim(),
+      remito2: form.remito2.trim(),
+      remito3: form.remito3.trim(),
       observaciones: form.observaciones?.trim() || null,
     })
     successMessage.value = `Carga registrada para ${carga.movil}.`
-    form.id_movil = ''
-    form.litros = ''
-    form.km = ''
-    form.observaciones = ''
+    clearFormFields()
   } catch {
     formError.value = store.error
   }

--- a/frontend/src/views/HomeView.vue
+++ b/frontend/src/views/HomeView.vue
@@ -354,7 +354,7 @@ const adminActions = computed(() => [
   { name: 'produccion', label: 'Ir a Carga de Producción', description: 'Abre el formulario de producción.', to: { name: 'produccion' }, badge: null },
   { name: 'combustible', label: 'Ir a Carga de Combustible', description: 'Abre el formulario de combustible.', to: { name: 'combustible' }, badge: null },
   { name: 'pendientes', label: 'Abrir Pendientes', description: 'Cola offline y reintentos.', to: { name: 'pendientes' }, badge: produccionStore.pendingCount },
-  { name: 'admin', label: 'Abrir Panel Admin', description: 'Catálogos, permisos y relaciones.', to: { name: 'admin-dashboard' }, badge: null },
+  { name: 'admin', label: 'Abrir Panel Admin', description: 'Catálogos, permisos y relaciones.', to: { name: 'admin-center' }, badge: null },
 ])
 
 const adminTotals = computed(() => adminStore.dashboard.reduce((acc, unidad) => {

--- a/frontend/src/views/ProduccionFormView.vue
+++ b/frontend/src/views/ProduccionFormView.vue
@@ -575,6 +575,9 @@
 
       <!-- ═══ 7. COMBUSTIBLE ═══ -->
       <SectionCard v-show="pasoActual === 6" title="Combustible">
+        <div class="mb-3 rounded-lg border border-info/30 bg-info-light/40 p-3 text-sm text-info-dark">
+          Si registrás combustible en este parte, también se descuenta del stock. No repitas la carga en la sección Carga de Combustible.
+        </div>
         <div class="flex items-center justify-between">
           <span class="text-sm font-medium text-neutral-700">¿Se cargó combustible?</span>
           <button
@@ -601,6 +604,14 @@
             v-model.number="form.combustible"
             :placeholder="cargoCombustible ? 'Cantidad cargada (obligatorio)' : 'Ej: 150'"
             min="0"
+            required
+          />
+          <InputField
+            label="KM / Horómetro al cargar"
+            type="number"
+            v-model.number="form.km_combustible"
+            placeholder="Lectura real del equipo"
+            min="1"
             required
           />
           <div class="grid gap-3 sm:grid-cols-3">
@@ -1156,6 +1167,7 @@ const form = reactive({
   hrs_no_op: 0,
   motivo_no_op: '',
   combustible: 0,
+  km_combustible: 0,
   remito: '',
   remito2: '',
   remito3: '',
@@ -1212,6 +1224,7 @@ const horasValidas = computed(() => {
 const combustibleValido = computed(() => {
   if (!cargoCombustible.value) return true
   if (Number(form.combustible) <= 0) return false
+  if (Number(form.km_combustible) <= 0) return false
   return String(form.remito ?? '').trim().length > 0
 })
 
@@ -1338,6 +1351,9 @@ const mensajePasoIncompleto = computed(() => {
   if (pasoActual.value === 6 && !combustibleValido.value) {
     if (Number(form.combustible) <= 0) {
       return 'Marcaste que se cargó combustible, pero los litros están en 0. Ingresá una cantidad mayor a 0 o desactivá el toggle.'
+    }
+    if (Number(form.km_combustible) <= 0) {
+      return 'Marcaste que se cargó combustible: ingresá el KM u horómetro real del equipo para poder continuar.'
     }
     return 'Marcaste que se cargó combustible: ingresá al menos el Remito 1 para poder continuar.'
   }
@@ -1571,6 +1587,7 @@ async function onPredioChange() {
 watch(cargoCombustible, (val) => {
   if (!val) {
     form.combustible = 0
+    form.km_combustible = 0
     form.remito = ''
     form.remito2 = ''
     form.remito3 = ''
@@ -1777,6 +1794,7 @@ async function handleSubmit() {
       hr_inicio: form.hr_inicio,
       hr_fin: form.hr_fin,
       combustible: form.combustible,
+      km_combustible: cargoCombustible.value ? Number(form.km_combustible) : 0,
       remito: cargoCombustible.value ? String(form.remito ?? '').trim() : '',
       remito2: cargoCombustible.value ? String(form.remito2 ?? '').trim() : '',
       remito3: cargoCombustible.value ? String(form.remito3 ?? '').trim() : '',

--- a/frontend/src/views/admin/AdminCenterView.test.js
+++ b/frontend/src/views/admin/AdminCenterView.test.js
@@ -1,0 +1,39 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+
+import AdminCenterView from './AdminCenterView.vue'
+
+describe('AdminCenterView', () => {
+  it('groups every administrative destination in the center', () => {
+    const wrapper = mount(AdminCenterView, {
+      global: {
+        stubs: {
+          AppIcon: true,
+          PageHeader: true,
+          RouterLink: {
+            props: ['to'],
+            template: '<a :data-route="to.name" :data-entity="to.params?.entity"><slot /></a>',
+          },
+        },
+      },
+    })
+
+    expect(wrapper.text()).toContain('Personas y equipos')
+    expect(wrapper.text()).toContain('Configuración productiva')
+    expect(wrapper.text()).toContain('Seguridad')
+
+    const entityLinks = wrapper.findAll('[data-route="admin-crud"]')
+    expect(entityLinks.map((link) => link.attributes('data-entity'))).toEqual([
+      'personal',
+      'moviles',
+      'asignaciones',
+      'unidades-negocio',
+      'tipos-proceso',
+      'lugares-carga',
+      'predios',
+      'rodales',
+      'actas',
+    ])
+    expect(wrapper.findAll('[data-route="admin-configuracion"]')).toHaveLength(1)
+  })
+})

--- a/frontend/src/views/admin/AdminCenterView.vue
+++ b/frontend/src/views/admin/AdminCenterView.vue
@@ -1,0 +1,88 @@
+<template>
+  <div class="space-y-3">
+    <PageHeader
+      kicker="Administración"
+      title="Centro administrativo"
+      description="Gestioná personas, equipos, catálogos y accesos desde un único lugar."
+      elevated
+    />
+
+    <section class="grid gap-3 lg:grid-cols-2 xl:grid-cols-3" aria-label="Áreas administrativas">
+      <article
+        v-for="group in adminGroups"
+        :key="group.key"
+        class="app-card flex min-h-full flex-col rounded-xl p-4"
+      >
+        <header class="mb-3 flex items-start gap-3 border-b border-neutral-200 pb-3">
+          <span class="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-primary-light/35 text-primary-dark">
+            <AppIcon :name="group.icon" />
+          </span>
+          <div class="min-w-0">
+            <h2 class="text-lg font-extrabold text-neutral-950">{{ group.title }}</h2>
+            <p class="mt-1 text-sm text-neutral-500">{{ group.description }}</p>
+          </div>
+        </header>
+
+        <nav class="grid gap-2" :aria-label="group.title">
+          <router-link
+            v-for="item in group.items"
+            :key="item.key"
+            :to="item.to"
+            class="app-surface-muted group flex min-h-12 items-center justify-between gap-3 rounded-lg border px-3 py-2.5 text-left transition hover:-translate-y-px hover:border-primary/35 hover:bg-primary-light/15 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30"
+          >
+            <span class="flex min-w-0 items-center gap-3">
+              <AppIcon :name="item.icon" size="sm" class="shrink-0 text-neutral-500 group-hover:text-primary-dark" />
+              <span class="min-w-0">
+                <span class="block text-sm font-extrabold text-neutral-900">{{ item.label }}</span>
+                <span class="mt-0.5 block text-xs text-neutral-500">{{ item.description }}</span>
+              </span>
+            </span>
+            <AppIcon name="forward" size="sm" class="shrink-0 text-neutral-400 group-hover:text-primary-dark" />
+          </router-link>
+        </nav>
+      </article>
+    </section>
+  </div>
+</template>
+
+<script setup>
+import AppIcon from '@/components/ui/AppIcon.vue'
+import PageHeader from '@/components/ui/PageHeader.vue'
+
+const adminGroups = [
+  {
+    key: 'personas-equipos',
+    title: 'Personas y equipos',
+    description: 'Personal, móviles y asignaciones operativas.',
+    icon: 'personnel',
+    items: [
+      { key: 'personal', label: 'Personal', description: 'Usuarios, roles y relaciones operativas.', icon: 'personnel', to: { name: 'admin-crud', params: { entity: 'personal' } } },
+      { key: 'moviles', label: 'Móviles', description: 'Equipos, unidades y datos técnicos.', icon: 'machine', to: { name: 'admin-crud', params: { entity: 'moviles' } } },
+      { key: 'asignaciones', label: 'Asignaciones operativas', description: 'Choferes, móviles y procesos vinculados.', icon: 'assignment', to: { name: 'admin-crud', params: { entity: 'asignaciones' } } },
+    ],
+  },
+  {
+    key: 'configuracion-productiva',
+    title: 'Configuración productiva',
+    description: 'Catálogos utilizados durante las cargas.',
+    icon: 'process',
+    items: [
+      { key: 'unidades', label: 'Unidades de negocio', description: 'Estructura operativa y vinculaciones.', icon: 'unit', to: { name: 'admin-crud', params: { entity: 'unidades-negocio' } } },
+      { key: 'procesos', label: 'Tipos de proceso', description: 'Procesos y requisitos de carga.', icon: 'process', to: { name: 'admin-crud', params: { entity: 'tipos-proceso' } } },
+      { key: 'lugares', label: 'Lugares de carga', description: 'Puntos de carga por unidad.', icon: 'location', to: { name: 'admin-crud', params: { entity: 'lugares-carga' } } },
+      { key: 'predios', label: 'Predios', description: 'Predios disponibles para producción.', icon: 'field', to: { name: 'admin-crud', params: { entity: 'predios' } } },
+      { key: 'rodales', label: 'Rodales', description: 'Rodales y valores productivos.', icon: 'plot', to: { name: 'admin-crud', params: { entity: 'rodales' } } },
+      { key: 'actas', label: 'Actas', description: 'Actas habilitadas para registrar producción.', icon: 'records', to: { name: 'admin-crud', params: { entity: 'actas' } } },
+    ],
+  },
+  {
+    key: 'seguridad',
+    title: 'Seguridad',
+    description: 'Permisos generales y políticas de acceso.',
+    icon: 'admin',
+    items: [
+      { key: 'acceso', label: 'Configuración de acceso', description: 'Parámetros administrativos y de seguridad.', icon: 'settings', to: { name: 'admin-configuracion' } },
+    ],
+  },
+]
+</script>


### PR DESCRIPTION
- registra el egreso de combustible desde Producción en la misma transacción
- exige KM/horómetro real, lugar de carga y remito obligatorio
- agrega idempotencia mediante form_uuid para evitar duplicados por reintentos
- reserva Carga de Combustible para abastecimientos sin parte de producción
- preserva remitos, tipo de combustible y vínculo con el parte
- incorpora la migración de form_uuid sin modificar datos históricos
- restaura el Centro administrativo y su acceso al final de la sidebar
- centraliza los CRUD administrativos y elimina accesos duplicados
- actualiza manuales y pruebas de regresión