### PR TITLE
feat(ux): restaurar Centro administrativo y centralizar navegacion admin

### DIFF
--- a/docs/manuales/manual-admin.md
+++ b/docs/manuales/manual-admin.md
@@ -53,8 +53,9 @@ Secciones de menu disponibles:
 | Seccion | Pantallas |
 | --- | --- |
 | `Inicio` | Panel operativo general y accesos rapidos. |
-| `Operacion` | `Dashboard Operativo`, `Personal`, `Moviles`, `Asignaciones Operativas`. |
-| `Catalogos` | `Unidades de Negocio`, `Tipos de Proceso`, `Lugares de Carga`, `Predios`, `Rodales`, `Configuracion de Acceso`. |
+| `Administracion` | Centro administrativo para personas, equipos, catalogos y accesos. |
+| `Operacion` | `Dashboard Operativo` y `Dashboard Produccion`. |
+| `Combustible` | Cargas de combustible sin parte de produccion. |
 | `Produccion` | `Carga de Produccion`, `Pendientes`, `Mis Registros`. |
 | `Configuracion` | Instalacion de app y cierre de sesion. |
 
@@ -120,6 +121,9 @@ El dashboard admin incluye:
 Si no hay datos, ampliar el rango de fechas o revisar que existan registros cargados.
 
 ## 5. Gestion operativa y catalogos
+
+Entrar desde `Administracion`. El centro administrativo agrupa personas,
+equipos, asignaciones, catalogos productivos y configuracion de acceso.
 
 Las pantallas de gestion comparten una estructura:
 
@@ -235,7 +239,7 @@ Los rodales se usan al completar `Ubicacion y Referencia` en la carga de producc
 
 ## 6. Asignaciones operativas
 
-Entrar desde `Operacion > Asignaciones Operativas`.
+Entrar desde `Administracion > Asignaciones operativas`.
 
 La pantalla incluye un panel rapido para asignar:
 
@@ -258,7 +262,7 @@ Tambien se puede editar o eliminar asignaciones existentes desde la tabla.
 
 ## 7. Configuracion de acceso
 
-Entrar desde `Catalogos > Configuracion de Acceso`.
+Entrar desde `Administracion > Configuracion de acceso`.
 
 Esta pantalla permite habilitar o deshabilitar `Acceso Admin` para otros usuarios.
 
@@ -292,6 +296,10 @@ El formulario mantiene los mismos 9 pasos:
 9. Revision.
 
 Como admin, revisar especialmente unidad, operador, equipo y proceso antes de guardar, ya que una carga manual puede afectar reportes globales.
+
+Si el parte incluye combustible, completar litros, KM u horometro real, lugar
+de carga y al menos el Remito 1. Ese parte ya genera el egreso de stock; la
+seccion `Carga de Combustible` queda solo para abastecimientos sin parte.
 
 ### Pendientes
 

--- a/docs/manuales/manual-encargado.md
+++ b/docs/manuales/manual-encargado.md
@@ -153,13 +153,17 @@ Los campos requeridos deben tener valores mayores a 0.
 
 Registrar combustible y aceites cuando correspondan.
 
+Cuando se carga combustible, completar litros, KM u horometro real y al menos
+el Remito 1. El parte crea el egreso de stock; no repetir el abastecimiento en
+`Carga de Combustible`.
+
 Si el proceso incluye sistema de corte, completar los datos solicitados de espada, puntera, cadena, pinon o cantidad de cadenas segun aplique.
 
 ### Paso 8: Ubicacion y Referencia
 
 Completar:
 
-- `Lugar de Carga`, si existe para la unidad.
+- `Lugar de Carga`, obligatorio cuando el parte incluye combustible.
 - `Acta`.
 - `Predio`.
 - `Rodal` o `Rodal manual`.

--- a/docs/manuales/manual-operador.md
+++ b/docs/manuales/manual-operador.md
@@ -140,7 +140,9 @@ Usar este paso para registrar combustible y consumos asociados cuando correspond
 
 Campos habituales:
 
-- `Combustible`.
+- `Combustible` en litros.
+- `KM / Horometro al cargar`.
+- `Remito 1` obligatorio y hasta dos remitos adicionales.
 - `Aceite cadena`.
 - `Aceite hidraulico`.
 - `Aceite motor`.
@@ -148,13 +150,15 @@ Campos habituales:
 - `Aceite embrague`.
 - Datos del sistema de corte, cuando el proceso lo solicita.
 
-Si no se cargo combustible, dejar el control desactivado o en 0.
+Si se informa combustible, el parte genera tambien el egreso de stock. No se
+debe repetir ese abastecimiento en `Carga de Combustible`. Si no se cargo
+combustible, dejar el control desactivado o en 0.
 
 ### Paso 8: Ubicacion y Referencia
 
 Completar:
 
-- `Lugar de Carga`, si esta disponible para la unidad.
+- `Lugar de Carga`, obligatorio cuando el parte incluye combustible.
 - `Acta`.
 - `Predio`.
 - `Rodal` desde la lista o `Rodal manual`.

--- a/frontend/public/manuales/manual-admin.md
+++ b/frontend/public/manuales/manual-admin.md
@@ -53,8 +53,9 @@ Secciones de menu disponibles:
 | Seccion | Pantallas |
 | --- | --- |
 | `Inicio` | Panel operativo general y accesos rapidos. |
-| `Operacion` | `Dashboard Operativo`, `Personal`, `Moviles`, `Asignaciones Operativas`. |
-| `Catalogos` | `Unidades de Negocio`, `Tipos de Proceso`, `Lugares de Carga`, `Predios`, `Rodales`, `Configuracion de Acceso`. |
+| `Administracion` | Centro administrativo para personas, equipos, catalogos y accesos. |
+| `Operacion` | `Dashboard Operativo` y `Dashboard Produccion`. |
+| `Combustible` | Cargas de combustible sin parte de produccion. |
 | `Produccion` | `Carga de Produccion`, `Pendientes`, `Mis Registros`. |
 | `Configuracion` | Instalacion de app y cierre de sesion. |
 
@@ -120,6 +121,9 @@ El dashboard admin incluye:
 Si no hay datos, ampliar el rango de fechas o revisar que existan registros cargados.
 
 ## 5. Gestion operativa y catalogos
+
+Entrar desde `Administracion`. El centro administrativo agrupa personas,
+equipos, asignaciones, catalogos productivos y configuracion de acceso.
 
 Las pantallas de gestion comparten una estructura:
 
@@ -235,7 +239,7 @@ Los rodales se usan al completar `Ubicacion y Referencia` en la carga de producc
 
 ## 6. Asignaciones operativas
 
-Entrar desde `Operacion > Asignaciones Operativas`.
+Entrar desde `Administracion > Asignaciones operativas`.
 
 La pantalla incluye un panel rapido para asignar:
 
@@ -258,7 +262,7 @@ Tambien se puede editar o eliminar asignaciones existentes desde la tabla.
 
 ## 7. Configuracion de acceso
 
-Entrar desde `Catalogos > Configuracion de Acceso`.
+Entrar desde `Administracion > Configuracion de acceso`.
 
 Esta pantalla permite habilitar o deshabilitar `Acceso Admin` para otros usuarios.
 
@@ -292,6 +296,10 @@ El formulario mantiene los mismos 9 pasos:
 9. Revision.
 
 Como admin, revisar especialmente unidad, operador, equipo y proceso antes de guardar, ya que una carga manual puede afectar reportes globales.
+
+Si el parte incluye combustible, completar litros, KM u horometro real, lugar
+de carga y al menos el Remito 1. Ese parte ya genera el egreso de stock; la
+seccion `Carga de Combustible` queda solo para abastecimientos sin parte.
 
 ### Pendientes
 

--- a/frontend/public/manuales/manual-encargado.md
+++ b/frontend/public/manuales/manual-encargado.md
@@ -153,13 +153,17 @@ Los campos requeridos deben tener valores mayores a 0.
 
 Registrar combustible y aceites cuando correspondan.
 
+Cuando se carga combustible, completar litros, KM u horometro real y al menos
+el Remito 1. El parte crea el egreso de stock; no repetir el abastecimiento en
+`Carga de Combustible`.
+
 Si el proceso incluye sistema de corte, completar los datos solicitados de espada, puntera, cadena, pinon o cantidad de cadenas segun aplique.
 
 ### Paso 8: Ubicacion y Referencia
 
 Completar:
 
-- `Lugar de Carga`, si existe para la unidad.
+- `Lugar de Carga`, obligatorio cuando el parte incluye combustible.
 - `Acta`.
 - `Predio`.
 - `Rodal` o `Rodal manual`.

--- a/frontend/public/manuales/manual-operador.md
+++ b/frontend/public/manuales/manual-operador.md
@@ -140,7 +140,9 @@ Usar este paso para registrar combustible y consumos asociados cuando correspond
 
 Campos habituales:
 
-- `Combustible`.
+- `Combustible` en litros.
+- `KM / Horometro al cargar`.
+- `Remito 1` obligatorio y hasta dos remitos adicionales.
 - `Aceite cadena`.
 - `Aceite hidraulico`.
 - `Aceite motor`.
@@ -148,13 +150,15 @@ Campos habituales:
 - `Aceite embrague`.
 - Datos del sistema de corte, cuando el proceso lo solicita.
 
-Si no se cargo combustible, dejar el control desactivado o en 0.
+Si se informa combustible, el parte genera tambien el egreso de stock. No se
+debe repetir ese abastecimiento en `Carga de Combustible`. Si no se cargo
+combustible, dejar el control desactivado o en 0.
 
 ### Paso 8: Ubicacion y Referencia
 
 Completar:
 
-- `Lugar de Carga`, si esta disponible para la unidad.
+- `Lugar de Carga`, obligatorio cuando el parte incluye combustible.
 - `Acta`.
 - `Predio`.
 - `Rodal` desde la lista o `Rodal manual`.

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -158,6 +158,21 @@
                   </div>
                 </Transition>
               </section>
+
+              <router-link
+                v-for="item in trailingItems"
+                :key="item.key"
+                :to="item.to"
+                :class="navItemClass(isItemActive(item))"
+                :title="sidebarCollapsed ? item.label : undefined"
+                exact-active-class="!border-[#10B981]/45 !bg-[#0F2A1E] !text-white"
+                @click="mobileMenuOpen = false"
+              >
+                <span :class="['flex min-w-0 items-center', sidebarCollapsed ? 'md:justify-center md:gap-0 gap-3' : 'gap-3']">
+                  <AppIcon :name="item.icon" size="sm" class="shrink-0" />
+                  <span :class="['truncate', sidebarCollapsed ? 'md:hidden' : '']">{{ item.label }}</span>
+                </span>
+              </router-link>
             </div>
           </nav>
 
@@ -250,6 +265,7 @@ import { useTheme } from '@/composables/useTheme'
 import OfflineBanner from '@/components/ui/OfflineBanner.vue'
 import ToastHost from '@/components/ToastHost.vue'
 import AppIcon from '@/components/ui/AppIcon.vue'
+import { createSidebarNavigation } from '@/config/navigation'
 
 const router = useRouter()
 const route = useRoute()
@@ -261,14 +277,12 @@ const mobileMenuOpen = ref(false)
 const sidebarCollapsed = ref(localStorage.getItem('sidebarCollapsed') === '1')
 const openSections = reactive({
   operacion: false,
-  catalogos: false,
   combustible: false,
   produccion: false,
 })
 
 const isAdmin = computed(() => authStore.isAdmin)
 const isEncargado = computed(() => authStore.user?.encargado === 1)
-const canViewDashboard = computed(() => isAdmin.value || isEncargado.value)
 const backendConnectionLabel = computed(() => {
   if (!connectivityStore.isOnline) return 'Sin conexión'
   if (connectivityStore.pendingInitialHealthCheck) return 'Verificando servidor'
@@ -296,66 +310,14 @@ const userInitials = computed(() => {
 const themeToggleLabel = computed(() => (isDark.value ? 'Cambiar a modo claro' : 'Cambiar a modo oscuro'))
 const themeStatusLabel = computed(() => (isDark.value ? 'Modo oscuro' : 'Modo claro'))
 
-const primaryItems = computed(() => [
-  { key: 'home', label: 'Inicio', icon: 'home', to: { name: 'home' } },
-  { key: 'manuales', label: 'Manuales', icon: 'manual', to: { name: 'manuales' } },
-])
-
-const navSections = computed(() => {
-  const sections = []
-
-  if (canViewDashboard.value || isAdmin.value) {
-    const operacionItems = []
-    if (canViewDashboard.value) {
-      operacionItems.push({ key: 'dashboard', label: 'Dashboard Operativo', icon: 'dashboard', to: { name: 'dashboard' } })
-    }
-    if (isAdmin.value) {
-      operacionItems.push(
-        { key: 'admin-dashboard', label: 'Dashboard Producción', icon: 'dashboard', to: { name: 'admin-dashboard' } },
-        { key: 'personal', label: 'Personal', icon: 'personnel', to: { name: 'admin-crud', params: { entity: 'personal' } } },
-        { key: 'moviles', label: 'Moviles', icon: 'machine', to: { name: 'admin-crud', params: { entity: 'moviles' } } },
-        { key: 'asignaciones', label: 'Asignaciones Operativas', icon: 'assignment', to: { name: 'admin-crud', params: { entity: 'asignaciones' } } },
-      )
-    }
-    sections.push({ key: 'operacion', label: 'Operacion', items: operacionItems })
-  }
-
-  if (isAdmin.value) {
-    sections.push({
-      key: 'catalogos',
-      label: 'Catálogos',
-      items: [
-        { key: 'unidades', label: 'Unidades de Negocio', icon: 'unit', to: { name: 'admin-crud', params: { entity: 'unidades-negocio' } } },
-        { key: 'tipos', label: 'Tipos de Proceso', icon: 'process', to: { name: 'admin-crud', params: { entity: 'tipos-proceso' } } },
-        { key: 'lugares', label: 'Lugares de Carga', icon: 'location', to: { name: 'admin-crud', params: { entity: 'lugares-carga' } } },
-        { key: 'predios', label: 'Predios', icon: 'field', to: { name: 'admin-crud', params: { entity: 'predios' } } },
-        { key: 'rodales', label: 'Rodales', icon: 'plot', to: { name: 'admin-crud', params: { entity: 'rodales' } } },
-        { key: 'actas', label: 'Actas', icon: 'records', to: { name: 'admin-crud', params: { entity: 'actas' } } },
-        { key: 'acceso', label: 'Configuración de Acceso', icon: 'settings', to: { name: 'admin-configuracion' } },
-      ],
-    })
-  }
-
-  sections.push({
-    key: 'combustible',
-    label: 'Combustible',
-    items: [
-      { key: 'carga-combustible', label: 'Carga de Combustible', icon: 'fuel', to: { name: 'combustible' } },
-    ],
-  })
-
-  const produccionItems = [
-    { key: 'carga-produccion', label: 'Carga de Producción', icon: 'production', to: { name: 'produccion' } },
-    { key: 'pendientes', label: 'Pendientes', icon: 'pending', to: { name: 'pendientes' }, badge: produccionStore.pendingCount },
-  ]
-
-  if (!isEncargado.value || isAdmin.value) {
-    produccionItems.push({ key: 'mis-registros', label: 'Mis Registros', icon: 'records', to: { name: 'mis-registros' } })
-  }
-
-  sections.push({ key: 'produccion', label: 'Producción', items: produccionItems })
-  return sections
-})
+const sidebarNavigation = computed(() => createSidebarNavigation({
+  isAdmin: isAdmin.value,
+  isEncargado: isEncargado.value,
+  pendingCount: produccionStore.pendingCount,
+}))
+const primaryItems = computed(() => sidebarNavigation.value.primaryItems)
+const navSections = computed(() => sidebarNavigation.value.sections)
+const trailingItems = computed(() => sidebarNavigation.value.trailingItems)
 
 function toggleSection(key) {
   openSections[key] = !openSections[key]
@@ -395,6 +357,7 @@ function isSectionActive(section) {
 }
 
 function isItemActive(item) {
+  if (item.activeRoutes?.includes(route.name)) return true
   if (item.to.name === 'admin-crud') {
     return route.name === 'admin-crud' && route.params.entity === item.to.params.entity
   }

--- a/frontend/src/config/navigation.js
+++ b/frontend/src/config/navigation.js
@@ -1,0 +1,77 @@
+function link(key, label, icon, to, extra = {}) {
+  return { key, label, icon, to, ...extra }
+}
+
+function section(key, label, items) {
+  return { key, label, items }
+}
+
+export function createSidebarNavigation({
+  isAdmin = false,
+  isEncargado = false,
+  pendingCount = 0,
+} = {}) {
+  const primaryItems = [
+    link('home', 'Inicio', 'home', { name: 'home' }),
+    link('manuales', 'Manuales', 'manual', { name: 'manuales' }),
+  ]
+
+  const trailingItems = []
+  if (isAdmin) {
+    trailingItems.push(link(
+      'admin-center',
+      'Administración',
+      'admin',
+      { name: 'admin-center' },
+      { activeRoutes: ['admin-center', 'admin-crud', 'admin-configuracion'] },
+    ))
+  }
+
+  const sections = []
+  if (isAdmin || isEncargado) {
+    const operationItems = [
+      link('dashboard', 'Dashboard Operativo', 'dashboard', { name: 'dashboard' }),
+    ]
+    if (isAdmin) {
+      operationItems.push(
+        link('admin-dashboard', 'Dashboard Producción', 'dashboard', { name: 'admin-dashboard' }),
+      )
+    }
+    sections.push(section('operacion', 'Operación', operationItems))
+  }
+
+  sections.push(section('combustible', 'Combustible', [
+    link('carga-combustible', 'Carga de Combustible', 'fuel', { name: 'combustible' }),
+  ]))
+
+  const productionItems = [
+    link('carga-produccion', 'Carga de Producción', 'production', { name: 'produccion' }),
+    link(
+      'pendientes',
+      'Pendientes',
+      'pending',
+      { name: 'pendientes' },
+      { badge: Number(pendingCount || 0) },
+    ),
+  ]
+  if (!isEncargado || isAdmin) {
+    productionItems.push(
+      link('mis-registros', 'Mis Registros', 'records', { name: 'mis-registros' }),
+    )
+  }
+  sections.push(section('produccion', 'Producción', productionItems))
+
+  return { primaryItems, sections, trailingItems }
+}
+
+export function flattenNavigation({
+  primaryItems = [],
+  sections = [],
+  trailingItems = [],
+}) {
+  return [
+    ...primaryItems,
+    ...sections.flatMap((navigationSection) => navigationSection.items),
+    ...trailingItems,
+  ]
+}

--- a/frontend/src/config/navigation.test.js
+++ b/frontend/src/config/navigation.test.js
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+
+import { createSidebarNavigation, flattenNavigation } from './navigation'
+
+function routeNames(navigation) {
+  return flattenNavigation(navigation).map((item) => item.to.name)
+}
+
+describe('role-aware sidebar navigation', () => {
+  it('keeps operator navigation compact and without administrative routes', () => {
+    const navigation = createSidebarNavigation({ pendingCount: 3 })
+
+    expect(navigation.primaryItems.map((item) => item.key)).toEqual(['home', 'manuales'])
+    expect(navigation.sections.map((section) => section.key)).toEqual(['combustible', 'produccion'])
+    expect(routeNames(navigation)).not.toContain('admin-center')
+    expect(routeNames(navigation)).not.toContain('admin-crud')
+    expect(navigation.sections[1].items[1].badge).toBe(3)
+  })
+
+  it('shows the operational dashboard but not personal records to an encargado', () => {
+    const navigation = createSidebarNavigation({ isEncargado: true })
+
+    expect(navigation.sections.map((section) => section.key)).toEqual([
+      'operacion',
+      'combustible',
+      'produccion',
+    ])
+    expect(routeNames(navigation)).toContain('dashboard')
+    expect(routeNames(navigation)).not.toContain('mis-registros')
+  })
+
+  it('routes administrative management through one center without duplicated CRUD links', () => {
+    const navigation = createSidebarNavigation({ isAdmin: true, isEncargado: true })
+    const names = routeNames(navigation)
+    const adminItem = navigation.trailingItems.find((item) => item.key === 'admin-center')
+
+    expect(adminItem.to.name).toBe('admin-center')
+    expect(navigation.primaryItems.map((item) => item.key)).toEqual(['home', 'manuales'])
+    expect(navigation.trailingItems.map((item) => item.key)).toEqual(['admin-center'])
+    expect(adminItem.activeRoutes).toEqual([
+      'admin-center',
+      'admin-crud',
+      'admin-configuracion',
+    ])
+    expect(names).toContain('admin-dashboard')
+    expect(names).not.toContain('admin-crud')
+    expect(new Set(names).size).toBe(names.length)
+  })
+})

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -58,7 +58,13 @@ const routes = [
     children: [
       {
         path: '',
-        redirect: { name: 'admin-dashboard' },
+        redirect: { name: 'admin-center' },
+      },
+      {
+        path: 'gestion',
+        name: 'admin-center',
+        component: () => import('../views/admin/AdminCenterView.vue'),
+        meta: { requiresAuth: true, requiresAdmin: true },
       },
       {
         path: 'dashboard',
@@ -87,22 +93,27 @@ const router = createRouter({
   routes,
 })
 
-router.beforeEach((to, from, next) => {
-  const authStore = useAuthStore()
+export function authorizeRoute(to, authStore) {
   const authenticated =
     authStore.isAuthenticated || authStore.isAuthenticatedOffline
 
   if (to.meta.requiresAuth && !authenticated) {
-    next({ name: 'login' })
+    return { name: 'login' }
   } else if (to.meta.requiresAdmin && authStore.user?.is_admin !== 1) {
-    next({ name: 'home' })
+    return { name: 'home' }
   } else if (to.meta.requiresEncargado && authStore.user?.encargado !== 1 && authStore.user?.is_admin !== 1) {
-    next({ name: 'home' })
+    return { name: 'home' }
   } else if (to.name === 'login' && authenticated) {
-    next({ name: 'home' })
-  } else {
-    next()
+    return { name: 'home' }
   }
+
+  return true
+}
+
+router.beforeEach((to, from, next) => {
+  const result = authorizeRoute(to, useAuthStore())
+  if (result === true) next()
+  else next(result)
 })
 
 export default router

--- a/frontend/src/router/index.test.js
+++ b/frontend/src/router/index.test.js
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+
+import router, { authorizeRoute } from './index'
+
+describe('admin center route', () => {
+  it('is registered as the administrator-only default route', () => {
+    const resolved = router.resolve({ name: 'admin-center' })
+    const adminRoot = router.getRoutes().find((route) => route.path === '/admin')
+
+    expect(resolved.path).toBe('/admin/gestion')
+    expect(resolved.meta.requiresAuth).toBe(true)
+    expect(resolved.meta.requiresAdmin).toBe(true)
+    expect(adminRoot.redirect).toEqual({ name: 'admin-center' })
+  })
+
+  it('redirects a non-admin user away from the admin center', () => {
+    const to = router.resolve({ name: 'admin-center' })
+    const authStore = {
+      isAuthenticated: true,
+      isAuthenticatedOffline: false,
+      user: { is_admin: 0, encargado: 0 },
+    }
+
+    expect(authorizeRoute(to, authStore)).toEqual({ name: 'home' })
+  })
+
+  it('allows an authenticated administrator into the admin center', () => {
+    const to = router.resolve({ name: 'admin-center' })
+    const authStore = {
+      isAuthenticated: true,
+      isAuthenticatedOffline: false,
+      user: { is_admin: 1, encargado: 0 },
+    }
+
+    expect(authorizeRoute(to, authStore)).toBe(true)
+  })
+})

--- a/frontend/src/views/HomeView.vue
+++ b/frontend/src/views/HomeView.vue
@@ -354,7 +354,7 @@ const adminActions = computed(() => [
   { name: 'produccion', label: 'Ir a Carga de Producción', description: 'Abre el formulario de producción.', to: { name: 'produccion' }, badge: null },
   { name: 'combustible', label: 'Ir a Carga de Combustible', description: 'Abre el formulario de combustible.', to: { name: 'combustible' }, badge: null },
   { name: 'pendientes', label: 'Abrir Pendientes', description: 'Cola offline y reintentos.', to: { name: 'pendientes' }, badge: produccionStore.pendingCount },
-  { name: 'admin', label: 'Abrir Panel Admin', description: 'Catálogos, permisos y relaciones.', to: { name: 'admin-dashboard' }, badge: null },
+  { name: 'admin', label: 'Abrir Panel Admin', description: 'Catálogos, permisos y relaciones.', to: { name: 'admin-center' }, badge: null },
 ])
 
 const adminTotals = computed(() => adminStore.dashboard.reduce((acc, unidad) => {

--- a/frontend/src/views/admin/AdminCenterView.test.js
+++ b/frontend/src/views/admin/AdminCenterView.test.js
@@ -1,0 +1,39 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+
+import AdminCenterView from './AdminCenterView.vue'
+
+describe('AdminCenterView', () => {
+  it('groups every administrative destination in the center', () => {
+    const wrapper = mount(AdminCenterView, {
+      global: {
+        stubs: {
+          AppIcon: true,
+          PageHeader: true,
+          RouterLink: {
+            props: ['to'],
+            template: '<a :data-route="to.name" :data-entity="to.params?.entity"><slot /></a>',
+          },
+        },
+      },
+    })
+
+    expect(wrapper.text()).toContain('Personas y equipos')
+    expect(wrapper.text()).toContain('Configuración productiva')
+    expect(wrapper.text()).toContain('Seguridad')
+
+    const entityLinks = wrapper.findAll('[data-route="admin-crud"]')
+    expect(entityLinks.map((link) => link.attributes('data-entity'))).toEqual([
+      'personal',
+      'moviles',
+      'asignaciones',
+      'unidades-negocio',
+      'tipos-proceso',
+      'lugares-carga',
+      'predios',
+      'rodales',
+      'actas',
+    ])
+    expect(wrapper.findAll('[data-route="admin-configuracion"]')).toHaveLength(1)
+  })
+})

--- a/frontend/src/views/admin/AdminCenterView.vue
+++ b/frontend/src/views/admin/AdminCenterView.vue
@@ -1,0 +1,88 @@
+<template>
+  <div class="space-y-3">
+    <PageHeader
+      kicker="Administración"
+      title="Centro administrativo"
+      description="Gestioná personas, equipos, catálogos y accesos desde un único lugar."
+      elevated
+    />
+
+    <section class="grid gap-3 lg:grid-cols-2 xl:grid-cols-3" aria-label="Áreas administrativas">
+      <article
+        v-for="group in adminGroups"
+        :key="group.key"
+        class="app-card flex min-h-full flex-col rounded-xl p-4"
+      >
+        <header class="mb-3 flex items-start gap-3 border-b border-neutral-200 pb-3">
+          <span class="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-primary-light/35 text-primary-dark">
+            <AppIcon :name="group.icon" />
+          </span>
+          <div class="min-w-0">
+            <h2 class="text-lg font-extrabold text-neutral-950">{{ group.title }}</h2>
+            <p class="mt-1 text-sm text-neutral-500">{{ group.description }}</p>
+          </div>
+        </header>
+
+        <nav class="grid gap-2" :aria-label="group.title">
+          <router-link
+            v-for="item in group.items"
+            :key="item.key"
+            :to="item.to"
+            class="app-surface-muted group flex min-h-12 items-center justify-between gap-3 rounded-lg border px-3 py-2.5 text-left transition hover:-translate-y-px hover:border-primary/35 hover:bg-primary-light/15 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30"
+          >
+            <span class="flex min-w-0 items-center gap-3">
+              <AppIcon :name="item.icon" size="sm" class="shrink-0 text-neutral-500 group-hover:text-primary-dark" />
+              <span class="min-w-0">
+                <span class="block text-sm font-extrabold text-neutral-900">{{ item.label }}</span>
+                <span class="mt-0.5 block text-xs text-neutral-500">{{ item.description }}</span>
+              </span>
+            </span>
+            <AppIcon name="forward" size="sm" class="shrink-0 text-neutral-400 group-hover:text-primary-dark" />
+          </router-link>
+        </nav>
+      </article>
+    </section>
+  </div>
+</template>
+
+<script setup>
+import AppIcon from '@/components/ui/AppIcon.vue'
+import PageHeader from '@/components/ui/PageHeader.vue'
+
+const adminGroups = [
+  {
+    key: 'personas-equipos',
+    title: 'Personas y equipos',
+    description: 'Personal, móviles y asignaciones operativas.',
+    icon: 'personnel',
+    items: [
+      { key: 'personal', label: 'Personal', description: 'Usuarios, roles y relaciones operativas.', icon: 'personnel', to: { name: 'admin-crud', params: { entity: 'personal' } } },
+      { key: 'moviles', label: 'Móviles', description: 'Equipos, unidades y datos técnicos.', icon: 'machine', to: { name: 'admin-crud', params: { entity: 'moviles' } } },
+      { key: 'asignaciones', label: 'Asignaciones operativas', description: 'Choferes, móviles y procesos vinculados.', icon: 'assignment', to: { name: 'admin-crud', params: { entity: 'asignaciones' } } },
+    ],
+  },
+  {
+    key: 'configuracion-productiva',
+    title: 'Configuración productiva',
+    description: 'Catálogos utilizados durante las cargas.',
+    icon: 'process',
+    items: [
+      { key: 'unidades', label: 'Unidades de negocio', description: 'Estructura operativa y vinculaciones.', icon: 'unit', to: { name: 'admin-crud', params: { entity: 'unidades-negocio' } } },
+      { key: 'procesos', label: 'Tipos de proceso', description: 'Procesos y requisitos de carga.', icon: 'process', to: { name: 'admin-crud', params: { entity: 'tipos-proceso' } } },
+      { key: 'lugares', label: 'Lugares de carga', description: 'Puntos de carga por unidad.', icon: 'location', to: { name: 'admin-crud', params: { entity: 'lugares-carga' } } },
+      { key: 'predios', label: 'Predios', description: 'Predios disponibles para producción.', icon: 'field', to: { name: 'admin-crud', params: { entity: 'predios' } } },
+      { key: 'rodales', label: 'Rodales', description: 'Rodales y valores productivos.', icon: 'plot', to: { name: 'admin-crud', params: { entity: 'rodales' } } },
+      { key: 'actas', label: 'Actas', description: 'Actas habilitadas para registrar producción.', icon: 'records', to: { name: 'admin-crud', params: { entity: 'actas' } } },
+    ],
+  },
+  {
+    key: 'seguridad',
+    title: 'Seguridad',
+    description: 'Permisos generales y políticas de acceso.',
+    icon: 'admin',
+    items: [
+      { key: 'acceso', label: 'Configuración de acceso', description: 'Parámetros administrativos y de seguridad.', icon: 'settings', to: { name: 'admin-configuracion' } },
+    ],
+  },
+]
+</script>


### PR DESCRIPTION
## Objetivo

Replica la parte de **UX** del PR #106 (romanvsc) sobre `main`, **sin** el fix de combustible (que se mantiene en el #106). El objetivo es tener el Centro administrativo, la sidebar unificada y la navegación centralizada como PR independiente y revisable.

## Cambios

- `frontend/src/App.vue` — sidebar reescrita para consumir `createSidebarNavigation`; agrega `trailingItems` al final (donde va el Centro admin).
- `frontend/src/config/navigation.js` (NEW) — fuente única de la navegación según rol (admin / encargado / operador).
- `frontend/src/config/navigation.test.js` (NEW) — cobertura de la composición por rol.
- `frontend/src/router/index.js` — nueva ruta `admin-center` con redirect por defecto; extrae `authorizeRoute` para testeo.
- `frontend/src/router/index.test.js` (NEW) — cobertura de `authorizeRoute`.
- `frontend/src/views/admin/AdminCenterView.vue` (NEW) — vista que centraliza los CRUDs administrativos.
- `frontend/src/views/admin/AdminCenterView.test.js` (NEW) — smoke test.
- `frontend/src/views/HomeView.vue` — el atajo "Abrir Panel Admin" apunta a `admin-center`.
- Manuales (`docs/` y `frontend/public/` admin / encargado / operador) — actualizan la ruta y describen el Centro.

## Tests / Validaciones

- [x] `npm test` — **159/159 pasan** (22 archivos, 9.40s)
  - Incluye `navigation.test.js` (3), `router/index.test.js` (3), `AdminCenterView.test.js` (1)
- [x] `npm run build` — OK, 1878 modules, PWA SW generado
  - Mismo warning preexistente de bundle >500KB (no es regresión)
- [x] `git diff --cached --check` — limpio

## Evidencia

`docs/screenshots/pr-ux-admin-center/` (pendiente — se agrega cuando vos lo verifiques visualmente)

## Fuera de alcance

- **Fix de combustible (issue #105 / PR #106)**: form_uuid, idempotencia, fuente de verdad, migración SQL, cambios en `CargaCombustible` y `ProduccionForm`. Eso queda en el #106.
- Datos demo / seed.
- Migración de datos históricos.
- Deploy a prod.

## Conflictos esperados con el #106

Este PR va a tener **conflictos de merge** cuando el #106 se integre a `main`, porque ambos tocan los mismos archivos de UI:

- `frontend/src/App.vue`
- `frontend/src/router/index.js`
- `frontend/src/views/HomeView.vue`
- manuales en `docs/` y `frontend/public/`

**Orden sugerido:** mergear primero el #106, después rebasear esta rama sobre `main` actualizado y resolver los conflictos tomando el código de navegación del #106 (que es la fuente original).

## Riesgos / pendientes

- Sin evidencia visual todavía (lo agrego cuando me digas).
- El refactor de `App.vue` es grande (-62 líneas) y conviene revisarlo con la UI abierta antes de mergear.
- El bundle principal sigue en ~535KB (preexistente).

## Cómo verificar

```bash
git fetch origin
git checkout codex/pr-ux-admin-center
cd frontend
npm install
npm test
npm run build
```

Después, abrir la app y:

1. Verificar que la sidebar muestra el nuevo Centro administrativo al final
2. Click en `/admin/gestion` debe abrir `AdminCenterView`
3. Los manuales (operador / encargado / admin) deben mencionar el Centro
