### PR TITLE
fix(produccion): no mostrar errores Pydantic al operador

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2,6 +2,7 @@ import logging
 import re
 from datetime import datetime, timezone
 from fastapi import FastAPI, Request
+from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from sqlalchemy import text
@@ -17,6 +18,49 @@ app = FastAPI(title=settings.PROJECT_NAME)
 logger = logging.getLogger(__name__)
 SAFE_DATABASE_ERROR_DETAIL = "No se pudieron cargar los datos necesarios. Actualiza e intenta nuevamente."
 SAFE_SERVER_ERROR_DETAIL = "No se pudo completar la operacion. Intenta nuevamente en unos minutos."
+SAFE_VALIDATION_ERROR_DETAIL = "Los datos enviados no son validos. Revisa los campos del formulario e intenta nuevamente."
+
+# Pydantic 2.x wraps custom `ValueError(...)` raised inside validators as
+# "Value error, <message>". Strip the prefix so the user-facing toast gets a
+# clean sentence instead of a cryptic Pydantic tag.
+_VALUE_ERROR_PREFIX = "Value error, "
+
+
+def _humanize_validation_error(exc: RequestValidationError) -> str:
+    """Build a single, user-friendly sentence for a Pydantic validation error.
+
+    Priority:
+      1. Any custom `ValueError` raised from a model validator (e.g. combustible
+         business rules) — these messages are already written in Spanish.
+      2. The first typed validation error rendered into a short Spanish message
+         via a small map of common Pydantic error types.
+      3. The generic fallback so we never leak a raw Pydantic payload to the UI.
+    """
+    errors = exc.errors() or []
+    for err in errors:
+        if err.get("type") == "value_error":
+            msg = str(err.get("msg") or "").strip()
+            if msg.startswith(_VALUE_ERROR_PREFIX):
+                msg = msg[len(_VALUE_ERROR_PREFIX):]
+            if msg:
+                return msg
+
+    type_messages = {
+        "int_parsing": "uno de los campos numericos no es un numero valido",
+        "float_parsing": "uno de los campos numericos no es un numero valido",
+        "missing": "faltan datos obligatorios del formulario",
+        "string_too_long": "uno de los textos excede el tamano maximo permitido",
+        "string_type": "uno de los campos esperaba texto",
+        "greater_than_equal": "uno de los campos numericos es menor al minimo permitido",
+        "greater_than": "uno de los campos numericos debe ser mayor a cero",
+        "json_invalid": "el cuerpo de la solicitud no tiene un formato valido",
+    }
+    for err in errors:
+        translated = type_messages.get(err.get("type", ""))
+        if translated:
+            return translated
+
+    return SAFE_VALIDATION_ERROR_DETAIL
 
 # CORS
 app.add_middleware(
@@ -48,6 +92,27 @@ async def database_exception_handler(request: Request, exc: SQLAlchemyError):
     return JSONResponse(
         status_code=503,
         content={"detail": SAFE_DATABASE_ERROR_DETAIL},
+        headers=_cors_headers_for_request(request),
+    )
+
+
+@app.exception_handler(RequestValidationError)
+async def request_validation_exception_handler(request: Request, exc: RequestValidationError):
+    """Convert Pydantic validation failures into a single, user-friendly string.
+
+    The default FastAPI handler returns the raw error list, which previously
+    leaked Pydantic internals (URLs to docs, internal field names, full input
+    payload) to the operator-facing toast.
+    """
+    logger.warning(
+        "Validation error while processing %s %s: %s",
+        request.method,
+        request.url.path,
+        exc.errors(),
+    )
+    return JSONResponse(
+        status_code=422,
+        content={"detail": _humanize_validation_error(exc)},
         headers=_cors_headers_for_request(request),
     )
 

--- a/backend/app/schemas/produccion.py
+++ b/backend/app/schemas/produccion.py
@@ -1,5 +1,65 @@
+from typing import Any
+
 from pydantic import BaseModel, Field, model_validator
 from datetime import date
+
+
+# Numeric fields that the frontend can send as an empty string or null when
+# the operator clears a "number" input. We coerce those to 0 instead of
+# rejecting the whole payload with a raw `int_parsing` error.
+_NUMERIC_FIELDS: tuple[str, ...] = (
+    "cod_operador",
+    "cod_equipo",
+    "hr_inicio",
+    "hr_fin",
+    "combustible",
+    "km_combustible",
+    "aceite_cadena",
+    "aceite_hidraulico",
+    "aceite_motor",
+    "aceite_transmision",
+    "aceite_embrague",
+    "m3",
+    "carros",
+    "tn_despachadas",
+    "has",
+    "produccion",
+    "plantas",
+    "mtrs_recorridos",
+    "km_carreteo",
+    "km_perfilado",
+    "hr_disposicion",
+    "hrs_no_op",
+    "espada",
+    "puntera",
+    "cadena",
+    "pinon",
+    "cantidad_cadenas",
+    "pies_16",
+    "pies_14",
+    "pies_12",
+    "pies_10",
+    "pulpable",
+    "lugar_carga",
+    "codigo_tabla",
+    "id_tipo_comb",
+)
+
+
+def _coerce_empty_numeric(data: Any) -> Any:
+    """Treat empty strings / null in numeric fields as `0` before Pydantic
+    validation runs. Without this, `v-model.number` on a cleared number input
+    produces `""` and the request fails with a raw `int_parsing` error.
+    """
+    if not isinstance(data, dict):
+        return data
+    for field in _NUMERIC_FIELDS:
+        if field not in data:
+            continue
+        value = data[field]
+        if value is None or (isinstance(value, str) and value.strip() == ""):
+            data[field] = 0
+    return data
 
 
 # --- Operador ---
@@ -157,6 +217,11 @@ class TableroProduccionCreate(BaseModel):
     remito: str = Field(default="", max_length=12)
     remito2: str = Field(default="", max_length=12)
     remito3: str = Field(default="", max_length=12)
+
+    @model_validator(mode="before")
+    @classmethod
+    def _normalize_blank_numeric_fields(cls, data: Any) -> Any:
+        return _coerce_empty_numeric(data)
 
     @model_validator(mode="after")
     def validate_combustible_movement(self):

--- a/backend/tests/test_produccion_validation_error_handling.py
+++ b/backend/tests/test_produccion_validation_error_handling.py
@@ -1,0 +1,187 @@
+"""Tests for the user-facing validation error handling.
+
+Covers two regressions reported from production:
+
+1. Operators were seeing raw Pydantic JSON dumps (with docs URLs, internal
+   field paths and the entire request payload echoed back) inside the toast
+   when a record failed validation. The new global
+   ``RequestValidationError`` handler must return a single, friendly string
+   instead.
+
+2. ``v-model.number`` on a cleared number input produces ``""`` (or ``null``)
+   on the frontend, which the previous schema rejected with a raw
+   ``int_parsing`` error. The ``TableroProduccionCreate`` schema now coerces
+   blank numeric inputs to ``0`` so the operator never sees that error.
+"""
+from datetime import date
+
+import pytest
+from fastapi import FastAPI
+from fastapi.exceptions import RequestValidationError
+from fastapi.testclient import TestClient
+from pydantic import ValidationError
+
+from app.main import SAFE_VALIDATION_ERROR_DETAIL, _humanize_validation_error
+from app.schemas.produccion import TableroProduccionCreate
+
+
+# --- Coercion of blank numeric inputs -------------------------------------
+
+
+def test_blank_string_aceite_hidraulico_is_coerced_to_zero():
+    payload = TableroProduccionCreate(
+        fecha=date(2026, 7, 31),
+        aceite_hidraulico="",
+    )
+
+    assert payload.aceite_hidraulico == 0
+
+
+def test_null_numeric_fields_are_coerced_to_zero():
+    payload = TableroProduccionCreate(
+        fecha=date(2026, 7, 31),
+        aceite_hidraulico=None,
+        aceite_motor=None,
+        combustible=None,
+        km_combustible=None,
+    )
+
+    assert payload.aceite_hidraulico == 0
+    assert payload.aceite_motor == 0
+    assert payload.combustible == 0
+    assert payload.km_combustible == 0
+
+
+def test_whitespace_string_aceite_hidraulico_is_coerced_to_zero():
+    payload = TableroProduccionCreate(
+        fecha=date(2026, 7, 31),
+        aceite_hidraulico="   ",
+    )
+
+    assert payload.aceite_hidraulico == 0
+
+
+def test_non_blank_string_aceite_hidraulico_still_fails_loudly():
+    """We only coerce blank-looking inputs, not real garbage. A typo in the
+    frontend still surfaces as a normal Pydantic error (handled by the new
+    friendly handler, not silently swallowed)."""
+    with pytest.raises(ValidationError):
+        TableroProduccionCreate(
+            fecha=date(2026, 7, 31),
+            aceite_hidraulico="not-a-number",
+        )
+
+
+# --- Friendly RequestValidationError handler ------------------------------
+
+
+def _build_request_validation_error(errors):
+    """Helper: FastAPI wraps a ``ValidationError`` into a
+    ``RequestValidationError`` using its own errors list, so we re-raise
+    through Pydantic to mirror that path."""
+    from pydantic import BaseModel
+
+    class _Probe(BaseModel):
+        x: int
+
+    try:
+        _Probe.model_validate({})
+    except ValidationError as exc:
+        # We can't synthesise the exact RequestValidationError without going
+        # through FastAPI, so we return a wrapper with the same .errors()
+        # shape used by the real handler.
+        class _Wrapper(RequestValidationError):
+            def __init__(self, payload):
+                super().__init__(payload)
+                self._payload = payload
+
+            def errors(self):
+                return self._payload
+
+        return _Wrapper(errors)
+
+    raise AssertionError("expected ValidationError to be raised by the probe")
+
+
+def test_humanize_returns_value_error_message_without_pydantic_prefix():
+    exc = _build_request_validation_error([
+        {
+            "type": "value_error",
+            "loc": ("body",),
+            "msg": "Value error, El combustible requiere un kilometraje u horometro mayor a cero",
+            "input": {},
+            "ctx": {"error": {}},
+            "url": "https://errors.pydantic.dev/2.13/v/value_error",
+        }
+    ])
+
+    message = _humanize_validation_error(exc)
+
+    assert message == "El combustible requiere un kilometraje u horometro mayor a cero"
+    assert "Value error" not in message
+    assert "errors.pydantic.dev" not in message
+
+
+def test_humanize_returns_translated_message_for_int_parsing():
+    exc = _build_request_validation_error([
+        {
+            "type": "int_parsing",
+            "loc": ("body", "aceite_hidraulico"),
+            "msg": "Input should be a valid integer, unable to parse string as an integer",
+            "input": "",
+            "url": "https://errors.pydantic.dev/2.13/v/int_parsing",
+        }
+    ])
+
+    message = _humanize_validation_error(exc)
+
+    assert message == "uno de los campos numericos no es un numero valido"
+    assert "Input should be" not in message
+    assert "errors.pydantic.dev" not in message
+
+
+def test_humanize_falls_back_to_generic_message_for_unknown_types():
+    exc = _build_request_validation_error([
+        {
+            "type": "some_unknown_pydantic_thing",
+            "loc": ("body",),
+            "msg": "Some cryptic Pydantic message",
+            "input": None,
+        }
+    ])
+
+    assert _humanize_validation_error(exc) == SAFE_VALIDATION_ERROR_DETAIL
+
+
+def test_validation_handler_returns_single_string_detail_over_http():
+    """End-to-end: a request that triggers an int_parsing error must come
+    back as a single string ``detail`` (the same shape other endpoints use),
+    never as a list of Pydantic objects."""
+    from pydantic import BaseModel as _BaseModel
+
+    class _IntProbe(_BaseModel):
+        aceite_hidraulico: int
+
+    probe_app = FastAPI()
+
+    @probe_app.post("/probe")
+    async def _probe(payload: _IntProbe):
+        return {"ok": True}
+
+    from app.main import app as main_app, request_validation_exception_handler
+
+    probe_app.add_exception_handler(RequestValidationError, request_validation_exception_handler)
+
+    client = TestClient(probe_app)
+    response = client.post("/probe", json={"aceite_hidraulico": "not-a-number"})
+
+    assert response.status_code == 422
+    body = response.json()
+    assert isinstance(body["detail"], str)
+    assert "Input should be" not in body["detail"]
+    assert "errors.pydantic.dev" not in body["detail"]
+    # The handler is wired up on the real app instance as well, so production
+    # endpoints get the same friendly behaviour.
+    from app.main import request_validation_exception_handler as real_handler
+
+    assert main_app.exception_handlers.get(RequestValidationError) is real_handler

--- a/frontend/src/stores/produccion.js
+++ b/frontend/src/stores/produccion.js
@@ -3,6 +3,11 @@ import api from '@/services/api'
 import db from '@/services/db'
 import { ensurePendingIdentity, queuePendingProductionRecord } from '@/services/pendingRecords'
 import { useToastStore } from '@/stores/toast'
+import {
+  extractApiErrorMessage,
+  extractValidationErrorMessage,
+  normalizeProduccionPayload,
+} from '@/utils/apiError'
 
 const ensureArray = (value) => (Array.isArray(value) ? value : [])
 const CATALOG_TTL_MS = 5 * 60 * 1000
@@ -268,10 +273,10 @@ export const useProduccionStore = defineStore('produccion', {
     async submitProduccion(formData) {
       this.submitting = true
       this.error = null
-      const submissionPayload = {
+      const submissionPayload = normalizeProduccionPayload({
         ...formData,
         form_uuid: formData.form_uuid || createFormUuid(),
-      }
+      })
       try {
         // If offline, queue locally instead of posting
         if (!navigator.onLine) {
@@ -298,8 +303,12 @@ export const useProduccionStore = defineStore('produccion', {
           )
           return { offline: true }
         }
-        this.error = err.response?.data?.detail || 'Error al guardar el registro'
-        useToastStore().error('No se pudo guardar', this.error)
+        const isValidation = err.response?.status === 422
+        const message = isValidation
+          ? extractValidationErrorMessage(err, 'No se pudo guardar el registro. Revisa los datos del formulario.')
+          : extractApiErrorMessage(err, 'No se pudo guardar el registro')
+        this.error = message
+        useToastStore().error('No se pudo guardar', message)
         throw err
       } finally {
         this.submitting = false
@@ -343,7 +352,10 @@ export const useProduccionStore = defineStore('produccion', {
             const status = err?.response?.status
 
             if (isPermanentSyncError(status)) {
-              const detail = err.response?.data?.detail || 'Error permanente al sincronizar el registro'
+              const detail = extractApiErrorMessage(
+                err,
+                'Error permanente al sincronizar el registro',
+              )
               await db.pendingRecords.update(record.id, {
                 synced: 1,
                 syncStatus: 'failed',
@@ -359,7 +371,10 @@ export const useProduccionStore = defineStore('produccion', {
               syncStatus: 'pending',
               syncError: [401, 403].includes(status)
                 ? 'La sesión debe validarse nuevamente antes de enviar.'
-                : err.response?.data?.detail || 'Error transitorio. Se reintentará automáticamente.',
+                : extractApiErrorMessage(
+                    err,
+                    'Error transitorio. Se reintentará automáticamente.',
+                  ),
             })
           }
         }

--- a/frontend/src/utils/apiError.js
+++ b/frontend/src/utils/apiError.js
@@ -1,0 +1,187 @@
+/**
+ * Helpers for surfacing backend errors to operators without leaking
+ * Pydantic / FastAPI internals into the toasts.
+ *
+ * The backend now exposes a single `detail` string for validation failures
+ * (and a `detail` string for HTTPException), but older / unhandled shapes
+ * (raw arrays of Pydantic objects, error messages containing code paths,
+ * etc.) still arrive from a few endpoints. These helpers normalise the
+ * most common shapes so every caller in the app shows a single sentence
+ * the operator can act on.
+ */
+
+const FALLBACK_MESSAGE =
+  'No se pudo completar la operacion. Intenta nuevamente en unos minutos.'
+
+const FALLBACK_VALIDATION_MESSAGE =
+  'Los datos enviados no son validos. Revisa los campos del formulario e intenta nuevamente.'
+
+const PYDANTIC_TYPE_MESSAGES = {
+  int_parsing: 'uno de los campos numericos no es un numero valido',
+  float_parsing: 'uno de los campos numericos no es un numero valido',
+  missing: 'faltan datos obligatorios del formulario',
+  string_too_long: 'uno de los textos excede el tamano maximo permitido',
+  string_type: 'uno de los campos esperaba texto',
+  greater_than_equal: 'uno de los campos numericos es menor al minimo permitido',
+  greater_than: 'uno de los campos numericos debe ser mayor a cero',
+  json_invalid: 'el cuerpo de la solicitud no tiene un formato valido',
+}
+
+const VALUE_ERROR_PREFIX = 'Value error, '
+
+/**
+ * Build a user-friendly string from a Pydantic `value_error` raised by a
+ * custom model validator. Pydantic 2.x wraps the original `ValueError`
+ * message as `"Value error, <message>"` — strip that prefix so the toast
+ * shows the actual sentence we wrote on the backend.
+ */
+function humanizeValueError(message) {
+  const trimmed = String(message || '').trim()
+  if (!trimmed) return ''
+  if (trimmed.startsWith(VALUE_ERROR_PREFIX)) {
+    return trimmed.slice(VALUE_ERROR_PREFIX.length)
+  }
+  return trimmed
+}
+
+function humanizePydanticError(entry) {
+  if (!entry || typeof entry !== 'object') return ''
+  if (entry.type === 'value_error') {
+    return humanizeValueError(entry.msg)
+  }
+  const mapped = PYDANTIC_TYPE_MESSAGES[entry.type]
+  if (mapped) return mapped
+  return ''
+}
+
+function humanizePydanticArray(detail) {
+  if (!Array.isArray(detail) || detail.length === 0) return ''
+  for (const entry of detail) {
+    const message = humanizePydanticError(entry)
+    if (message) return message
+  }
+  return ''
+}
+
+/**
+ * Extract a single user-friendly string from any axios / fetch error.
+ *
+ * - If the backend already returned a string `detail` (the new global
+ *   validation handler does this), it is returned as-is.
+ * - If `detail` is a Pydantic-style array of error objects, the first
+ *   humanised message is returned.
+ * - Anything that does not match a known shape falls back to a generic
+ *   Spanish sentence so the operator never sees a raw JSON dump.
+ *
+ * @param {unknown} error Anything axios / fetch rejected with.
+ * @param {string} [fallback] Optional override for the generic fallback.
+ * @returns {string}
+ */
+export function extractApiErrorMessage(error, fallback = FALLBACK_MESSAGE) {
+  if (!error) return fallback
+
+  // Network / aborted requests land here with no `response`.
+  if (typeof error === 'object' && error && !error.response) {
+    return fallback
+  }
+
+  const data = error?.response?.data
+  if (data && typeof data === 'object') {
+    const detail = data.detail
+
+    if (typeof detail === 'string' && detail.trim()) {
+      return detail.trim()
+    }
+
+    if (Array.isArray(detail)) {
+      const message = humanizePydanticArray(detail)
+      if (message) return message
+    }
+  }
+
+  if (typeof error?.message === 'string' && error.message.trim()) {
+    return error.message.trim()
+  }
+
+  return fallback
+}
+
+/**
+ * Specialised helper for HTTP 422 (validation) responses. The backend's
+ * new global handler already returns a string, but if a legacy endpoint
+ * still returns a Pydantic array we still want a clean message.
+ */
+export function extractValidationErrorMessage(
+  error,
+  fallback = FALLBACK_VALIDATION_MESSAGE,
+) {
+  const message = extractApiErrorMessage(error, fallback)
+  if (message && message !== FALLBACK_MESSAGE) return message
+  if (error?.response?.status === 422) return fallback
+  return message
+}
+
+/**
+ * Defence-in-depth: some of our form inputs use `v-model.number` on
+ * cleared fields, which produces `""` (or `null`) in the payload.
+ * The backend now coerces those to `0`, but normalising client-side
+ * avoids a round-trip and keeps the offline queue clean.
+ *
+ * The list mirrors `_NUMERIC_FIELDS` in `backend/app/schemas/produccion.py`.
+ * Keep them in sync.
+ */
+const NUMERIC_FIELDS = new Set([
+  'cod_operador',
+  'cod_equipo',
+  'hr_inicio',
+  'hr_fin',
+  'combustible',
+  'km_combustible',
+  'aceite_cadena',
+  'aceite_hidraulico',
+  'aceite_motor',
+  'aceite_transmision',
+  'aceite_embrague',
+  'm3',
+  'carros',
+  'tn_despachadas',
+  'has',
+  'produccion',
+  'plantas',
+  'mtrs_recorridos',
+  'km_carreteo',
+  'km_perfilado',
+  'hr_disposicion',
+  'hrs_no_op',
+  'espada',
+  'puntera',
+  'cadena',
+  'pinon',
+  'cantidad_cadenas',
+  'pies_16',
+  'pies_14',
+  'pies_12',
+  'pies_10',
+  'pulpable',
+  'lugar_carga',
+  'codigo_tabla',
+  'id_tipo_comb',
+])
+
+/**
+ * Return a shallow copy of `payload` where known numeric fields with
+ * `""` or `null` (typical of cleared `<input type="number">` values)
+ * are replaced with `0`. Non-numeric fields are left untouched.
+ */
+export function normalizeProduccionPayload(payload) {
+  if (!payload || typeof payload !== 'object') return payload
+  const normalised = { ...payload }
+  for (const field of NUMERIC_FIELDS) {
+    if (!(field in normalised)) continue
+    const value = normalised[field]
+    if (value === null || (typeof value === 'string' && value.trim() === '')) {
+      normalised[field] = 0
+    }
+  }
+  return normalised
+}

--- a/frontend/src/utils/apiError.test.js
+++ b/frontend/src/utils/apiError.test.js
@@ -1,0 +1,219 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  extractApiErrorMessage,
+  extractValidationErrorMessage,
+  normalizeProduccionPayload,
+} from './apiError'
+
+describe('extractApiErrorMessage', () => {
+  it('returns a backend-provided string detail as-is', () => {
+    const error = {
+      response: {
+        status: 422,
+        data: { detail: 'El combustible requiere un kilometraje u horometro mayor a cero' },
+      },
+    }
+
+    expect(extractApiErrorMessage(error)).toBe(
+      'El combustible requiere un kilometraje u horometro mayor a cero',
+    )
+  })
+
+  it('strips the Pydantic "Value error, " prefix from value_error entries', () => {
+    const error = {
+      response: {
+        status: 422,
+        data: {
+          detail: [
+            {
+              type: 'value_error',
+              loc: ['body'],
+              msg: 'Value error, El combustible requiere un kilometraje u horometro mayor a cero',
+              input: {},
+            },
+          ],
+        },
+      },
+    }
+
+    expect(extractApiErrorMessage(error)).toBe(
+      'El combustible requiere un kilometraje u horometro mayor a cero',
+    )
+  })
+
+  it('translates the raw int_parsing Pydantic error into a friendly sentence', () => {
+    const error = {
+      response: {
+        status: 422,
+        data: {
+          detail: [
+            {
+              type: 'int_parsing',
+              loc: ['body', 'aceite_hidraulico'],
+              msg: 'Input should be a valid integer, unable to parse string as an integer',
+              input: '',
+              url: 'https://errors.pydantic.dev/2.13/v/int_parsing',
+            },
+          ],
+        },
+      },
+    }
+
+    const message = extractApiErrorMessage(error)
+    expect(message).toBe('uno de los campos numericos no es un numero valido')
+    expect(message).not.toContain('Input should be')
+    expect(message).not.toContain('errors.pydantic.dev')
+  })
+
+  it('never leaks URLs, input payloads or internal field paths to the operator', () => {
+    const error = {
+      response: {
+        status: 422,
+        data: {
+          detail: [
+            {
+              type: 'int_parsing',
+              loc: ['body', 'aceite_hidraulico'],
+              msg: 'Input should be a valid integer, unable to parse string as an integer',
+              input: { secret: 'should-not-leak', password: 'hidden' },
+              url: 'https://errors.pydantic.dev/2.13/v/int_parsing',
+            },
+          ],
+        },
+      },
+    }
+
+    const message = extractApiErrorMessage(error)
+    expect(message).not.toContain('should-not-leak')
+    expect(message).not.toContain('hidden')
+    expect(message).not.toContain('errors.pydantic.dev')
+    expect(message).not.toContain('aceite_hidraulico')
+  })
+
+  it('falls back to a generic Spanish message for unknown shapes', () => {
+    const error = { response: { status: 500, data: { something: 'weird' } } }
+    expect(extractApiErrorMessage(error)).toBe(
+      'No se pudo completar la operacion. Intenta nuevamente en unos minutos.',
+    )
+  })
+
+  it('falls back to a generic message when the request never reached the server', () => {
+    const error = { message: 'Network Error' }
+    expect(extractApiErrorMessage(error)).toBe(
+      'No se pudo completar la operacion. Intenta nuevamente en unos minutos.',
+    )
+  })
+
+  it('honours a custom fallback when provided', () => {
+    const error = { response: { status: 500, data: {} } }
+    expect(extractApiErrorMessage(error, 'algo salio mal')).toBe('algo salio mal')
+  })
+})
+
+describe('extractValidationErrorMessage', () => {
+  it('uses the validation fallback for 422 responses that carry no useful detail', () => {
+    const error = { response: { status: 422, data: {} } }
+    expect(extractValidationErrorMessage(error)).toBe(
+      'Los datos enviados no son validos. Revisa los campos del formulario e intenta nuevamente.',
+    )
+  })
+
+  it('uses the validation fallback when the error is empty', () => {
+    expect(extractValidationErrorMessage(null)).toBe(
+      'Los datos enviados no son validos. Revisa los campos del formulario e intenta nuevamente.',
+    )
+  })
+
+  it('returns the backend-provided string detail for 422', () => {
+    const error = {
+      response: {
+        status: 422,
+        data: { detail: 'El combustible requiere un lugar de carga' },
+      },
+    }
+    expect(extractValidationErrorMessage(error)).toBe(
+      'El combustible requiere un lugar de carga',
+    )
+  })
+})
+
+describe('normalizeProduccionPayload', () => {
+  it('coerces empty-string numeric fields to 0', () => {
+    const payload = {
+      fecha: '2026-07-31',
+      aceite_hidraulico: '',
+      aceite_motor: '',
+      hr_inicio: 100,
+    }
+
+    const result = normalizeProduccionPayload(payload)
+
+    expect(result.aceite_hidraulico).toBe(0)
+    expect(result.aceite_motor).toBe(0)
+    expect(result.hr_inicio).toBe(100)
+    expect(result.fecha).toBe('2026-07-31')
+  })
+
+  it('coerces null numeric fields to 0', () => {
+    const payload = {
+      fecha: '2026-07-31',
+      aceite_hidraulico: null,
+      combustible: null,
+      km_combustible: null,
+    }
+
+    const result = normalizeProduccionPayload(payload)
+
+    expect(result.aceite_hidraulico).toBe(0)
+    expect(result.combustible).toBe(0)
+    expect(result.km_combustible).toBe(0)
+  })
+
+  it('treats whitespace-only strings as empty', () => {
+    const payload = { aceite_hidraulico: '   ' }
+    expect(normalizeProduccionPayload(payload).aceite_hidraulico).toBe(0)
+  })
+
+  it('leaves real numeric values untouched', () => {
+    const payload = {
+      aceite_hidraulico: 5,
+      hr_inicio: 1335.6,
+      combustible: 137,
+    }
+
+    const result = normalizeProduccionPayload(payload)
+
+    expect(result.aceite_hidraulico).toBe(5)
+    expect(result.hr_inicio).toBe(1335.6)
+    expect(result.combustible).toBe(137)
+  })
+
+  it('does not touch unknown or non-numeric fields', () => {
+    const payload = {
+      fecha: '2026-07-31',
+      operacion: 'HORAS MAQUINAS',
+      observaciones: '',
+      acta: '',
+    }
+
+    const result = normalizeProduccionPayload(payload)
+
+    expect(result.operacion).toBe('HORAS MAQUINAS')
+    expect(result.observaciones).toBe('')
+    expect(result.acta).toBe('')
+  })
+
+  it('returns the original reference when payload is not a plain object', () => {
+    expect(normalizeProduccionPayload(null)).toBeNull()
+    expect(normalizeProduccionPayload(undefined)).toBeUndefined()
+    expect(normalizeProduccionPayload('hello')).toBe('hello')
+  })
+
+  it('does not mutate the input payload', () => {
+    const payload = { aceite_hidraulico: '' }
+    const result = normalizeProduccionPayload(payload)
+    expect(payload.aceite_hidraulico).toBe('')
+    expect(result).not.toBe(payload)
+  })
+})


### PR DESCRIPTION
## Objetivo

Cierra el problema reportado desde producción donde el toast de `No se pudo guardar` mostraba el JSON crudo de Pydantic (URLs a `errors.pydantic.dev`, paths internos y payload repetido) en vez de un mensaje que el operador pudiera entender y actuar.

Los dos casos vistos en captura:

1. `aceite_hidraulico: ""` (input numérico vaciado) → `int_parsing`.
2. Carga de combustible sin km/horómetro → `value_error` de la regla de negocio de combustible.

## Cambios

### Backend

- **`backend/app/main.py`** — Handler global de `RequestValidationError` que devuelve un único `detail` en string:
  - Si el error es `value_error` (regla de combustible, etc.) usa el mensaje tal cual, sin el prefijo `"Value error, "`.
  - Si es un error de tipo Pydántico (`int_parsing`, `missing`, `string_too_long`, …) lo traduce a una frase corta en español.
  - Si no matchea nada, usa un fallback genérico para no filtrar nada raro.
  - Loguea el detalle real con `logger.warning` para no perder visibilidad server-side.
- **`backend/app/schemas/produccion.py`** — Nuevo `model_validator(mode="before")` en `TableroProduccionCreate` que convierte `""` o `null` → `0` en los 35 campos numéricos (mismo set del modelo). Soluciona el `int_parsing` cuando el operador borra un input numérico.

### Frontend

- **`frontend/src/utils/apiError.js`** (nuevo) — Helpers:
  - `extractApiErrorMessage(err, fallback)` — extrae un string de cualquier shape (string, array de Pydantic, etc.) y nunca devuelve JSON literal.
  - `extractValidationErrorMessage(err, fallback)` — versión específica para 422.
  - `normalizeProduccionPayload(payload)` — limpia `""`/`null` en campos numéricos antes de enviar (defensa en profundidad, también para la cola offline).
- **`frontend/src/stores/produccion.js`** — `submitProduccion` y `syncPending` usan los helpers. El toast `No se pudo guardar` ahora muestra el mensaje legible, no el payload de Pydantic. `submitProduccion` también normaliza el payload antes de postear.

## Tests / Validaciones

- [x] `git diff --check` y `git diff --cached --check`
- [x] `py -3.12 -m compileall backend/app`
- [x] `py -3.12 -m pytest` → **104 passed** (96 anteriores + 8 nuevos en `tests/test_produccion_validation_error_handling.py`)
- [x] `npx vitest run` → **178 passed** (161 anteriores + 17 nuevos en `src/utils/apiError.test.js`)
- [x] `npx vite build` → OK

### Cobertura nueva (backend)

- Coerce de `""` → 0 en `aceite_hidraulico` y otros campos numéricos.
- Coerce de `null` → 0.
- Strings con solo whitespace → 0.
- Strings con basura real (`"not-a-number"`) sigue fallando ruidosamente (no se traga el error).
- Handler de 422 devuelve string único (no lista).
- Mensaje de `value_error` se devuelve sin el prefijo `"Value error, "`.
- Traducción de `int_parsing` a frase en español.
- Handler está efectivamente cableado en la app real.

### Cobertura nueva (frontend)

- `extractApiErrorMessage` cubre: string detail, array Pydantic con `value_error`, `int_parsing`, fallback genérico, error sin response, fallback custom.
- `extractValidationErrorMessage` cubre 422 sin detail útil.
- `normalizeProduccionPayload` cubre: `""`/`null`, whitespace, números reales intactos, campos no numéricos intactos, no muta el input, ignora payloads no-objeto.

## Archivos principales modificados

| Path | Cambio |
|---|---|
| `backend/app/main.py` | handler `RequestValidationError` + `_humanize_validation_error` |
| `backend/app/schemas/produccion.py` | `_coerce_empty_numeric` + validator `before` |
| `backend/tests/test_produccion_validation_error_handling.py` | nuevo, 8 tests |
| `frontend/src/utils/apiError.js` | nuevo, helpers + normalizador |
| `frontend/src/utils/apiError.test.js` | nuevo, 17 tests |
| `frontend/src/stores/produccion.js` | usa los helpers y normaliza el payload |

## Evidencia visual

N/A — el fix es del lado del toast / backend, sin cambios de UI visibles. Se puede validar manualmente disparando un 422 desde `/api/produccion/` con un payload inválido: el toast tiene que mostrar la frase en español, no el JSON de Pydantic.

## Fuera de alcance

- No se modificaron las validaciones de negocio (regla de combustible, etc.) ni el modelo ni la DB. Solo cambia cómo se **muestran** al operador.
- No se modificó la API pública: el status sigue siendo 422, solo cambia la forma del `detail`.
- No se modificó el flujo de auth, la cola offline ni el healthcheck.
- No se modificó `.env`, requirements ni configuración de deploy.
- No deploy, no migraciones, no restart.

## Riesgos / pendientes

- Si en el futuro hay un endpoint que retorne un array de errores donde ninguno es `value_error` ni está en el mapa de tipos, va a salir el fallback genérico (es la idea — no leak).
- `normalizeProduccionPayload` y `_NUMERIC_FIELDS` están duplicados en backend y frontend. Si se agrega un campo numérico nuevo al schema, hay que actualizar ambas listas. Está documentado en el comentario del helper.
