### PR TITLE
Deploy seguro de produccion_fg exclusivamente desde main

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -1,346 +1,326 @@
-# Deploy en produccion (fasa_195)
+# Deploy de producción — `produccion_fg`
 
-Documento de referencia para deployar `registro_produccion` en el server
-`fasa_195` (192.168.0.195, user `ferreteria`, ssh key `~/.ssh/fasa_195`).
+> **Guía canónica.** Este es el procedimiento oficial para desplegar
+> únicamente `produccion_fg` en `fasa_195` desde `origin/main`.
 
-> Mantener este archivo vivo. Si el flujo cambia, actualizar.
+El objetivo es que una persona autorizada pueda ejecutar el despliegue sin
+conocer previamente la arquitectura y obtener evidencia suficiente para
+confirmar o revertir el cambio.
 
----
+## Alcance obligatorio
 
-## Arquitectura del server
+El procedimiento:
 
-`produccion.servinlgsm.com.ar` corre con **un solo backend** (container Docker)
-y un frontend estatico servido por nginx.
+- acepta exclusivamente un paquete construido desde el commit actual de
+  `origin/main`;
+- actualiza juntos el backend Docker y el frontend estático de
+  `produccion_fg`;
+- construye una imagen inmutable etiquetada con el SHA completo;
+- crea backup, manifiesto y rollback automático;
+- valida el contenedor, el endpoint interno y el asset del frontend;
+- usa `docker compose ... --no-deps` para no recrear servicios vecinos.
 
-| Componente | Ruta / puerto | Como se levanta | Quien lo usa |
-|---|---|---|---|
-| **Frontend** (HTML/JS/CSS) | `/var/www/html/django/produccion_fg/frontend/` | Copia desde el tarball | nginx sirve los assets estaticos |
-| **Backend container** | `127.0.0.1:18005` (Docker) | `docker compose -f /srv/apps/registro_produccion/docker-compose.yml up -d` | nginx hace proxy_pass a este |
+El procedimiento **no**:
 
-El **container Docker es el unico backend de produccion**. El nginx esta
-configurado para apuntar a el:
+- despliega ramas, tags ni commits que todavía no estén en `main`;
+- modifica `indufor` ni `indufor_demo`;
+- modifica Nginx, archivos `.env` o credenciales;
+- consulta ni modifica bases de datos;
+- aplica migraciones;
+- requiere `sudo`.
 
+Si el rango entre la revisión publicada y `origin/main` contiene archivos bajo
+`db_migrations/`, el preflight aborta. Ver [Migraciones](#migraciones).
+
+## Arquitectura vigente
+
+| Componente | Ruta o puerto | Publicación |
+|---|---|---|
+| Repo remoto | `/srv/apps/registro_produccion` | Checkout Git usado para construir la imagen |
+| Backend | `registro_produccion_produccion_fg` | Docker, host `127.0.0.1:18005` |
+| Frontend | `/var/www/html/django/produccion_fg/frontend/` | Archivos estáticos servidos por Nginx |
+| Manifiesto | `/var/www/html/django/produccion_fg/RELEASE_MANIFEST.txt` | Commit publicado |
+| Backups | `~/deploy-backups/registro_produccion/` | Imagen, frontend y manifiesto recuperables |
+
+Nginx publica `https://produccion.servinlgsm.com.ar/` y deriva `/api/*` al
+puerto interno `18005`. Este flujo no modifica esa configuración.
+
+## Requisitos
+
+### En la computadora local
+
+- Checkout limpio del repositorio.
+- Git y GitHub accesible como remoto `origin`.
+- PowerShell 7.
+- Python 3.12 con las dependencias de test del backend.
+- Node.js/npm con las dependencias del frontend.
+- SSH/SCP con el alias `fasa_195` configurado.
+
+### En `fasa_195`
+
+- Hostname `fg-ubuntu`.
+- Usuario autorizado `ferreteria`.
+- Acceso a Git, Docker, Compose, `curl`, `tar`, `flock` y `sha256sum`.
+- Permiso del usuario sobre Docker, el repo remoto y el directorio del
+  frontend.
+
+No hace falta `sudo`. No imprimir el contenido de ningún `.env`.
+
+## 1. Preparar `main` local
+
+Desde PowerShell:
+
+```powershell
+Set-Location D:\notebook\active\registro_produccion
+git status -sb
+git fetch --prune origin
+git switch main
+git pull --ff-only origin main
+
+$head = (git rev-parse HEAD).Trim()
+$originMain = (git rev-parse origin/main).Trim()
+if ($head -ne $originMain) {
+    throw "HEAD no coincide con origin/main"
+}
+
+$trackedChanges = git status --porcelain --untracked-files=no
+if ($trackedChanges) {
+    throw "Hay cambios trackeados sin commitear"
+}
 ```
-Browser
-   |
-   v
-nginx (443) -- /api/* --> 127.0.0.1:18005 (container Docker, produccion_fg)
-        \-- /*       --> /var/www/html/django/produccion_fg/frontend/
+
+No continuar desde una rama de trabajo. El PR debe estar mergeado y visible en
+`origin/main`.
+
+## 2. Validar y generar el paquete
+
+El generador ejecuta tests del backend, tests del frontend y build Vite. También
+verifica que el paquete no contenga `.env` y escribe `RELEASE_MANIFEST.txt`.
+
+```powershell
+powershell -ExecutionPolicy Bypass -File scripts\build_deploy_package.ps1
+
+$shortSha = (git rev-parse --short HEAD).Trim()
+$fullSha = (git rev-parse HEAD).Trim()
+$package = Resolve-Path "dist_deploy\registro_produccion_deploy_$shortSha.tar.gz"
+Get-FileHash $package -Algorithm SHA256
 ```
 
-> **Historico**: antes habia un segundo backend en el host (puerto 8005)
-> manejado por `/var/www/html/django/produccion_fg/restart.sh`. Ese script
-> esta marcado como DEPRECATED y no se usa mas. El proceso de host se
-> mantiene vivo por inercia pero nginx no lo apunta. Si queres limpiar
-> el server, mira la seccion "Limpiar el backend legacy del host" mas
-> abajo.
+No usar `-AllowAnyBranch` ni `-SkipTests` para producción.
 
-El `docker-compose.yml` en `/srv/apps/registro_produccion/docker-compose.yml`
-define el container. El `Dockerfile` copia `backend/` al container y arranca
-gunicorn en :8000. Docker mapea el :8000 del container al :18005 del host.
+## 3. Subir el paquete
 
-### Diagrama de directorios
-
-```
-/srv/apps/registro_produccion/    # SOURCE_DIR: repo git, codigo fuente del container
-├── docker-compose.yml
-├── Dockerfile
-├── backend/                       # lo que se copia al container
-├── db_migrations/                  # los SQL que corre el script de deploy
-├── deploy_produccion_fg.sh        # el script de deploy (auto-detecta Docker)
-├── AGENTS.md
-└── DEPLOY.md                      # este archivo
-
-/var/www/html/django/produccion_fg/  # APP_DIR: target del deploy, sirve solo el frontend
-├── frontend/                      # assets estaticos (nginx los sirve)
-├── backend/                       # LEGACY - no se usa mas, se puede borrar
-│   ├── venv/                      # LEGACY
-│   ├── .env                       # LEGACY (db url, sirve para las migraciones)
-│   └── app/                       # LEGACY
-├── restart.sh                     # DEPRECATED
-└── RELEASE_MANIFEST.txt           # manifest del ultimo deploy exitoso
+```powershell
+scp $package "fasa_195:/home/ferreteria/$($package.Path | Split-Path -Leaf)"
 ```
 
----
+Guardar el SHA256 local para compararlo con la salida del preflight.
 
-## Pre-flight checks
+## 4. Actualizar el checkout remoto
 
-Antes de tocar nada, verificar:
+Esto actualiza únicamente el checkout Git; todavía no cambia contenedores ni
+frontend publicado.
+
+```powershell
+ssh -o BatchMode=yes fasa_195
+```
+
+En el servidor:
 
 ```bash
-ssh -i ~/.ssh/fasa_195 ferreteria@fasa_195
-
-# 1. Estado actual del container
-docker ps --format 'table {{.Names}}\t{{.Image}}\t{{.Status}}\t{{.Ports}}' \
-  | grep produccion_fg
-
-# 2. Commit que esta corriendo realmente (deberia matchear origin/main)
-docker inspect registro_produccion_produccion_fg --format '{{.Config.Image}}'
-
-# 3. Que el repo del server este sincronizado
 cd /srv/apps/registro_produccion
 git status -sb
-git log --oneline -3
-
-# 4. Health del backend actual
-curl -fsS http://127.0.0.1:18005/health
+git fetch --prune origin
+git switch main
+git pull --ff-only origin main
+test "$(git rev-parse HEAD)" = "$(git rev-parse origin/main)"
 ```
 
-Si el commit del container no coincide con `origin/main` de GitHub, el
-container esta desactualizado. Hay que rebuild.
+Si el checkout no está limpio o el pull no es fast-forward, detenerse. No usar
+`git reset --hard` para forzar el procedimiento.
 
----
+## 5. Ejecutar el preflight
 
-## Flujo de deploy paso a paso
-
-### 1. Validar localmente
-
-Desde tu maquina local, en la rama `main` con el commit que queres deployar:
-
-```powershell
-cd D:\notebook\active\registro_produccion
-
-# Validar que el codigo compila y los tests pasan
-cd backend; py -3.12 -m pytest ; py -3.12 -m compileall app ; cd ..
-cd frontend; npx.cmd vitest run ; npx.cmd vite build ; cd ..
-
-# Armar el paquete de deploy
-powershell -ExecutionPolicy Bypass -File scripts\build_deploy_package.ps1
-# Output: dist_deploy/registro_produccion_deploy_<sha>.tar.gz
-```
-
-### 2. Subir el paquete al server
-
-```powershell
-scp -i $env:USERPROFILE\.ssh\fasa_195 `
-  dist_deploy\registro_produccion_deploy_<sha>.tar.gz `
-  ferreteria@fasa_195:/home/ferreteria/
-```
-
-### 3. Conectarse al server y hacer el deploy
-
-```powershell
-ssh -i $env:USERPROFILE\.ssh\fasa_195 -t ferreteria@fasa_195
-```
-
-Adentro del server:
+Reemplazar el nombre de ejemplo por el paquete generado en el paso 2:
 
 ```bash
-# 3a. Sincronizar el codigo fuente (esto trae TODO: backend, frontend, db_migrations)
 cd /srv/apps/registro_produccion
-git fetch origin
-git reset --hard origin/main
-git log --oneline -1   # confirmar que estamos en el commit deseado
+bash scripts/deploy_produccion_fg_main_fasa195.sh --check \
+  /home/ferreteria/registro_produccion_deploy_5ee50b0.tar.gz
+```
 
-# 3b. Aplicar migraciones DB (idempotentes, se pueden correr varias veces)
-#     El script apply_db_migrations del deploy_produccion_fg.sh lee las
-#     credenciales del .env del host y aplica los SQL de db_migrations.
-#     Lo corremos manualmente para tener control fino:
-DB="$(python3 -c "
-from urllib.parse import urlparse
-import re
-content = open('/var/www/html/django/produccion_fg/backend/.env').read()
-for line in content.splitlines():
-    m = re.match(r'^DATABASE_URL=(.*)', line.strip())
-    if m:
-        u = urlparse(m.group(1))
-        print(f'mysql -h{u.hostname} -P{u.port or 3306} -u{u.username} -p{u.password} {u.path.lstrip(\"/\")}')
-        break
-")"
-echo "Comando mysql: $DB"
+El modo `--check` puede ejecutar `git fetch`, inspeccionar Docker y extraer el
+paquete en un temporal. No construye imágenes, no recrea contenedores y no
+publica archivos.
 
-# Backup antes de migrar
-mysqldump $(echo $DB | sed 's/-p\([^ ]*\) /-p\1 /' | awk '{for(i=1;i<=NF;i++){if($i=="-p"){i++;continue}print $i}}') \
-  | gzip > /var/backups/registro_produccion/pre_migration_$(date +%Y%m%d_%H%M%S).sql.gz
+Debe terminar con:
 
-# Aplicar migraciones nuevas (revisar que no se aplicaron antes)
-for sql in /srv/apps/registro_produccion/db_migrations/*.sql; do
-  echo "==> Aplicando $(basename $sql)"
-  eval "$DB" < "$sql"
-done
+```text
+==> Preflight successful
+deployed_commit=...
+target_commit=...
+package_sha256=...
+```
 
-# 3c. Rebuild del container con el codigo nuevo
+Detenerse si:
+
+- el paquete no coincide con `origin/main`;
+- el checkout remoto no coincide con `origin/main`;
+- la revisión publicada no es ancestro de `origin/main`;
+- hay migraciones entre ambas revisiones;
+- el contenedor actual no está healthy;
+- faltan el frontend o el manifiesto actuales.
+
+## 6. Ejecutar el deploy
+
+### Interactivo, recomendado
+
+```bash
 cd /srv/apps/registro_produccion
-docker compose -f docker-compose.yml build produccion_fg
-
-# 3d. Re-deploy del container (sin dependencias para no tocar indufor)
-docker compose -f docker-compose.yml up -d --no-deps produccion_fg
-
-# 3e. Validar
-sleep 5
-curl -fsS http://127.0.0.1:18005/health
-echo
-echo "Commit del container:"
-docker inspect registro_produccion_produccion_fg --format '{{.Config.Image}}'
+bash scripts/deploy_produccion_fg_main_fasa195.sh --deploy \
+  /home/ferreteria/registro_produccion_deploy_5ee50b0.tar.gz
 ```
 
-### 4. Verificar en el browser
+Escribir exactamente `DEPLOY` cuando se solicite.
 
-1. Hard refresh en `https://produccion.servinlgsm.com.ar/` (Ctrl+Shift+R)
-2. Si el Service Worker del PWA tiene la version vieja cacheada, ir a
-   DevTools > Application > Service Workers > Unregister, despues
-   Storage > Clear site data.
-3. Probar el flujo nuevo (ej: Admin > Lugares de carga > Editar un lugar).
+### No interactivo
 
----
-
-## Troubleshooting
-
-### "Deployo pero los usuarios siguen viendo el codigo viejo"
-
-El deploy actualizo el backend del host (puerto 8005) pero NO el container
-Docker (puerto 18005). Verificar:
+Usar solamente después de revisar un `--check` exitoso:
 
 ```bash
-# Que el container este con la imagen nueva
-docker inspect registro_produccion_produccion_fg --format '{{.Config.Image}}'
-
-# Si la imagen no es la nueva, hacer rebuild + up
 cd /srv/apps/registro_produccion
-docker compose -f docker-compose.yml build produccion_fg
-docker compose -f docker-compose.yml up -d --no-deps produccion_fg
+bash scripts/deploy_produccion_fg_main_fasa195.sh --deploy --yes \
+  /home/ferreteria/registro_produccion_deploy_5ee50b0.tar.gz
 ```
 
-### "El frontend no se actualiza en el browser"
+El script construye la imagen, valida Python dentro de ella, recrea únicamente
+`produccion_fg` con `--no-deps`, espera health y después intercambia el
+frontend de forma atómica.
 
-1. Hard refresh (Ctrl+Shift+R).
-2. Si sigue igual, DevTools > Application > Service Workers > Unregister
-   + Storage > Clear site data.
-3. Verificar que el server este sirviendo la version nueva:
+## 7. Revisar la evidencia
 
-```bash
-curl -fsS http://127.0.0.1/ | grep -oE 'assets/index-[A-Za-z0-9_-]+\.js' | head -1
-# Comparar con el index.html que se genero en el build local
+Una ejecución correcta termina con estas claves:
+
+```text
+deploy_status=success
+target_commit=...
+target_image=registro_produccion:...
+target_image_id=sha256:...
+produccion_fg_health=healthy
+produccion_fg_health_url=http://127.0.0.1:18005/health
+frontend_asset=assets/index-....js
+indufor_unchanged=yes
+indufor_demo_unchanged=yes
+backup_dir=...
 ```
 
-### "Login tira 500 o la app no responde"
-
-Probar el backend directo:
+Comprobación adicional en el servidor:
 
 ```bash
+docker inspect registro_produccion_produccion_fg \
+  --format '{{.Image}}|{{.State.Health.Status}}'
 curl -fsS http://127.0.0.1:18005/health
-curl -fsS http://127.0.0.1:8005/health
+grep -E '^(commit|branch)=' \
+  /var/www/html/django/produccion_fg/RELEASE_MANIFEST.txt
 ```
 
-- Si `:18005` falla: container caido o codigo roto. Ver logs:
-  `docker logs registro_produccion_produccion_fg --tail 100`
-- Si `:8005` falla: irrelevante para produccion (no se usa), pero si
-  queres: `/var/www/html/django/produccion_fg/restart.sh`
+El campo `version` del health puede provenir del `.env` y quedar desactualizado.
+La evidencia autoritativa es el commit del manifiesto junto con el ID real de
+la imagen activa.
 
-### "El query a la DB falla con 'Unknown column'"
+## 8. Verificación pública y PWA
 
-Los `__tablename__` de los modelos SQLAlchemy no coinciden con los nombres
-reales de las tablas en la DB. Es un problema de alineacion, no del deploy.
-
-- Verificar con `DESCRIBE <tabla>` en la DB.
-- Si el modelo usa PascalCase pegado (`tableroproduccion`) y la DB tiene
-  snake_case (`tablero_produccion`), hay que actualizar el `__tablename__`
-  del modelo. No es parte del deploy, es un fix de modelo.
-
-### "El deploy script tira 'JSON decode error' en PowerShell"
-
-Cuando probas endpoints con `Invoke-RestMethod -Body @{...} -ContentType
-'application/json'` desde PowerShell, a veces no serializa bien. Workaround:
+La red de `fasa_195` no tiene hairpin NAT confiable. Verificar el sitio público
+desde la computadora local:
 
 ```powershell
-$body = @{dni='12345678'; password='mipass'} | ConvertTo-Json -Compress
-Invoke-RestMethod -Method Post -Uri 'http://localhost:8000/api/auth/login' `
-  -Body $body -ContentType 'application/json'
+$response = Invoke-WebRequest https://produccion.servinlgsm.com.ar/ -UseBasicParsing
+$response.StatusCode
+[regex]::Match($response.Content, 'assets/index-[A-Za-z0-9_-]+\.js').Value
 ```
 
-### "El deploy script reinicia el backend equivocado"
+Resultado esperado: HTTP 200 y el mismo `frontend_asset` informado por el
+deploy.
 
-El `deploy_produccion_fg.sh` actual reinicia el backend del **host**
-(puerto 8005), no el container (puerto 18005). Esto es un bug conocido.
-Workaround: hacer el rebuild + up del container manualmente, como se
-documenta arriba. Fix permanente pendiente en otro PR.
+Para la prueba funcional, pedir a una persona operadora que cierre y vuelva a
+abrir la aplicación. Si la PWA conserva la revisión anterior:
 
----
+1. hacer recarga completa;
+2. desregistrar el Service Worker;
+3. limpiar los datos del sitio;
+4. abrir nuevamente la aplicación.
 
-## Comandos utiles de diagnostico
+## Rollback
+
+El rollback es automático si falla la imagen, el health, el frontend, el
+manifiesto o las invariantes de servicios vecinos. Restaura:
+
+1. imagen/tag anterior de `produccion_fg`;
+2. contenedor anterior;
+3. frontend anterior;
+4. `RELEASE_MANIFEST.txt` anterior;
+5. health interno.
+
+El manifiesto del intento queda en `~/deploy-backups/registro_produccion/` con
+uno de estos estados:
+
+- `status=success`;
+- `status=rolled_back`;
+- `status=rollback_failed`.
+
+Si aparece `rollback_failed`, no improvisar cambios sobre Nginx, `.env`, bases
+o instancias vecinas. Conservar la salida y revisar el backup, el ID de imagen
+y el estado del contenedor.
+
+## Migraciones
+
+**No aplica migraciones.** El deploy normal aborta si detecta cambios bajo
+`db_migrations/` entre la revisión publicada y `origin/main`.
+
+Una migración requiere una tarea separada con:
+
+- revisión del SQL;
+- identificación explícita de la base de `produccion_fg`;
+- backup verificado;
+- aprobación específica antes de modificar datos;
+- validación y rollback propios.
+
+No agregar migraciones manuales al procedimiento de esta guía.
+
+## Diagnóstico rápido
+
+### El frontend sigue viejo
+
+Comparar el asset publicado con la salida del deploy:
 
 ```bash
-# Ver que container esta corriendo y con que imagen
-docker ps | grep produccion
-
-# Logs del container
-docker logs registro_produccion_produccion_fg --tail 100 -f
-
-# Ejecutar comando adentro del container
-docker exec -it registro_produccion_produccion_fg bash
-
-# Probar API desde el server
-curl -fsS http://127.0.0.1:18005/health
-curl -fsS http://127.0.0.1:8005/health
-
-# Probar API publica (sin hairpin NAT, falla por la red local)
-curl -fsS https://produccion.servinlgsm.com.ar/api/produccion/lugares-carga?un_id=1
-
-# Inspeccionar la respuesta del admin lugares-carga
-TOKEN=$(curl -fsS -H "Content-Type: application/json" \
-  -d '{"dni":"23347203","password":"7203"}' \
-  http://127.0.0.1:18005/api/auth/login \
-  | python3 -c 'import sys, json; print(json.load(sys.stdin)["access_token"])')
-curl -fsS -H "Authorization: Bearer $TOKEN" \
-  http://127.0.0.1:18005/api/admin/lugares-carga | python3 -m json.tool
-
-# Ver el nginx config del dominio
-cat /etc/nginx/sites-enabled/produccion.servinlgsm.com.ar
-
-# Ver la migracion que esta pendiente
-ls -la /srv/apps/registro_produccion/db_migrations/
+grep -oE 'assets/index-[A-Za-z0-9_-]+\.js' \
+  /var/www/html/django/produccion_fg/frontend/index.html | head -1
 ```
 
----
+Si el servidor tiene el asset correcto, aplicar los pasos de PWA/Service
+Worker del apartado anterior.
 
-## Hairpin NAT
-
-El router de la red local **no tiene hairpin NAT** configurado. Esto
-significa que desde el server no podes hacer `curl
-https://produccion.servinlgsm.com.ar/` (la IP publica no resuelve de
-vuelta al server). Por eso todos los curls de este doc apuntan a
-`127.0.0.1` o a los puertos internos. La validacion de la URL publica
-la hace alguien desde fuera de la LAN.
-
----
-
-## Limpiar el backend legacy del host (opcional)
-
-Si queres que quede SOLO el container Docker, hay que matar el proceso
-del backend legacy que sigue corriendo en el host (puerto 8005). Eso se
-hace con sudo (no se puede desde el user `ferreteria`):
+### El contenedor no queda healthy
 
 ```bash
-# Conectado al server por ssh, con sudo:
-sudo kill -9 2683786     # PID del master gunicorn del backend legacy
-# Si no sabes el PID, busca:
-sudo ps -ef | grep 'bind 0.0.0.0:8005' | grep -v grep
-
-# Una vez muerto, opcionalmente borrar el codigo legacy del APP_DIR:
-sudo rm -rf /var/www/html/django/produccion_fg/backend/venv
-sudo rm -rf /var/www/html/django/produccion_fg/backend/app
-# Mantener backend/.env porque el script de deploy lo lee para las migraciones
-# Mantener frontend/ porque nginx lo sirve
-# restart.sh ya esta deprecado, se puede borrar sin drama
+docker inspect registro_produccion_produccion_fg \
+  --format '{{.Image}}|{{.State.Status}}|{{.State.Health.Status}}'
+docker logs registro_produccion_produccion_fg --tail 100
 ```
 
-Verificacion:
+No mostrar ni copiar secretos de los logs.
 
-```bash
-# Puerto 8005 deberia estar libre
-ss -tlnp | grep ':8005' || echo "OK: puerto 8005 libre"
-# Puerto 18005 (container) sigue respondiendo
-curl -fsS http://127.0.0.1:18005/health
-```
+### El preflight dice que producción no es ancestro de `main`
 
-## Pendiente
+Existe una revisión desplegada que todavía no fue mergeada o el historial
+divergió. Mergear primero el PR correcto o preparar un rollback explícito. No
+forzar el deploy.
 
-- [x] Fixear `deploy_produccion_fg.sh` para que detecte el modo Docker
-      y haga `git pull` + `docker compose build` + `docker compose up -d`
-      en vez de tocar el host. (Hecho)
-- [x] Marcar `restart.sh` como DEPRECATED. (Hecho)
-- [x] Actualizar `DEPLOY.md` con la nueva arquitectura. (Hecho)
-- [ ] Limpiar el backend legacy en :8005 (matar proceso y borrar venv/app
-      del APP_DIR). Requiere sudo en el server.
-- [ ] Alinear los `__tablename__` de los modelos legacy con la DB real
-      (snake_case). Es un PR aparte, no urgente.
+## Otros documentos
+
+- [`docs/DEPLOY_GITHUB_MAIN_RUNBOOK.md`](docs/DEPLOY_GITHUB_MAIN_RUNBOOK.md):
+  flujo multiinstancia que actualiza `indufor` y `produccion_fg`; no usar para
+  el deploy normal descrito aquí.
+- [`docs/DEMO_DEPLOY_RUNBOOK.md`](docs/DEMO_DEPLOY_RUNBOOK.md): entorno demo.
+- `README_DEPLOY.md`: referencia histórica de la migración Docker.

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -16,6 +16,8 @@ El procedimiento:
 - actualiza juntos el backend Docker y el frontend estático de
   `produccion_fg`;
 - construye una imagen inmutable etiquetada con el SHA completo;
+- asigna esa imagen únicamente a `produccion_fg` mediante un override temporal,
+  sin modificar la etiqueta `registro_produccion:latest` compartida;
 - crea backup, manifiesto y rollback automático;
 - valida el contenedor, el endpoint interno y el asset del frontend;
 - usa `docker compose ... --no-deps` para no recrear servicios vecinos.
@@ -54,6 +56,8 @@ puerto interno `18005`. Este flujo no modifica esa configuración.
 - PowerShell 7.
 - Python 3.12 con las dependencias de test del backend.
 - Node.js/npm con las dependencias del frontend.
+- Espacio temporal suficiente para materializar el commit e instalar sus
+  dependencias con `npm ci`.
 - SSH/SCP con el alias `fasa_195` configurado.
 
 ### En `fasa_195`
@@ -94,8 +98,12 @@ No continuar desde una rama de trabajo. El PR debe estar mergeado y visible en
 
 ## 2. Validar y generar el paquete
 
-El generador ejecuta tests del backend, tests del frontend y build Vite. También
-verifica que el paquete no contenga `.env` y escribe `RELEASE_MANIFEST.txt`.
+El generador materializa `HEAD` en un directorio temporal mediante
+`git archive`, instala el frontend con `npm ci` y ejecuta tests del backend,
+tests del frontend y build Vite sobre esa copia. El paquete se copia
+exclusivamente desde el commit materializado: archivos locales no trackeados o
+ignorados no pueden incorporarse. También verifica que el paquete no contenga
+`.env` y escribe `RELEASE_MANIFEST.txt`.
 
 ```powershell
 powershell -ExecutionPolicy Bypass -File scripts\build_deploy_package.ps1
@@ -107,6 +115,9 @@ Get-FileHash $package -Algorithm SHA256
 ```
 
 No usar `-AllowAnyBranch` ni `-SkipTests` para producción.
+
+La carpeta temporal se elimina siempre, tanto al terminar correctamente como
+ante un error.
 
 ## 3. Subir el paquete
 

--- a/backend/tests/test_deploy_produccion_fg_main_fasa195.py
+++ b/backend/tests/test_deploy_produccion_fg_main_fasa195.py
@@ -69,6 +69,7 @@ class DeployHarness:
         mode: str,
         *extra_arguments: str,
         target_commit: str = "target-commit",
+        source_head: str = "target-commit",
         deployed_is_ancestor: bool = True,
         changed_files: str = "",
         git_status: str = "",
@@ -85,6 +86,7 @@ class DeployHarness:
                 "CALL_LOG": bash_path(self.root / "calls.log"),
                 "FAKE_STATE_DIR": bash_path(self.root),
                 "FAKE_TARGET_COMMIT": target_commit,
+                "FAKE_SOURCE_HEAD": source_head,
                 "FAKE_DEPLOYED_IS_ANCESTOR": "1" if deployed_is_ancestor else "0",
                 "FAKE_CHANGED_FILES": changed_files,
                 "FAKE_GIT_STATUS": git_status,
@@ -164,6 +166,7 @@ case "$*" in
   "status --porcelain") printf '%s' "${FAKE_GIT_STATUS:-}" ;;
   "fetch --prune origin") : ;;
   "rev-parse origin/main") printf '%s\n' "${FAKE_TARGET_COMMIT:-target-commit}" ;;
+  "rev-parse HEAD") printf '%s\n' "${FAKE_SOURCE_HEAD:-target-commit}" ;;
   "merge-base --is-ancestor deployed-commit "*)
     [[ "${FAKE_DEPLOYED_IS_ANCESTOR:-1}" == "1" ]]
     ;;
@@ -249,6 +252,13 @@ def test_check_rejects_diverged_or_newer_production(deploy_harness: DeployHarnes
 
     assert result.returncode != 0
     assert "deployed commit is not an ancestor" in result.stderr
+
+
+def test_check_rejects_source_checkout_not_at_origin_main(deploy_harness: DeployHarness):
+    result = deploy_harness.run("--check", source_head="older-main")
+
+    assert result.returncode != 0
+    assert "source checkout does not match origin/main" in result.stderr
 
 
 def test_check_aborts_when_range_contains_db_migrations(deploy_harness: DeployHarness):

--- a/backend/tests/test_deploy_produccion_fg_main_fasa195.py
+++ b/backend/tests/test_deploy_produccion_fg_main_fasa195.py
@@ -75,6 +75,7 @@ class DeployHarness:
         git_status: str = "",
         fail_target_health: bool = False,
         fail_rollback: bool = False,
+        change_indufor_after_deploy: bool = False,
     ) -> subprocess.CompletedProcess[str]:
         env = os.environ.copy()
         env.update(
@@ -92,6 +93,9 @@ class DeployHarness:
                 "FAKE_GIT_STATUS": git_status,
                 "FAKE_FAIL_TARGET_HEALTH": "1" if fail_target_health else "0",
                 "FAKE_FAIL_ROLLBACK": "1" if fail_rollback else "0",
+                "FAKE_CHANGE_INDUFOR_AFTER_DEPLOY": (
+                    "1" if change_indufor_after_deploy else "0"
+                ),
             }
         )
         script = REPO_ROOT / "scripts/deploy_produccion_fg_main_fasa195.sh"
@@ -185,7 +189,11 @@ case "$*" in
     printf '%s\n' produccion_fg
     ;;
   "inspect -f {{.Id}}|{{.Image}} registro_produccion_indufor")
-    printf '%s\n' indufor-container-id\|indufor-image-id
+    if [[ -f "$FAKE_STATE_DIR/target-deployed" && "${FAKE_CHANGE_INDUFOR_AFTER_DEPLOY:-0}" == "1" ]]; then
+      printf '%s\n' changed-indufor-container\|changed-indufor-image
+    else
+      printf '%s\n' indufor-container-id\|indufor-image-id
+    fi
     ;;
   "inspect -f {{.Id}}|{{.Image}} registro_produccion_indufor_demo")
     printf '%s\n' demo-container-id\|demo-image-id
@@ -324,3 +332,14 @@ def test_failed_rollback_is_reported_truthfully(deploy_harness: DeployHarness):
     assert result.returncode != 0
     assert deploy_harness.manifest["status"] == "rollback_failed"
     assert "rollback failed" in result.stderr
+
+
+def test_neighbor_invariant_failure_triggers_rollback(deploy_harness: DeployHarness):
+    result = deploy_harness.run(
+        "--deploy", "--yes", change_indufor_after_deploy=True
+    )
+
+    assert result.returncode != 0
+    assert "indufor changed during deploy" in result.stderr
+    assert "docker tag old-image-id registro_produccion:latest" in deploy_harness.calls
+    assert deploy_harness.manifest["status"] == "rolled_back"

--- a/backend/tests/test_deploy_produccion_fg_main_fasa195.py
+++ b/backend/tests/test_deploy_produccion_fg_main_fasa195.py
@@ -76,6 +76,7 @@ class DeployHarness:
         fail_target_health: bool = False,
         fail_rollback: bool = False,
         change_indufor_after_deploy: bool = False,
+        fail_frontend_publish: bool = False,
     ) -> subprocess.CompletedProcess[str]:
         env = os.environ.copy()
         env.update(
@@ -96,6 +97,7 @@ class DeployHarness:
                 "FAKE_CHANGE_INDUFOR_AFTER_DEPLOY": (
                     "1" if change_indufor_after_deploy else "0"
                 ),
+                "FAKE_FAIL_FRONTEND_PUBLISH": "1" if fail_frontend_publish else "0",
             }
         )
         script = REPO_ROOT / "scripts/deploy_produccion_fg_main_fasa195.sh"
@@ -236,6 +238,16 @@ esac
     )
     write_fake(fake_bin / "curl", "printf 'curl %s\\n' \"$*\" >>\"$CALL_LOG\"")
     write_fake(fake_bin / "sleep", ":")
+    write_fake(
+        fake_bin / "mv",
+        r'''
+printf 'mv %s\n' "$*" >>"$CALL_LOG"
+if [[ "${FAKE_FAIL_FRONTEND_PUBLISH:-0}" == "1" && "$1" == *"/frontend.next-"* && "$2" == */frontend ]]; then
+  exit 1
+fi
+exec /usr/bin/mv "$@"
+''',
+    )
 
     return DeployHarness(tmp_path)
 
@@ -342,4 +354,16 @@ def test_neighbor_invariant_failure_triggers_rollback(deploy_harness: DeployHarn
     assert result.returncode != 0
     assert "indufor changed during deploy" in result.stderr
     assert "docker tag old-image-id registro_produccion:latest" in deploy_harness.calls
+    assert deploy_harness.manifest["status"] == "rolled_back"
+
+
+def test_partial_frontend_switch_restores_previous_frontend(
+    deploy_harness: DeployHarness,
+):
+    result = deploy_harness.run("--deploy", "--yes", fail_frontend_publish=True)
+
+    assert result.returncode != 0
+    assert (deploy_harness.app_parent / "frontend" / "index.html").read_text(
+        encoding="utf-8"
+    ) == "old frontend"
     assert deploy_harness.manifest["status"] == "rolled_back"

--- a/backend/tests/test_deploy_produccion_fg_main_fasa195.py
+++ b/backend/tests/test_deploy_produccion_fg_main_fasa195.py
@@ -1,0 +1,316 @@
+import io
+import os
+import subprocess
+import tarfile
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+BASH = Path(r"C:\Program Files\Git\bin\bash.exe")
+
+
+def bash_path(path: Path) -> str:
+    resolved = path.resolve()
+    return f"/{resolved.drive[0].lower()}{resolved.as_posix()[2:]}"
+
+
+def write_fake(path: Path, body: str) -> None:
+    path.write_text(
+        f"#!/usr/bin/env bash\nset -eu\n{body}\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+    path.chmod(0o755)
+
+
+def add_tar_text(archive: tarfile.TarFile, name: str, content: str) -> None:
+    payload = content.encode("utf-8")
+    info = tarfile.TarInfo(name)
+    info.size = len(payload)
+    archive.addfile(info, io.BytesIO(payload))
+
+
+@dataclass
+class DeployHarness:
+    root: Path
+
+    @property
+    def source_dir(self) -> Path:
+        return self.root / "source"
+
+    @property
+    def app_parent(self) -> Path:
+        return self.root / "published"
+
+    @property
+    def package(self) -> Path:
+        return self.root / "registro_produccion_deploy_target.tar.gz"
+
+    @property
+    def calls(self) -> str:
+        call_log = self.root / "calls.log"
+        return call_log.read_text(encoding="utf-8") if call_log.exists() else ""
+
+    @property
+    def manifest(self) -> dict[str, str]:
+        manifests = sorted((self.root / "backups").glob("deploy_*.env"))
+        assert manifests
+        return dict(
+            line.split("=", 1)
+            for line in manifests[-1].read_text(encoding="utf-8").splitlines()
+            if "=" in line
+        )
+
+    def run(
+        self,
+        mode: str,
+        *extra_arguments: str,
+        target_commit: str = "target-commit",
+        deployed_is_ancestor: bool = True,
+        changed_files: str = "",
+        git_status: str = "",
+        fail_target_health: bool = False,
+        fail_rollback: bool = False,
+    ) -> subprocess.CompletedProcess[str]:
+        env = os.environ.copy()
+        env.update(
+            {
+                "SOURCE_DIR": bash_path(self.source_dir),
+                "APP_PARENT": bash_path(self.app_parent),
+                "BACKUP_DIR": bash_path(self.root / "backups"),
+                "LOCK_FILE": bash_path(self.root / "deploy.lock"),
+                "CALL_LOG": bash_path(self.root / "calls.log"),
+                "FAKE_STATE_DIR": bash_path(self.root),
+                "FAKE_TARGET_COMMIT": target_commit,
+                "FAKE_DEPLOYED_IS_ANCESTOR": "1" if deployed_is_ancestor else "0",
+                "FAKE_CHANGED_FILES": changed_files,
+                "FAKE_GIT_STATUS": git_status,
+                "FAKE_FAIL_TARGET_HEALTH": "1" if fail_target_health else "0",
+                "FAKE_FAIL_ROLLBACK": "1" if fail_rollback else "0",
+            }
+        )
+        script = REPO_ROOT / "scripts/deploy_produccion_fg_main_fasa195.sh"
+        return subprocess.run(
+            [
+                str(BASH),
+                "-c",
+                'export PATH="$1:$PATH"; shift; exec "$@"',
+                "deploy-test",
+                bash_path(self.root / "fake-bin"),
+                bash_path(script),
+                mode,
+                *extra_arguments,
+                bash_path(self.package),
+            ],
+            cwd=self.source_dir,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+
+@pytest.fixture
+def deploy_harness(tmp_path: Path) -> DeployHarness:
+    source_dir = tmp_path / "source"
+    app_parent = tmp_path / "published"
+    frontend_dir = app_parent / "frontend"
+    fake_bin = tmp_path / "fake-bin"
+    for directory in (source_dir / ".git", frontend_dir, fake_bin, tmp_path / "backups"):
+        directory.mkdir(parents=True)
+
+    (source_dir / "docker-compose.yml").write_text(
+        "services:\n  produccion_fg:\n    image: registro_produccion:latest\n",
+        encoding="utf-8",
+    )
+    (frontend_dir / "index.html").write_text("old frontend", encoding="utf-8")
+    (app_parent / "RELEASE_MANIFEST.txt").write_text(
+        "name=registro_produccion\n"
+        "commit=deployed-commit\n"
+        "short_commit=deployed\n"
+        "branch=main\n",
+        encoding="utf-8",
+    )
+    with tarfile.open(tmp_path / "registro_produccion_deploy_target.tar.gz", "w:gz") as archive:
+        add_tar_text(archive, "backend/app/main.py", "APP = 'target'\n")
+        add_tar_text(archive, "backend/requirements.txt", "fastapi\n")
+        add_tar_text(
+            archive,
+            "frontend/dist/index.html",
+            '<div id="app"></div><script src="/assets/index-target.js"></script>\n',
+        )
+        add_tar_text(archive, "frontend/dist/assets/index-target.js", "console.log('target')\n")
+        add_tar_text(
+            archive,
+            "RELEASE_MANIFEST.txt",
+            "name=registro_produccion\n"
+            "commit=target-commit\n"
+            "short_commit=target\n"
+            "branch=main\n"
+            "built_at=2026-08-01T00:00:00Z\n",
+        )
+
+    write_fake(fake_bin / "hostname", "printf '%s\\n' fg-ubuntu")
+    write_fake(fake_bin / "flock", "printf 'flock %s\\n' \"$*\" >>\"$CALL_LOG\"")
+    write_fake(
+        fake_bin / "git",
+        r'''
+printf 'git %s\n' "$*" >>"$CALL_LOG"
+case "$*" in
+  "rev-parse --is-inside-work-tree") printf '%s\n' true ;;
+  "status --porcelain") printf '%s' "${FAKE_GIT_STATUS:-}" ;;
+  "fetch --prune origin") : ;;
+  "rev-parse origin/main") printf '%s\n' "${FAKE_TARGET_COMMIT:-target-commit}" ;;
+  "merge-base --is-ancestor deployed-commit "*)
+    [[ "${FAKE_DEPLOYED_IS_ANCESTOR:-1}" == "1" ]]
+    ;;
+  "diff --name-only deployed-commit "*" -- db_migrations")
+    printf '%s' "${FAKE_CHANGED_FILES:-}"
+    ;;
+esac
+''',
+    )
+    write_fake(
+        fake_bin / "docker",
+        r'''
+printf 'docker %s\n' "$*" >>"$CALL_LOG"
+case "$*" in
+  "compose -f docker-compose.yml config --services")
+    printf '%s\n' produccion_fg
+    ;;
+  "inspect -f {{.Id}}|{{.Image}} registro_produccion_indufor")
+    printf '%s\n' indufor-container-id\|indufor-image-id
+    ;;
+  "inspect -f {{.Id}}|{{.Image}} registro_produccion_indufor_demo")
+    printf '%s\n' demo-container-id\|demo-image-id
+    ;;
+  "inspect -f {{.Image}} registro_produccion_produccion_fg")
+    if [[ -f "$FAKE_STATE_DIR/target-deployed" ]]; then
+      printf '%s\n' target-image-id
+    else
+      printf '%s\n' old-image-id
+    fi
+    ;;
+  "inspect -f {{.State.Health.Status}} registro_produccion_produccion_fg")
+    if [[ -f "$FAKE_STATE_DIR/target-deployed" && "${FAKE_FAIL_TARGET_HEALTH:-0}" == "1" ]]; then
+      printf '%s\n' unhealthy
+    else
+      printf '%s\n' healthy
+    fi
+    ;;
+  "image inspect registro_produccion:target-commit --format {{.Id}}")
+    printf '%s\n' target-image-id
+    ;;
+  "tag old-image-id registro_produccion:rollback-"*) : ;;
+  "tag registro_produccion:target-commit registro_produccion:latest")
+    touch "$FAKE_STATE_DIR/target-tagged"
+    ;;
+  "tag old-image-id registro_produccion:latest")
+    rm -f "$FAKE_STATE_DIR/target-tagged"
+    touch "$FAKE_STATE_DIR/rollback-tagged"
+    ;;
+  "compose -f docker-compose.yml up -d --no-build --no-deps --force-recreate produccion_fg")
+    if [[ -f "$FAKE_STATE_DIR/rollback-tagged" ]]; then
+      rm -f "$FAKE_STATE_DIR/target-deployed"
+      [[ "${FAKE_FAIL_ROLLBACK:-0}" != "1" ]]
+    else
+      touch "$FAKE_STATE_DIR/target-deployed"
+    fi
+    ;;
+esac
+''',
+    )
+    write_fake(fake_bin / "curl", "printf 'curl %s\\n' \"$*\" >>\"$CALL_LOG\"")
+    write_fake(fake_bin / "sleep", ":")
+
+    return DeployHarness(tmp_path)
+
+
+def test_check_is_read_only(deploy_harness: DeployHarness):
+    result = deploy_harness.run("--check")
+
+    assert result.returncode == 0, result.stderr
+    assert "docker build" not in deploy_harness.calls
+    assert "docker compose -f docker-compose.yml up" not in deploy_harness.calls
+
+
+def test_check_rejects_package_not_built_from_origin_main(deploy_harness: DeployHarness):
+    result = deploy_harness.run("--check", target_commit="different-main")
+
+    assert result.returncode != 0
+    assert "package commit does not match origin/main" in result.stderr
+
+
+def test_check_rejects_diverged_or_newer_production(deploy_harness: DeployHarness):
+    result = deploy_harness.run("--check", deployed_is_ancestor=False)
+
+    assert result.returncode != 0
+    assert "deployed commit is not an ancestor" in result.stderr
+
+
+def test_check_aborts_when_range_contains_db_migrations(deploy_harness: DeployHarness):
+    result = deploy_harness.run(
+        "--check", changed_files="db_migrations/20260801_schema.sql\n"
+    )
+
+    assert result.returncode != 0
+    assert "database migrations require a separate procedure" in result.stderr
+
+
+def test_deploy_requires_yes_when_non_interactive(deploy_harness: DeployHarness):
+    result = deploy_harness.run("--deploy")
+
+    assert result.returncode != 0
+    assert "interactive terminal or --yes" in result.stderr
+    assert "docker build" not in deploy_harness.calls
+
+
+def test_deploy_updates_only_produccion_fg(deploy_harness: DeployHarness):
+    result = deploy_harness.run("--deploy", "--yes")
+
+    assert result.returncode == 0, result.stderr
+    assert (
+        "docker compose -f docker-compose.yml up -d --no-build --no-deps "
+        "--force-recreate produccion_fg"
+    ) in deploy_harness.calls
+    assert "force-recreate indufor\n" not in deploy_harness.calls
+    assert "force-recreate indufor_demo\n" not in deploy_harness.calls
+
+
+def test_success_records_backend_frontend_and_unchanged_neighbors(
+    deploy_harness: DeployHarness,
+):
+    result = deploy_harness.run("--deploy", "--yes")
+
+    assert result.returncode == 0, result.stderr
+    assert "target_commit=target-commit" in result.stdout
+    assert "produccion_fg_health=healthy" in result.stdout
+    assert "frontend_asset=assets/index-target.js" in result.stdout
+    assert "indufor_unchanged=yes" in result.stdout
+    assert "indufor_demo_unchanged=yes" in result.stdout
+
+
+def test_failed_health_restores_image_frontend_and_manifest(
+    deploy_harness: DeployHarness,
+):
+    result = deploy_harness.run("--deploy", "--yes", fail_target_health=True)
+
+    assert result.returncode != 0
+    assert "docker tag old-image-id registro_produccion:latest" in deploy_harness.calls
+    assert deploy_harness.manifest["status"] == "rolled_back"
+    assert (deploy_harness.app_parent / "frontend" / "index.html").read_text(
+        encoding="utf-8"
+    ) == "old frontend"
+
+
+def test_failed_rollback_is_reported_truthfully(deploy_harness: DeployHarness):
+    result = deploy_harness.run(
+        "--deploy", "--yes", fail_target_health=True, fail_rollback=True
+    )
+
+    assert result.returncode != 0
+    assert deploy_harness.manifest["status"] == "rollback_failed"
+    assert "rollback failed" in result.stderr

--- a/backend/tests/test_deploy_produccion_fg_main_fasa195.py
+++ b/backend/tests/test_deploy_produccion_fg_main_fasa195.py
@@ -1,5 +1,6 @@
 import io
 import os
+import re
 import subprocess
 import tarfile
 from dataclasses import dataclass
@@ -31,6 +32,32 @@ def add_tar_text(archive: tarfile.TarFile, name: str, content: str) -> None:
     info = tarfile.TarInfo(name)
     info.size = len(payload)
     archive.addfile(info, io.BytesIO(payload))
+
+
+def write_deploy_package(path: Path, *, include_frontend_asset: bool = True) -> None:
+    with tarfile.open(path, "w:gz") as archive:
+        add_tar_text(archive, "backend/app/main.py", "APP = 'target'\n")
+        add_tar_text(archive, "backend/requirements.txt", "fastapi\n")
+        add_tar_text(
+            archive,
+            "frontend/dist/index.html",
+            '<div id="app"></div><script src="/assets/index-target.js"></script>\n',
+        )
+        if include_frontend_asset:
+            add_tar_text(
+                archive,
+                "frontend/dist/assets/index-target.js",
+                "console.log('target')\n",
+            )
+        add_tar_text(
+            archive,
+            "RELEASE_MANIFEST.txt",
+            "name=registro_produccion\n"
+            "commit=target-commit\n"
+            "short_commit=target\n"
+            "branch=main\n"
+            "built_at=2026-08-01T00:00:00Z\n",
+        )
 
 
 @dataclass
@@ -142,24 +169,7 @@ def deploy_harness(tmp_path: Path) -> DeployHarness:
         "branch=main\n",
         encoding="utf-8",
     )
-    with tarfile.open(tmp_path / "registro_produccion_deploy_target.tar.gz", "w:gz") as archive:
-        add_tar_text(archive, "backend/app/main.py", "APP = 'target'\n")
-        add_tar_text(archive, "backend/requirements.txt", "fastapi\n")
-        add_tar_text(
-            archive,
-            "frontend/dist/index.html",
-            '<div id="app"></div><script src="/assets/index-target.js"></script>\n',
-        )
-        add_tar_text(archive, "frontend/dist/assets/index-target.js", "console.log('target')\n")
-        add_tar_text(
-            archive,
-            "RELEASE_MANIFEST.txt",
-            "name=registro_produccion\n"
-            "commit=target-commit\n"
-            "short_commit=target\n"
-            "branch=main\n"
-            "built_at=2026-08-01T00:00:00Z\n",
-        )
+    write_deploy_package(tmp_path / "registro_produccion_deploy_target.tar.gz")
 
     write_fake(fake_bin / "hostname", "printf '%s\\n' fg-ubuntu")
     write_fake(fake_bin / "flock", "printf 'flock %s\\n' \"$*\" >>\"$CALL_LOG\"")
@@ -218,15 +228,8 @@ case "$*" in
     printf '%s\n' target-image-id
     ;;
   "tag old-image-id registro_produccion:rollback-"*) : ;;
-  "tag registro_produccion:target-commit registro_produccion:latest")
-    touch "$FAKE_STATE_DIR/target-tagged"
-    ;;
-  "tag old-image-id registro_produccion:latest")
-    rm -f "$FAKE_STATE_DIR/target-tagged"
-    touch "$FAKE_STATE_DIR/rollback-tagged"
-    ;;
-  "compose -f docker-compose.yml up -d --no-build --no-deps --force-recreate produccion_fg")
-    if [[ -f "$FAKE_STATE_DIR/rollback-tagged" ]]; then
+  "compose -f docker-compose.yml -f "*" up -d --no-build --no-deps --force-recreate produccion_fg")
+    if grep -q 'registro_produccion:rollback-' "$5"; then
       rm -f "$FAKE_STATE_DIR/target-deployed"
       [[ "${FAKE_FAIL_ROLLBACK:-0}" != "1" ]]
     else
@@ -290,6 +293,17 @@ def test_check_aborts_when_range_contains_db_migrations(deploy_harness: DeployHa
     assert "database migrations require a separate procedure" in result.stderr
 
 
+def test_check_rejects_package_when_referenced_frontend_asset_is_missing(
+    deploy_harness: DeployHarness,
+):
+    write_deploy_package(deploy_harness.package, include_frontend_asset=False)
+
+    result = deploy_harness.run("--check")
+
+    assert result.returncode != 0
+    assert "package frontend asset not found" in result.stderr
+
+
 def test_deploy_requires_yes_when_non_interactive(deploy_harness: DeployHarness):
     result = deploy_harness.run("--deploy")
 
@@ -302,10 +316,12 @@ def test_deploy_updates_only_produccion_fg(deploy_harness: DeployHarness):
     result = deploy_harness.run("--deploy", "--yes")
 
     assert result.returncode == 0, result.stderr
-    assert (
-        "docker compose -f docker-compose.yml up -d --no-build --no-deps "
-        "--force-recreate produccion_fg"
-    ) in deploy_harness.calls
+    assert re.search(
+        r"docker compose -f docker-compose\.yml -f \S+ up -d --no-build "
+        r"--no-deps --force-recreate produccion_fg",
+        deploy_harness.calls,
+    )
+    assert "registro_produccion:latest" not in deploy_harness.calls
     assert "force-recreate indufor\n" not in deploy_harness.calls
     assert "force-recreate indufor_demo\n" not in deploy_harness.calls
 
@@ -329,7 +345,8 @@ def test_failed_health_restores_image_frontend_and_manifest(
     result = deploy_harness.run("--deploy", "--yes", fail_target_health=True)
 
     assert result.returncode != 0
-    assert "docker tag old-image-id registro_produccion:latest" in deploy_harness.calls
+    assert "docker tag old-image-id registro_produccion:latest" not in deploy_harness.calls
+    assert deploy_harness.calls.count("--force-recreate produccion_fg") == 2
     assert deploy_harness.manifest["status"] == "rolled_back"
     assert (deploy_harness.app_parent / "frontend" / "index.html").read_text(
         encoding="utf-8"
@@ -353,7 +370,8 @@ def test_neighbor_invariant_failure_triggers_rollback(deploy_harness: DeployHarn
 
     assert result.returncode != 0
     assert "indufor changed during deploy" in result.stderr
-    assert "docker tag old-image-id registro_produccion:latest" in deploy_harness.calls
+    assert "docker tag old-image-id registro_produccion:latest" not in deploy_harness.calls
+    assert deploy_harness.calls.count("--force-recreate produccion_fg") == 2
     assert deploy_harness.manifest["status"] == "rolled_back"
 
 

--- a/backend/tests/test_deploy_scripts_contract.py
+++ b/backend/tests/test_deploy_scripts_contract.py
@@ -84,6 +84,29 @@ def test_github_main_docker_deploy_has_safe_contract():
     assert missing == []
 
 
+def test_produccion_fg_main_deploy_has_exclusive_safe_contract():
+    script = read("scripts/deploy_produccion_fg_main_fasa195.sh")
+    required_fragments = [
+        'REMOTE="origin"',
+        'BRANCH="main"',
+        'SERVICE="produccion_fg"',
+        "--check",
+        "--deploy",
+        "--yes",
+        "git merge-base --is-ancestor",
+        "db_migrations",
+        "--no-deps",
+        "frontend.next",
+        "frontend.previous",
+        "rollback_failed",
+        "indufor_unchanged",
+        "indufor_demo_unchanged",
+    ]
+
+    missing = [fragment for fragment in required_fragments if fragment not in script]
+    assert missing == []
+
+
 def test_github_main_runbook_documents_safe_operator_flow():
     runbook = read("docs/DEPLOY_GITHUB_MAIN_RUNBOOK.md")
     required = [

--- a/backend/tests/test_deploy_scripts_contract.py
+++ b/backend/tests/test_deploy_scripts_contract.py
@@ -125,6 +125,32 @@ def test_github_main_runbook_documents_safe_operator_flow():
     assert missing == []
 
 
+def test_deploy_md_is_the_canonical_produccion_fg_runbook():
+    runbook = read("DEPLOY.md")
+    required = [
+        "Guía canónica",
+        "origin/main",
+        "únicamente `produccion_fg`",
+        "build_deploy_package.ps1",
+        "deploy_produccion_fg_main_fasa195.sh --check",
+        "deploy_produccion_fg_main_fasa195.sh --deploy",
+        "--no-deps",
+        "No aplica migraciones",
+        "Service Worker",
+        "rollback_failed",
+    ]
+
+    missing = [fragment for fragment in required if fragment not in runbook]
+    assert missing == []
+
+
+def test_multiinstance_runbook_warns_against_normal_produccion_fg_deploy():
+    runbook = read("docs/DEPLOY_GITHUB_MAIN_RUNBOOK.md")
+
+    assert "NO usar para el deploy normal de `produccion_fg`" in runbook
+    assert "../DEPLOY.md" in runbook
+
+
 def test_production_deploy_package_applies_idempotent_db_migrations():
     package_script = read("scripts/build_deploy_package.ps1")
     deploy_script = read("deploy_produccion_fg.sh")

--- a/backend/tests/test_deploy_scripts_contract.py
+++ b/backend/tests/test_deploy_scripts_contract.py
@@ -33,6 +33,9 @@ def test_windows_package_script_builds_manifested_package_without_env_files():
     required_fragments = [
         "git rev-parse HEAD",
         "git rev-parse origin/main",
+        "git archive --format=tar",
+        "$CleanSource",
+        "npm ci",
         "python -m pytest",
         "npm run test",
         "npm run build",
@@ -101,10 +104,14 @@ def test_produccion_fg_main_deploy_has_exclusive_safe_contract():
         "rollback_failed",
         "indufor_unchanged",
         "indufor_demo_unchanged",
+        "write_compose_override",
+        'image: "%s"',
+        '[[ -f "$tmp_dir/frontend/dist/$frontend_asset" ]]',
     ]
 
     missing = [fragment for fragment in required_fragments if fragment not in script]
     assert missing == []
+    assert "registro_produccion:latest" not in script
 
 
 def test_github_main_runbook_documents_safe_operator_flow():
@@ -132,6 +139,9 @@ def test_deploy_md_is_the_canonical_produccion_fg_runbook():
         "origin/main",
         "únicamente `produccion_fg`",
         "build_deploy_package.ps1",
+        "git archive",
+        "npm ci",
+        "registro_produccion:latest",
         "deploy_produccion_fg_main_fasa195.sh --check",
         "deploy_produccion_fg_main_fasa195.sh --deploy",
         "--no-deps",
@@ -142,6 +152,7 @@ def test_deploy_md_is_the_canonical_produccion_fg_runbook():
 
     missing = [fragment for fragment in required if fragment not in runbook]
     assert missing == []
+    assert "sin modificar la etiqueta `registro_produccion:latest`" in runbook
 
 
 def test_multiinstance_runbook_warns_against_normal_produccion_fg_deploy():

--- a/docs/DEPLOY_GITHUB_MAIN_RUNBOOK.md
+++ b/docs/DEPLOY_GITHUB_MAIN_RUNBOOK.md
@@ -1,5 +1,9 @@
 # Deploy desde GitHub main
 
+> **Flujo multiinstancia. NO usar para el deploy normal de `produccion_fg`.**
+> El procedimiento canónico y exclusivo de producción está en
+> [`DEPLOY.md`](../DEPLOY.md).
+
 ## Alcance
 
 `scripts/deploy_main_fasa195.sh` actualiza exclusivamente los servicios Docker

--- a/docs/superpowers/plans/2026-08-01-produccion-fg-main-deploy.md
+++ b/docs/superpowers/plans/2026-08-01-produccion-fg-main-deploy.md
@@ -1,0 +1,428 @@
+# Produccion FG Main Deploy Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Entregar un flujo repetible, main-only y sin sudo para desplegar únicamente el backend y frontend de `produccion_fg` en `fasa_195`, con preflight, evidencia y rollback.
+
+**Architecture:** Un nuevo script Bash remoto valida un paquete generado desde `origin/main`, comprueba que la revisión productiva sea ancestro del objetivo y que no haya migraciones pendientes, construye una imagen inmutable y publica sólo `produccion_fg` más su frontend estático. `DEPLOY.md` pasa a ser la guía canónica; un harness de comandos falsos valida las fronteras, el modo read-only y el rollback sin tocar producción.
+
+**Tech Stack:** Bash, Git, Docker Compose, PowerShell, pytest, Vitest/Vite, SSH.
+
+---
+
+## Estructura de archivos
+
+- Crear `scripts/deploy_produccion_fg_main_fasa195.sh`: única entrada remota para `--check` y `--deploy` de `produccion_fg` desde `origin/main`.
+- Crear `backend/tests/test_deploy_produccion_fg_main_fasa195.py`: harness dinámico con Git/Docker/curl falsos para preflight, deploy y rollback.
+- Modificar `backend/tests/test_deploy_scripts_contract.py`: contrato estático de alcance y documentación canónica.
+- Modificar `DEPLOY.md`: runbook operativo principal con comandos copiables y checklist.
+- Modificar `docs/DEPLOY_GITHUB_MAIN_RUNBOOK.md`: advertencia visible de que es un flujo multiinstancia y no el procedimiento normal de `produccion_fg`.
+
+### Task 1: Definir el contrato ejecutable en tests
+
+**Files:**
+- Create: `backend/tests/test_deploy_produccion_fg_main_fasa195.py`
+- Modify: `backend/tests/test_deploy_scripts_contract.py`
+- Test: `backend/tests/test_deploy_produccion_fg_main_fasa195.py`
+
+- [ ] **Step 1: Crear fixture de paquete y comandos falsos**
+
+El fixture debe crear un tarball con esta estructura real:
+
+```text
+backend/app/main.py
+backend/requirements.txt
+frontend/dist/index.html
+frontend/dist/assets/index-target.js
+RELEASE_MANIFEST.txt
+```
+
+El manifiesto debe contener:
+
+```text
+name=registro_produccion
+commit=target-commit
+short_commit=target
+branch=main
+built_at=2026-08-01T00:00:00Z
+```
+
+Los binarios falsos deben registrar llamadas en `calls.log`. `git` debe responder a `status --porcelain`, `rev-parse origin/main`, `merge-base --is-ancestor` y `diff --name-only`. `docker` debe responder a `inspect`, `image inspect`, `build`, `run`, `tag` y `compose ... up` sin invocar Docker real.
+
+- [ ] **Step 2: Escribir tests RED de preflight**
+
+Agregar pruebas equivalentes a:
+
+```python
+def test_check_is_read_only(harness):
+    result = harness.run("--check")
+    assert result.returncode == 0, result.stderr
+    assert "docker build" not in harness.calls
+    assert "docker compose" not in harness.calls
+
+
+def test_check_rejects_package_not_built_from_origin_main(harness):
+    result = harness.run("--check", target_commit="different-main")
+    assert result.returncode != 0
+    assert "package commit does not match origin/main" in result.stderr
+
+
+def test_check_rejects_diverged_or_newer_production(harness):
+    result = harness.run("--check", deployed_is_ancestor=False)
+    assert result.returncode != 0
+    assert "deployed commit is not an ancestor" in result.stderr
+
+
+def test_check_aborts_when_range_contains_db_migrations(harness):
+    result = harness.run("--check", changed_files="db_migrations/20260801.sql\n")
+    assert result.returncode != 0
+    assert "database migrations require a separate procedure" in result.stderr
+```
+
+- [ ] **Step 3: Escribir tests RED de alcance y éxito**
+
+```python
+def test_deploy_updates_only_produccion_fg(harness):
+    result = harness.run("--deploy", "--yes")
+    assert result.returncode == 0, result.stderr
+    assert "up -d --no-build --no-deps --force-recreate produccion_fg" in harness.calls
+    assert "up -d --no-build --no-deps --force-recreate indufor" not in harness.calls
+    assert "up -d --no-build --no-deps --force-recreate indufor_demo" not in harness.calls
+
+
+def test_success_records_backend_frontend_and_unchanged_neighbors(harness):
+    result = harness.run("--deploy", "--yes")
+    assert "target_commit=target-commit" in result.stdout
+    assert "produccion_fg_health=healthy" in result.stdout
+    assert "frontend_asset=assets/index-target.js" in result.stdout
+    assert "indufor_unchanged=yes" in result.stdout
+    assert "indufor_demo_unchanged=yes" in result.stdout
+```
+
+- [ ] **Step 4: Escribir tests RED de rollback**
+
+```python
+def test_failed_health_restores_image_frontend_and_manifest(harness):
+    result = harness.run("--deploy", "--yes", fail_target_health=True)
+    assert result.returncode != 0
+    assert "docker tag old-image registro_produccion:latest" in harness.calls
+    assert harness.manifest["status"] == "rolled_back"
+    assert (harness.frontend_dir / "index.html").read_text() == "old frontend"
+
+
+def test_failed_rollback_is_reported_truthfully(harness):
+    result = harness.run("--deploy", "--yes", fail_rollback=True)
+    assert result.returncode != 0
+    assert harness.manifest["status"] == "rollback_failed"
+    assert "rollback failed" in result.stderr
+```
+
+- [ ] **Step 5: Extender el contrato estático**
+
+En `test_deploy_scripts_contract.py`, exigir como mínimo:
+
+```python
+required_fragments = [
+    'REMOTE="origin"',
+    'BRANCH="main"',
+    'SERVICE="produccion_fg"',
+    "--check",
+    "--deploy",
+    "--yes",
+    "git merge-base --is-ancestor",
+    "db_migrations",
+    "--no-deps",
+    "frontend.next",
+    "frontend.previous",
+    "rollback_failed",
+    "indufor_unchanged",
+    "indufor_demo_unchanged",
+]
+```
+
+- [ ] **Step 6: Ejecutar RED**
+
+Run:
+
+```powershell
+py -3.12 -m pytest backend/tests/test_deploy_produccion_fg_main_fasa195.py backend/tests/test_deploy_scripts_contract.py -q
+```
+
+Expected: FAIL porque `scripts/deploy_produccion_fg_main_fasa195.sh` todavía no existe.
+
+- [ ] **Step 7: Commit de tests RED**
+
+```bash
+git add backend/tests/test_deploy_produccion_fg_main_fasa195.py backend/tests/test_deploy_scripts_contract.py
+git commit -m "test(deploy): definir contrato exclusivo de produccion_fg"
+```
+
+### Task 2: Implementar el script main-only
+
+**Files:**
+- Create: `scripts/deploy_produccion_fg_main_fasa195.sh`
+- Test: `backend/tests/test_deploy_produccion_fg_main_fasa195.py`
+
+- [ ] **Step 1: Implementar parsing y constantes no reemplazables**
+
+El script debe comenzar con:
+
+```bash
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+EXPECTED_HOSTNAME="fg-ubuntu"
+REMOTE="origin"
+BRANCH="main"
+SERVICE="produccion_fg"
+CONTAINER="registro_produccion_produccion_fg"
+HEALTH_URL="http://127.0.0.1:18005/health"
+SOURCE_DIR="${SOURCE_DIR:-/srv/apps/registro_produccion}"
+APP_PARENT="${APP_PARENT:-/var/www/html/django/produccion_fg}"
+BACKUP_DIR="${BACKUP_DIR:-${HOME}/deploy-backups/registro_produccion}"
+LOCK_FILE="${LOCK_FILE:-${TMPDIR:-/tmp}/registro_produccion-produccion-fg.lock}"
+```
+
+Aceptar únicamente:
+
+```text
+--check PACKAGE
+--deploy PACKAGE
+--deploy --yes PACKAGE
+```
+
+Cualquier otra combinación termina con código 2 y muestra el uso.
+
+- [ ] **Step 2: Implementar preflight read-only**
+
+El preflight valida hostname, comandos, checkout limpio, paquete, manifiesto y frontend. Después ejecuta:
+
+```bash
+git fetch --prune "$REMOTE"
+target_commit="$(git rev-parse "$REMOTE/$BRANCH")"
+[[ "$release_commit" == "$target_commit" ]] || fail "package commit does not match origin/main"
+git merge-base --is-ancestor "$deployed_commit" "$target_commit" || \
+  fail "deployed commit is not an ancestor of origin/main"
+changed_migrations="$(git diff --name-only "$deployed_commit" "$target_commit" -- db_migrations)"
+[[ -z "$changed_migrations" ]] || fail "database migrations require a separate procedure"
+```
+
+También registra IDs de `indufor` e `indufor_demo`, valida `docker compose config` y no construye ni recrea contenedores en `--check`.
+
+- [ ] **Step 3: Implementar backup, imagen y publicación**
+
+En `--deploy`, luego de confirmar `DEPLOY` o recibir `--yes`:
+
+```bash
+target_image="registro_produccion:${target_commit}"
+docker build --tag "$target_image" .
+docker run --rm "$target_image" python -m compileall -q /app
+docker run --rm "$target_image" python -c "import app.main"
+docker tag "$target_image" registro_produccion:latest
+docker compose -f docker-compose.yml up -d --no-build --no-deps --force-recreate produccion_fg
+```
+
+El frontend del paquete se extrae primero a `frontend.next-${timestamp}`, se valida y se intercambia atómicamente con `frontend`, conservando `frontend.previous-${timestamp}` hasta finalizar.
+
+- [ ] **Step 4: Implementar rollback completo**
+
+El trap de error restaura en orden:
+
+```text
+RELEASE_MANIFEST.txt anterior
+frontend anterior
+tag registro_produccion:latest anterior
+contenedor produccion_fg anterior
+health interno
+```
+
+Registrar `status=rolled_back` sólo si todas las restauraciones pasan; en otro caso `status=rollback_failed` y un error explícito.
+
+- [ ] **Step 5: Implementar evidencia e invariantes**
+
+La salida de éxito incluye exactamente claves estables:
+
+```text
+deploy_status=success
+target_commit=${target_commit}
+target_image=${target_image}
+target_image_id=${target_image_id}
+produccion_fg_health=healthy
+produccion_fg_health_url=http://127.0.0.1:18005/health
+frontend_asset=assets/index-....js
+indufor_unchanged=yes
+indufor_demo_unchanged=yes
+backup_dir=${backup_dir}
+```
+
+- [ ] **Step 6: Ejecutar GREEN**
+
+```powershell
+py -3.12 -m pytest backend/tests/test_deploy_produccion_fg_main_fasa195.py backend/tests/test_deploy_scripts_contract.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Verificar sintaxis Bash en el host real sin ejecutar**
+
+```powershell
+Get-Content -Raw scripts\deploy_produccion_fg_main_fasa195.sh |
+  ssh -o BatchMode=yes fasa_195 'bash -n'
+```
+
+Expected: exit 0, sin salida.
+
+- [ ] **Step 8: Commit de implementación**
+
+```bash
+git add scripts/deploy_produccion_fg_main_fasa195.sh
+git commit -m "feat(deploy): agregar flujo main-only para produccion_fg"
+```
+
+### Task 3: Convertir DEPLOY.md en la guía canónica
+
+**Files:**
+- Modify: `DEPLOY.md`
+- Modify: `docs/DEPLOY_GITHUB_MAIN_RUNBOOK.md`
+- Modify: `backend/tests/test_deploy_scripts_contract.py`
+
+- [ ] **Step 1: Escribir test RED de documentación**
+
+Agregar un test que exija en `DEPLOY.md`:
+
+```python
+required = [
+    "Guía canónica",
+    "origin/main",
+    "únicamente `produccion_fg`",
+    "build_deploy_package.ps1",
+    "deploy_produccion_fg_main_fasa195.sh --check",
+    "deploy_produccion_fg_main_fasa195.sh --deploy",
+    "--no-deps",
+    "No aplica migraciones",
+    "Service Worker",
+    "rollback_failed",
+]
+```
+
+Agregar otro test que exija en el runbook multiinstancia la advertencia `NO usar para el deploy normal de produccion_fg`.
+
+- [ ] **Step 2: Ejecutar RED documental**
+
+```powershell
+py -3.12 -m pytest backend/tests/test_deploy_scripts_contract.py -q
+```
+
+Expected: FAIL por textos todavía ausentes.
+
+- [ ] **Step 3: Reescribir DEPLOY.md**
+
+Orden obligatorio:
+
+```text
+1. Alcance y prohibiciones
+2. Arquitectura y rutas
+3. Requisitos
+4. Checklist local desde main
+5. Generación y subida del paquete
+6. --check remoto
+7. --deploy remoto
+8. Evidencia esperada
+9. Verificación pública y PWA
+10. Rollback y diagnóstico
+11. Migraciones como procedimiento separado
+12. Referencias históricas/multiinstancia
+```
+
+Eliminar credenciales de ejemplo y comandos que impriman `DATABASE_URL` o contraseñas. No documentar `git reset --hard` como flujo normal.
+
+- [ ] **Step 4: Marcar el runbook multiinstancia**
+
+Agregar al inicio de `docs/DEPLOY_GITHUB_MAIN_RUNBOOK.md`:
+
+```markdown
+> **Flujo multiinstancia. NO usar para el deploy normal de `produccion_fg`.**
+> El procedimiento canónico está en [`DEPLOY.md`](../DEPLOY.md).
+```
+
+- [ ] **Step 5: Ejecutar GREEN documental**
+
+```powershell
+py -3.12 -m pytest backend/tests/test_deploy_scripts_contract.py -q
+git diff --check
+```
+
+Expected: PASS y sin errores de whitespace.
+
+- [ ] **Step 6: Commit documental**
+
+```bash
+git add DEPLOY.md docs/DEPLOY_GITHUB_MAIN_RUNBOOK.md backend/tests/test_deploy_scripts_contract.py
+git commit -m "docs(deploy): establecer runbook canónico de produccion_fg"
+```
+
+### Task 4: Validación integral y PR draft
+
+**Files:**
+- Verify: all changed files
+
+- [ ] **Step 1: Ejecutar validaciones completas**
+
+```powershell
+git diff --check origin/main...HEAD
+py -3.12 -m pytest backend/tests/test_deploy_produccion_fg_main_fasa195.py backend/tests/test_deploy_scripts_contract.py -q
+py -3.12 -m compileall backend/app
+Push-Location frontend
+npm test
+npm run build
+Pop-Location
+```
+
+Expected: todos los comandos terminan con código 0.
+
+- [ ] **Step 2: Ejecutar preflight real sin mutar producción**
+
+Después de que la rama esté mergeada en `main`, generar un paquete desde un checkout limpio de `main`, subirlo y ejecutar:
+
+```bash
+cd /srv/apps/registro_produccion
+bash scripts/deploy_produccion_fg_main_fasa195.sh --check \
+  /home/ferreteria/registro_produccion_deploy_5ee50b0.tar.gz
+```
+
+Antes del merge, validar sólo `bash -n` y los tests; no presentar un `--check` de una rama como prueba main-only.
+
+- [ ] **Step 3: Revisar alcance**
+
+```powershell
+git diff --stat origin/main...HEAD
+git diff --name-status origin/main...HEAD
+rg -n "nginx|mysql|DATABASE_URL|indufor_demo|indufor" scripts/deploy_produccion_fg_main_fasa195.sh DEPLOY.md
+```
+
+Confirmar que las menciones de Nginx, MySQL e instancias vecinas son prohibiciones o invariantes, nunca acciones.
+
+- [ ] **Step 4: Push y PR draft**
+
+```powershell
+git push -u origin codex/tarea-deploy-produccion-fg-main
+gh pr create --draft --base main --head codex/tarea-deploy-produccion-fg-main \
+  --title "feat(deploy): flujo exclusivo de produccion_fg desde main" \
+  --body "## Objetivo
+
+Establecer un deploy main-only y exclusivo de produccion_fg.
+
+## Validaciones
+
+- Tests de contrato
+- Sintaxis Bash
+- Frontend tests y build
+
+## Fuera de alcance
+
+- Deploy productivo
+- Migraciones
+- indufor e indufor_demo"
+```
+
+La descripción debe incluir objetivo, alcance, archivos, tests, ausencia de deploy productivo, fuera de alcance y `Closes` sólo si existe un issue asociado.

--- a/docs/superpowers/specs/2026-08-01-produccion-fg-main-deploy-design.md
+++ b/docs/superpowers/specs/2026-08-01-produccion-fg-main-deploy-design.md
@@ -1,0 +1,165 @@
+# Diseño: deploy reproducible de `produccion_fg` desde `main`
+
+## Objetivo
+
+Definir un único procedimiento operativo para que una persona autorizada pueda
+desplegar `produccion_fg` en `fasa_195` desde `origin/main`, con comandos
+copiables, evidencia verificable y rollback automático, sin depender de
+conocimiento previo de la arquitectura.
+
+## Decisiones de alcance
+
+- La única fuente desplegable es `origin/main`.
+- La única instancia que se modifica es `produccion_fg`.
+- Backend y frontend se publican como una misma revisión.
+- No se modifican `indufor`, `indufor_demo`, Nginx, archivos `.env` ni bases de
+  datos.
+- El procedimiento no requiere `sudo`; requiere el usuario SSH autorizado con
+  acceso al repositorio, Docker y al directorio del frontend.
+- Las migraciones de base de datos quedan fuera del deploy normal. Si hay
+  migraciones entre la revisión actualmente publicada y el objetivo, el
+  preflight aborta y exige un procedimiento de migración separado.
+
+## Enfoque elegido
+
+Se agregará un script dedicado a `produccion_fg` y se convertirá `DEPLOY.md` en
+la guía canónica. No se reutilizará el script multiinstancia como entrada
+principal porque actualiza también `indufor` y no publica el frontend estático.
+
+El flujo reutilizará el empaquetado existente para producir un artefacto con:
+
+- aplicación backend;
+- frontend compilado;
+- manifiesto con rama y commit;
+- ausencia verificada de archivos `.env`.
+
+El script remoto validará el artefacto, comparará su commit con `origin/main` y
+actualizará exclusivamente el contenedor y el frontend de `produccion_fg`.
+
+La entrada remota será `scripts/deploy_produccion_fg_main_fasa195.sh`, con una
+interfaz cerrada:
+
+```bash
+bash scripts/deploy_produccion_fg_main_fasa195.sh --check /ruta/al/paquete.tar.gz
+bash scripts/deploy_produccion_fg_main_fasa195.sh --deploy /ruta/al/paquete.tar.gz
+bash scripts/deploy_produccion_fg_main_fasa195.sh --deploy --yes /ruta/al/paquete.tar.gz
+```
+
+`--yes` sólo habilita ejecución no interactiva después de un `--check`
+exitoso; no permite cambiar rama, host, servicio ni commit objetivo.
+
+## Flujo operativo
+
+### 1. Preparación local
+
+La persona operadora parte de un checkout limpio en `main`, actualiza
+referencias y confirma que `HEAD == origin/main`. Ejecuta las validaciones del
+backend y frontend y genera el paquete con el script de build existente.
+
+El paquete declara el commit completo en `RELEASE_MANIFEST.txt`. No se permite
+usar `-AllowAnyBranch` en el procedimiento oficial.
+
+### 2. Preflight remoto
+
+Antes de modificar producción, el script:
+
+1. confirma hostname `fg-ubuntu`;
+2. confirma acceso a Git, Docker y `curl`;
+3. confirma checkout remoto limpio;
+4. ejecuta `git fetch --prune origin`;
+5. confirma que el commit del paquete coincide exactamente con `origin/main`;
+6. valida estructura, hash y manifiesto del paquete;
+7. rechaza archivos `.env`;
+8. confirma que existen el contenedor, el health interno y el frontend actual;
+9. detecta cambios bajo `db_migrations/` y aborta si existen;
+10. registra IDs del contenedor y de las imágenes de `indufor` e
+    `indufor_demo` para comprobar que no cambian.
+
+El modo `--check` no cambia ramas, imágenes, contenedores ni archivos
+publicados.
+
+### 3. Deploy
+
+Con confirmación explícita, el script:
+
+1. crea un backup en el home del usuario autorizado;
+2. etiqueta la imagen activa para rollback;
+3. construye una imagen inmutable etiquetada con el SHA completo objetivo;
+4. valida `compileall` e importación de `app.main` dentro de la imagen;
+5. recrea sólo `produccion_fg` con `--no-deps`;
+6. espera estado Docker `healthy` y HTTP 200 en `127.0.0.1:18005/health`;
+7. publica el frontend mediante intercambio atómico `frontend.next` →
+   `frontend`, conservando `frontend.previous` durante la validación;
+8. escribe el nuevo `RELEASE_MANIFEST.txt`;
+9. verifica que `indufor` e `indufor_demo` mantengan sus IDs originales.
+
+No se ejecutan migraciones ni comandos contra MySQL.
+
+### 4. Evidencia posterior
+
+La salida final informa:
+
+- commit objetivo;
+- ID real de la imagen activa;
+- estado y health de `produccion_fg`;
+- asset principal del frontend;
+- ubicación del backup y manifiesto;
+- confirmación de que `indufor` e `indufor_demo` no cambiaron.
+
+Desde una máquina externa a la LAN se valida además HTTP 200 del sitio público
+y que el HTML referencia el mismo asset generado por el paquete.
+
+## Rollback
+
+Ante cualquier fallo posterior al inicio del cambio, el script restaura:
+
+- la imagen anterior de `produccion_fg`;
+- el frontend anterior;
+- el manifiesto anterior.
+
+Después vuelve a comprobar el health interno. El manifiesto registra
+`status=rolled_back` o `status=rollback_failed`. Si el rollback falla, el
+script termina con error y conserva todos los artefactos para diagnóstico; no
+intenta modificar Nginx, `.env`, bases ni las otras instancias.
+
+## Documentación canónica
+
+`DEPLOY.md` será el punto de entrada y contendrá:
+
+- alcance y arquitectura mínima;
+- requisitos de acceso y herramientas;
+- checklist previa;
+- comandos locales y remotos copiables;
+- ejemplos de `--check` y `--deploy`;
+- evidencia esperada;
+- rollback y diagnóstico;
+- actualización de PWA/Service Worker;
+- advertencia de que `docs/DEPLOY_GITHUB_MAIN_RUNBOOK.md` corresponde al flujo
+  multiinstancia y no debe usarse para desplegar sólo `produccion_fg`.
+
+## Validación y tests
+
+Se agregarán tests de contrato para verificar que el script:
+
+- fija la fuente en `origin/main`;
+- rechaza ramas y commits distintos;
+- sólo recrea `produccion_fg` con `--no-deps`;
+- no contiene comandos de Nginx, MySQL ni cambios de `.env`;
+- aborta ante migraciones;
+- crea backup y rollback de imagen, frontend y manifiesto;
+- comprueba invariantes de `indufor` e `indufor_demo`;
+- produce evidencia del commit, imagen, health, asset y backup.
+
+Validaciones finales mínimas:
+
+```text
+git diff --check
+tests de contrato del deploy
+python -m compileall backend/app
+npm test
+npm run build
+bash -n del script en fasa_195
+ejecución de --check en fasa_195
+```
+
+La implementación termina en un PR draft separado del fix funcional #109.

--- a/scripts/build_deploy_package.ps1
+++ b/scripts/build_deploy_package.ps1
@@ -41,107 +41,160 @@ if ($TrackedChanges) {
     throw "Hay cambios trackeados sin commitear. Commit/revert antes de empaquetar."
 }
 
-if (-not $SkipTests) {
-    Run-Step "Backend tests" {
-        Push-Location "backend"
-        try {
-            python -m pytest
-        } finally {
-            Pop-Location
-        }
-    }
-
-    Run-Step "Frontend tests" {
-        Push-Location "frontend"
-        try {
-            npm run test
-        } finally {
-            Pop-Location
-        }
-    }
-}
-
-Run-Step "Frontend build" {
-    Push-Location "frontend"
-    try {
-        npm run build
-    } finally {
-        Pop-Location
-    }
-}
-
 $OutputPath = Join-Path $RepoRoot $OutputDir
 $StageRoot = Join-Path $OutputPath "stage"
 $Stage = Join-Path $StageRoot "registro_produccion"
 $PackageName = "registro_produccion_deploy_$ShortCommit.tar.gz"
 $PackagePath = Join-Path $OutputPath $PackageName
-
-if (Test-Path $StageRoot) {
-    Remove-Item -LiteralPath $StageRoot -Recurse -Force
-}
-
-New-Item -ItemType Directory -Force -Path $Stage | Out-Null
-New-Item -ItemType Directory -Force -Path (Join-Path $Stage "backend") | Out-Null
-New-Item -ItemType Directory -Force -Path (Join-Path $Stage "frontend") | Out-Null
-New-Item -ItemType Directory -Force -Path (Join-Path $Stage "backend/app") | Out-Null
-New-Item -ItemType Directory -Force -Path (Join-Path $Stage "frontend/dist") | Out-Null
-New-Item -ItemType Directory -Force -Path (Join-Path $Stage "db_migrations") | Out-Null
-
-Run-Step "Copiando backend/app" {
-    Copy-Item -Recurse -Force "backend/app/*" (Join-Path $Stage "backend/app")
-    Copy-Item -Force "backend/requirements.txt" (Join-Path $Stage "backend/requirements.txt")
-}
-
-Run-Step "Copiando frontend/dist" {
-    Copy-Item -Recurse -Force "frontend/dist/*" (Join-Path $Stage "frontend/dist")
-}
-
-Run-Step "Copiando deploy script" {
-    Copy-Item -Force "deploy_produccion_fg.sh" (Join-Path $Stage "deploy_produccion_fg.sh")
-}
-
-Run-Step "Copiando migraciones DB" {
-    Copy-Item -Force -Path "db_migrations\*.sql" -Destination "$Stage\db_migrations\"
-}
-
-$Manifest = @(
-    "name=registro_produccion"
-    "commit=$Commit"
-    "short_commit=$ShortCommit"
-    "branch=$Branch"
-    "built_at=$((Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ"))"
+$TempRoot = Join-Path ([System.IO.Path]::GetTempPath()) (
+    "registro_produccion_package_" + [guid]::NewGuid().ToString("N")
 )
-$Manifest | Set-Content -Encoding UTF8 (Join-Path $Stage "RELEASE_MANIFEST.txt")
+$CleanSource = Join-Path $TempRoot "source"
+$SourceArchive = Join-Path $TempRoot "source.tar"
 
-$ForbiddenEnvFiles = @(
-    "backend/.env",
-    "frontend/.env"
-)
+try {
+    New-Item -ItemType Directory -Force -Path $CleanSource | Out-Null
 
-foreach ($Forbidden in $ForbiddenEnvFiles) {
-    if (Test-Path (Join-Path $Stage $Forbidden)) {
-        throw "El staging contiene $Forbidden. No empaqueto secretos."
+    Run-Step "Materializando el commit $Commit" {
+        git archive --format=tar --output=$SourceArchive $Commit
+        if ($LASTEXITCODE -ne 0) {
+            throw "git archive fallo con codigo $LASTEXITCODE."
+        }
+        tar -xf $SourceArchive -C $CleanSource
+        if ($LASTEXITCODE -ne 0) {
+            throw "No se pudo extraer el commit materializado."
+        }
+    }
+
+    Run-Step "Instalando dependencias frontend desde lockfile" {
+        Push-Location (Join-Path $CleanSource "frontend")
+        try {
+            npm ci
+            if ($LASTEXITCODE -ne 0) {
+                throw "npm ci fallo con codigo $LASTEXITCODE."
+            }
+        } finally {
+            Pop-Location
+        }
+    }
+
+    if (-not $SkipTests) {
+        Run-Step "Backend tests" {
+            Push-Location (Join-Path $CleanSource "backend")
+            try {
+                python -m pytest
+                if ($LASTEXITCODE -ne 0) {
+                    throw "Backend tests fallaron con codigo $LASTEXITCODE."
+                }
+            } finally {
+                Pop-Location
+            }
+        }
+
+        Run-Step "Frontend tests" {
+            Push-Location (Join-Path $CleanSource "frontend")
+            try {
+                npm run test
+                if ($LASTEXITCODE -ne 0) {
+                    throw "Frontend tests fallaron con codigo $LASTEXITCODE."
+                }
+            } finally {
+                Pop-Location
+            }
+        }
+    }
+
+    Run-Step "Frontend build" {
+        Push-Location (Join-Path $CleanSource "frontend")
+        try {
+            npm run build
+            if ($LASTEXITCODE -ne 0) {
+                throw "Frontend build fallo con codigo $LASTEXITCODE."
+            }
+        } finally {
+            Pop-Location
+        }
+    }
+
+    if (Test-Path $StageRoot) {
+        Remove-Item -LiteralPath $StageRoot -Recurse -Force
+    }
+
+    New-Item -ItemType Directory -Force -Path $Stage | Out-Null
+    New-Item -ItemType Directory -Force -Path (Join-Path $Stage "backend") | Out-Null
+    New-Item -ItemType Directory -Force -Path (Join-Path $Stage "frontend") | Out-Null
+    New-Item -ItemType Directory -Force -Path (Join-Path $Stage "backend/app") | Out-Null
+    New-Item -ItemType Directory -Force -Path (Join-Path $Stage "frontend/dist") | Out-Null
+    New-Item -ItemType Directory -Force -Path (Join-Path $Stage "db_migrations") | Out-Null
+
+    Run-Step "Copiando backend/app desde el commit materializado" {
+        Copy-Item -Recurse -Force -Path (Join-Path $CleanSource "backend/app/*") `
+            -Destination (Join-Path $Stage "backend/app")
+        Copy-Item -Force -Path (Join-Path $CleanSource "backend/requirements.txt") `
+            -Destination (Join-Path $Stage "backend/requirements.txt")
+    }
+
+    Run-Step "Copiando frontend/dist desde el commit materializado" {
+        Copy-Item -Recurse -Force -Path (Join-Path $CleanSource "frontend/dist/*") `
+            -Destination (Join-Path $Stage "frontend/dist")
+    }
+
+    Run-Step "Copiando deploy script" {
+        Copy-Item -Force -Path (Join-Path $CleanSource "deploy_produccion_fg.sh") `
+            -Destination (Join-Path $Stage "deploy_produccion_fg.sh")
+    }
+
+    Run-Step "Copiando migraciones DB" {
+        Copy-Item -Force -Path (Join-Path $CleanSource "db_migrations\*.sql") `
+            -Destination "$Stage\db_migrations\"
+    }
+
+    $Manifest = @(
+        "name=registro_produccion"
+        "commit=$Commit"
+        "short_commit=$ShortCommit"
+        "branch=$Branch"
+        "built_at=$((Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ"))"
+    )
+    $Manifest | Set-Content -Encoding UTF8 (Join-Path $Stage "RELEASE_MANIFEST.txt")
+
+    $ForbiddenEnvFiles = @(
+        "backend/.env",
+        "frontend/.env"
+    )
+
+    foreach ($Forbidden in $ForbiddenEnvFiles) {
+        if (Test-Path (Join-Path $Stage $Forbidden)) {
+            throw "El staging contiene $Forbidden. No empaqueto secretos."
+        }
+    }
+
+    Get-ChildItem -Path $Stage -Directory -Recurse -Force -Filter "__pycache__" |
+        Remove-Item -Recurse -Force
+
+    Run-Step "Generando paquete" {
+        New-Item -ItemType Directory -Force -Path $OutputPath | Out-Null
+        if (Test-Path $PackagePath) {
+            Remove-Item -LiteralPath $PackagePath -Force
+        }
+        Push-Location $Stage
+        try {
+            tar -czf $PackagePath backend frontend db_migrations deploy_produccion_fg.sh RELEASE_MANIFEST.txt
+            if ($LASTEXITCODE -ne 0) {
+                throw "No se pudo generar el paquete."
+            }
+        } finally {
+            Pop-Location
+        }
+    }
+
+    $Hash = (Get-FileHash $PackagePath -Algorithm SHA256).Hash.ToLowerInvariant()
+    Write-Host "==> Paquete listo"
+    Write-Host "Path: $PackagePath"
+    Write-Host "Commit: $Commit"
+    Write-Host "SHA256: $Hash"
+} finally {
+    if (Test-Path $TempRoot) {
+        Remove-Item -LiteralPath $TempRoot -Recurse -Force
     }
 }
-
-Get-ChildItem -Path $Stage -Directory -Recurse -Force -Filter "__pycache__" |
-    Remove-Item -Recurse -Force
-
-Run-Step "Generando paquete" {
-    New-Item -ItemType Directory -Force -Path $OutputPath | Out-Null
-    if (Test-Path $PackagePath) {
-        Remove-Item -LiteralPath $PackagePath -Force
-    }
-    Push-Location $Stage
-    try {
-        tar -czf $PackagePath backend frontend db_migrations deploy_produccion_fg.sh RELEASE_MANIFEST.txt
-    } finally {
-        Pop-Location
-    }
-}
-
-$Hash = (Get-FileHash $PackagePath -Algorithm SHA256).Hash.ToLowerInvariant()
-Write-Host "==> Paquete listo"
-Write-Host "Path: $PackagePath"
-Write-Host "Commit: $Commit"
-Write-Host "SHA256: $Hash"

--- a/scripts/deploy_produccion_fg_main_fasa195.sh
+++ b/scripts/deploy_produccion_fg_main_fasa195.sh
@@ -1,0 +1,338 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+EXPECTED_HOSTNAME="fg-ubuntu"
+REMOTE="origin"
+BRANCH="main"
+SERVICE="produccion_fg"
+CONTAINER="registro_produccion_produccion_fg"
+HEALTH_URL="http://127.0.0.1:18005/health"
+SOURCE_DIR="${SOURCE_DIR:-/srv/apps/registro_produccion}"
+APP_PARENT="${APP_PARENT:-/var/www/html/django/produccion_fg}"
+BACKUP_DIR="${BACKUP_DIR:-${HOME}/deploy-backups/registro_produccion}"
+LOCK_FILE="${LOCK_FILE:-${TMPDIR:-/tmp}/registro_produccion-produccion-fg.lock}"
+
+usage() {
+  printf '%s\n' \
+    "Usage: $0 --check PACKAGE" \
+    "       $0 --deploy PACKAGE" \
+    "       $0 --deploy --yes PACKAGE"
+}
+
+fail() {
+  printf 'ERROR: %s\n' "$*" >&2
+  exit 1
+}
+
+log() {
+  printf '==> %s\n' "$*"
+}
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || fail "missing command: $1"
+}
+
+mode=""
+assume_yes=false
+package=""
+
+for argument in "$@"; do
+  case "$argument" in
+    --check|--deploy)
+      [[ -z "$mode" ]] || { usage >&2; exit 2; }
+      mode="$argument"
+      ;;
+    --yes)
+      assume_yes=true
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    -*)
+      printf 'ERROR: unknown argument: %s\n' "$argument" >&2
+      usage >&2
+      exit 2
+      ;;
+    *)
+      [[ -z "$package" ]] || { usage >&2; exit 2; }
+      package="$argument"
+      ;;
+  esac
+done
+
+[[ -n "$mode" && -n "$package" ]] || { usage >&2; exit 2; }
+if [[ "$mode" == "--check" && "$assume_yes" == true ]]; then
+  fail "--yes is only valid with --deploy"
+fi
+
+tmp_dir=""
+manifest=""
+previous_image_id=""
+rollback_tag=""
+previous_frontend=""
+failed_frontend=""
+previous_manifest=""
+failed_manifest=""
+frontend_switched=false
+manifest_switched=false
+deploy_started=false
+recovery_started=false
+
+cleanup() {
+  if [[ -n "$tmp_dir" && -d "$tmp_dir" ]]; then
+    rm -rf "$tmp_dir"
+  fi
+}
+trap cleanup EXIT
+
+wait_healthy() {
+  local status
+  for _ in {1..30}; do
+    status="$(docker inspect -f '{{.State.Health.Status}}' "$CONTAINER" 2>/dev/null || true)"
+    if [[ "$status" == "healthy" ]] && curl -fsS "$HEALTH_URL" >/dev/null; then
+      return 0
+    fi
+    sleep 2
+  done
+  printf 'ERROR: %s did not become healthy\n' "$CONTAINER" >&2
+  return 1
+}
+
+recover_and_exit() {
+  local original_exit="$1"
+  local recovery_failed=false
+
+  if [[ "$recovery_started" == true ]]; then
+    exit "$original_exit"
+  fi
+  recovery_started=true
+  trap - ERR INT TERM
+  set +e
+
+  printf 'ERROR: deploy failed; starting rollback\n' >&2
+
+  if [[ "$manifest_switched" == true ]]; then
+    if ! mv "$APP_PARENT/RELEASE_MANIFEST.txt" "$failed_manifest" ||
+       ! mv "$previous_manifest" "$APP_PARENT/RELEASE_MANIFEST.txt"; then
+      printf 'ERROR: failed to restore release manifest\n' >&2
+      recovery_failed=true
+    fi
+  fi
+
+  if [[ "$frontend_switched" == true ]]; then
+    if ! mv "$APP_PARENT/frontend" "$failed_frontend" ||
+       ! mv "$previous_frontend" "$APP_PARENT/frontend"; then
+      printf 'ERROR: failed to restore frontend\n' >&2
+      recovery_failed=true
+    fi
+  fi
+
+  if [[ "$deploy_started" == true ]]; then
+    if ! docker tag "$previous_image_id" registro_produccion:latest ||
+       ! docker compose -f docker-compose.yml up -d --no-build --no-deps --force-recreate "$SERVICE" ||
+       ! wait_healthy; then
+      printf 'ERROR: failed to restore produccion_fg image or health\n' >&2
+      recovery_failed=true
+    fi
+  fi
+
+  if [[ -n "$manifest" && -f "$manifest" ]]; then
+    if [[ "$recovery_failed" == true ]]; then
+      printf 'status=rollback_failed\n' >>"$manifest"
+    else
+      printf 'status=rolled_back\n' >>"$manifest"
+    fi
+  fi
+
+  if [[ "$recovery_failed" == true ]]; then
+    printf 'ERROR: rollback failed; inspect backup: %s\n' "${manifest:-not-created}" >&2
+  fi
+  exit "$original_exit"
+}
+
+handle_error() {
+  local exit_code=$?
+  recover_and_exit "$exit_code"
+}
+
+handle_signal() {
+  recover_and_exit 130
+}
+
+preflight() {
+  [[ "$(hostname)" == "$EXPECTED_HOSTNAME" ]] ||
+    fail "hostname must be $EXPECTED_HOSTNAME"
+
+  for command_name in git docker curl flock tar sha256sum awk grep mktemp; do
+    require_command "$command_name"
+  done
+
+  [[ -d "$SOURCE_DIR" ]] || fail "application checkout not found: $SOURCE_DIR"
+  cd "$SOURCE_DIR"
+  git rev-parse --is-inside-work-tree >/dev/null 2>&1 ||
+    fail "application checkout not found: $SOURCE_DIR"
+  [[ -z "$(git status --porcelain)" ]] || fail "checkout is not clean"
+  [[ -f docker-compose.yml ]] || fail "missing docker-compose.yml"
+  [[ -f "$package" ]] || fail "package not found: $package"
+  [[ -d "$APP_PARENT/frontend" ]] || fail "published frontend not found"
+  [[ -f "$APP_PARENT/frontend/index.html" ]] || fail "published frontend index not found"
+  [[ -f "$APP_PARENT/RELEASE_MANIFEST.txt" ]] || fail "release manifest not found"
+
+  package="$(cd "$(dirname "$package")" && pwd)/$(basename "$package")"
+  package_sha="$(sha256sum "$package" | awk '{print $1}')"
+  package_listing="$(tar -tzf "$package")"
+  [[ -n "$package_listing" ]] || fail "package is empty"
+  if grep -Eq '(^/|(^|/)\.\.(/|$))' <<<"$package_listing"; then
+    fail "package contains unsafe paths"
+  fi
+  if grep -Eq '(^|/)\.env($|\.)' <<<"$package_listing"; then
+    fail "package contains forbidden env files"
+  fi
+
+  tmp_dir="$(mktemp -d)"
+  tar -xzf "$package" -C "$tmp_dir"
+  [[ -f "$tmp_dir/RELEASE_MANIFEST.txt" ]] || fail "package manifest missing"
+  [[ -d "$tmp_dir/backend/app" ]] || fail "package backend missing"
+  [[ -f "$tmp_dir/backend/requirements.txt" ]] || fail "package requirements missing"
+  [[ -f "$tmp_dir/frontend/dist/index.html" ]] || fail "package frontend missing"
+
+  release_commit="$(awk -F= '$1 == "commit" {print $2}' "$tmp_dir/RELEASE_MANIFEST.txt" | tr -d '\r')"
+  release_branch="$(awk -F= '$1 == "branch" {print $2}' "$tmp_dir/RELEASE_MANIFEST.txt" | tr -d '\r')"
+  [[ -n "$release_commit" ]] || fail "package manifest has no commit"
+  [[ "$release_branch" == "$BRANCH" ]] || fail "package was not built from main"
+
+  deployed_commit="$(awk -F= '$1 == "commit" {print $2}' "$APP_PARENT/RELEASE_MANIFEST.txt" | tr -d '\r')"
+  [[ -n "$deployed_commit" ]] || fail "deployed release manifest has no commit"
+
+  git fetch --prune "$REMOTE"
+  target_commit="$(git rev-parse "$REMOTE/$BRANCH")"
+  source_commit="$(git rev-parse HEAD)"
+  [[ "$release_commit" == "$target_commit" ]] ||
+    fail "package commit does not match origin/main"
+  [[ "$source_commit" == "$target_commit" ]] ||
+    fail "source checkout does not match origin/main"
+  git merge-base --is-ancestor "$deployed_commit" "$target_commit" ||
+    fail "deployed commit is not an ancestor of origin/main"
+  changed_migrations="$(git diff --name-only "$deployed_commit" "$target_commit" -- db_migrations)"
+  [[ -z "$changed_migrations" ]] ||
+    fail "database migrations require a separate procedure"
+
+  docker compose -f docker-compose.yml config --services | grep -Fxq "$SERVICE" ||
+    fail "compose service missing: $SERVICE"
+  previous_image_id="$(docker inspect -f '{{.Image}}' "$CONTAINER")"
+  [[ -n "$previous_image_id" ]] || fail "current produccion_fg image is unknown"
+  [[ "$(docker inspect -f '{{.State.Health.Status}}' "$CONTAINER")" == "healthy" ]] ||
+    fail "current produccion_fg container is not healthy"
+  curl -fsS "$HEALTH_URL" >/dev/null || fail "current produccion_fg health endpoint failed"
+
+  indufor_before="$(docker inspect -f '{{.Id}}|{{.Image}}' registro_produccion_indufor)"
+  demo_before="$(docker inspect -f '{{.Id}}|{{.Image}}' registro_produccion_indufor_demo)"
+
+  log "Preflight successful"
+  printf 'deployed_commit=%s\n' "$deployed_commit"
+  printf 'target_commit=%s\n' "$target_commit"
+  printf 'package_sha256=%s\n' "$package_sha"
+}
+
+exec 9>"$LOCK_FILE"
+flock -n 9 || fail "another produccion_fg deploy is running"
+preflight
+
+if [[ "$mode" == "--check" ]]; then
+  exit 0
+fi
+
+if [[ "$assume_yes" != true ]]; then
+  [[ -t 0 ]] || fail "--deploy requires an interactive terminal or --yes"
+  read -r -p "Type DEPLOY to continue: " answer
+  [[ "$answer" == "DEPLOY" ]] || fail "deployment cancelled"
+fi
+
+timestamp="$(date -u +%Y%m%dT%H%M%SZ)"
+mkdir -p "$BACKUP_DIR"
+manifest="$BACKUP_DIR/deploy_${timestamp}_${target_commit}.env"
+rollback_tag="registro_produccion:rollback-${timestamp}"
+previous_frontend="$APP_PARENT/frontend.previous-${timestamp}"
+failed_frontend="$APP_PARENT/frontend.failed-${timestamp}"
+previous_manifest="$APP_PARENT/RELEASE_MANIFEST.previous-${timestamp}.txt"
+failed_manifest="$APP_PARENT/RELEASE_MANIFEST.failed-${timestamp}.txt"
+staging_frontend="$APP_PARENT/frontend.next-${timestamp}"
+
+tar -czf "$BACKUP_DIR/frontend_${timestamp}_${deployed_commit}.tar.gz" -C "$APP_PARENT" frontend
+cp "$APP_PARENT/RELEASE_MANIFEST.txt" "$BACKUP_DIR/RELEASE_MANIFEST_${timestamp}_${deployed_commit}.txt"
+printf '%s\n' \
+  "deployed_commit=$deployed_commit" \
+  "previous_image_id=$previous_image_id" \
+  "target_commit=$target_commit" \
+  "package_sha256=$package_sha" \
+  "started_at=$timestamp" >"$manifest"
+chmod 600 "$manifest"
+docker tag "$previous_image_id" "$rollback_tag"
+
+mkdir "$staging_frontend"
+cp -a "$tmp_dir/frontend/dist/." "$staging_frontend/"
+grep -qi '<div id="app"></div>' "$staging_frontend/index.html" ||
+  fail "staged frontend does not contain app marker"
+frontend_asset="$(grep -oE 'assets/index-[A-Za-z0-9_-]+\.js' "$staging_frontend/index.html" | head -1)"
+[[ -n "$frontend_asset" ]] || fail "staged frontend main asset not found"
+
+trap handle_error ERR
+trap handle_signal INT TERM
+
+target_image="registro_produccion:${target_commit}"
+log "Building immutable image $target_image"
+docker build --tag "$target_image" .
+docker run --rm "$target_image" python -m compileall -q /app
+docker run --rm "$target_image" python -c "import app.main"
+target_image_id="$(docker image inspect "$target_image" --format '{{.Id}}')"
+
+docker tag "$target_image" registro_produccion:latest
+deploy_started=true
+docker compose -f docker-compose.yml up -d --no-build --no-deps --force-recreate "$SERVICE"
+wait_healthy
+[[ "$(docker inspect -f '{{.Image}}' "$CONTAINER")" == "$target_image_id" ]] ||
+  fail "running image does not match target image"
+
+mv "$APP_PARENT/frontend" "$previous_frontend"
+mv "$staging_frontend" "$APP_PARENT/frontend"
+frontend_switched=true
+
+printf '%s\n' \
+  "name=registro_produccion" \
+  "commit=$target_commit" \
+  "short_commit=${target_commit:0:7}" \
+  "branch=$BRANCH" \
+  "built_at=$timestamp" >"$APP_PARENT/RELEASE_MANIFEST.next-${timestamp}.txt"
+mv "$APP_PARENT/RELEASE_MANIFEST.txt" "$previous_manifest"
+mv "$APP_PARENT/RELEASE_MANIFEST.next-${timestamp}.txt" "$APP_PARENT/RELEASE_MANIFEST.txt"
+manifest_switched=true
+
+[[ "$(grep -oE 'assets/index-[A-Za-z0-9_-]+\.js' "$APP_PARENT/frontend/index.html" | head -1)" == "$frontend_asset" ]] ||
+  fail "published frontend asset does not match package"
+wait_healthy
+
+indufor_after="$(docker inspect -f '{{.Id}}|{{.Image}}' registro_produccion_indufor)"
+demo_after="$(docker inspect -f '{{.Id}}|{{.Image}}' registro_produccion_indufor_demo)"
+[[ "$indufor_after" == "$indufor_before" ]] || fail "indufor changed during deploy"
+[[ "$demo_after" == "$demo_before" ]] || fail "indufor_demo changed during deploy"
+
+printf '%s\n' \
+  "target_image=$target_image" \
+  "target_image_id=$target_image_id" \
+  "frontend_asset=$frontend_asset" \
+  "status=success" \
+  "completed_at=$(date -u +%Y%m%dT%H%M%SZ)" >>"$manifest"
+trap - ERR INT TERM
+
+printf '%s\n' \
+  "deploy_status=success" \
+  "target_commit=$target_commit" \
+  "target_image=$target_image" \
+  "target_image_id=$target_image_id" \
+  "produccion_fg_health=healthy" \
+  "produccion_fg_health_url=$HEALTH_URL" \
+  "frontend_asset=$frontend_asset" \
+  "indufor_unchanged=yes" \
+  "indufor_demo_unchanged=yes" \
+  "backup_dir=$BACKUP_DIR"

--- a/scripts/deploy_produccion_fg_main_fasa195.sh
+++ b/scripts/deploy_produccion_fg_main_fasa195.sh
@@ -67,6 +67,7 @@ if [[ "$mode" == "--check" && "$assume_yes" == true ]]; then
 fi
 
 tmp_dir=""
+compose_override=""
 manifest=""
 previous_image_id=""
 rollback_tag=""
@@ -80,6 +81,9 @@ deploy_started=false
 recovery_started=false
 
 cleanup() {
+  if [[ -n "$compose_override" && -f "$compose_override" ]]; then
+    rm -f "$compose_override"
+  fi
   if [[ -n "$tmp_dir" && -d "$tmp_dir" ]]; then
     rm -rf "$tmp_dir"
   fi
@@ -97,6 +101,18 @@ wait_healthy() {
   done
   printf 'ERROR: %s did not become healthy\n' "$CONTAINER" >&2
   return 1
+}
+
+write_compose_override() {
+  local image_ref="$1"
+  printf 'services:\n  %s:\n    image: "%s"\n' "$SERVICE" "$image_ref" >"$compose_override"
+}
+
+recreate_produccion_fg() {
+  local image_ref="$1"
+  write_compose_override "$image_ref"
+  docker compose -f docker-compose.yml -f "$compose_override" \
+    up -d --no-build --no-deps --force-recreate "$SERVICE"
 }
 
 recover_and_exit() {
@@ -137,9 +153,9 @@ recover_and_exit() {
   fi
 
   if [[ "$deploy_started" == true ]]; then
-    if ! docker tag "$previous_image_id" registro_produccion:latest ||
-       ! docker compose -f docker-compose.yml up -d --no-build --no-deps --force-recreate "$SERVICE" ||
-       ! wait_healthy; then
+    if ! recreate_produccion_fg "$rollback_tag" ||
+       ! wait_healthy ||
+       [[ "$(docker inspect -f '{{.Image}}' "$CONTAINER")" != "$previous_image_id" ]]; then
       printf 'ERROR: failed to restore produccion_fg image or health\n' >&2
       recovery_failed=true
     fi
@@ -204,6 +220,10 @@ preflight() {
   [[ -d "$tmp_dir/backend/app" ]] || fail "package backend missing"
   [[ -f "$tmp_dir/backend/requirements.txt" ]] || fail "package requirements missing"
   [[ -f "$tmp_dir/frontend/dist/index.html" ]] || fail "package frontend missing"
+  frontend_asset="$(grep -oE 'assets/index-[A-Za-z0-9_-]+\.js' "$tmp_dir/frontend/dist/index.html" | head -1)"
+  [[ -n "$frontend_asset" ]] || fail "package frontend main asset not found"
+  [[ -f "$tmp_dir/frontend/dist/$frontend_asset" ]] ||
+    fail "package frontend asset not found: $frontend_asset"
 
   release_commit="$(awk -F= '$1 == "commit" {print $2}' "$tmp_dir/RELEASE_MANIFEST.txt" | tr -d '\r')"
   release_branch="$(awk -F= '$1 == "branch" {print $2}' "$tmp_dir/RELEASE_MANIFEST.txt" | tr -d '\r')"
@@ -259,6 +279,7 @@ fi
 
 timestamp="$(date -u +%Y%m%dT%H%M%SZ)"
 mkdir -p "$BACKUP_DIR"
+compose_override="$(mktemp)"
 manifest="$BACKUP_DIR/deploy_${timestamp}_${target_commit}.env"
 rollback_tag="registro_produccion:rollback-${timestamp}"
 previous_frontend="$APP_PARENT/frontend.previous-${timestamp}"
@@ -282,8 +303,8 @@ mkdir "$staging_frontend"
 cp -a "$tmp_dir/frontend/dist/." "$staging_frontend/"
 grep -qi '<div id="app"></div>' "$staging_frontend/index.html" ||
   fail "staged frontend does not contain app marker"
-frontend_asset="$(grep -oE 'assets/index-[A-Za-z0-9_-]+\.js' "$staging_frontend/index.html" | head -1)"
-[[ -n "$frontend_asset" ]] || fail "staged frontend main asset not found"
+[[ -f "$staging_frontend/$frontend_asset" ]] ||
+  fail "staged frontend asset not found: $frontend_asset"
 
 trap handle_error ERR
 trap handle_signal INT TERM
@@ -295,9 +316,8 @@ docker run --rm "$target_image" python -m compileall -q /app
 docker run --rm "$target_image" python -c "import app.main"
 target_image_id="$(docker image inspect "$target_image" --format '{{.Id}}')"
 
-docker tag "$target_image" registro_produccion:latest
 deploy_started=true
-docker compose -f docker-compose.yml up -d --no-build --no-deps --force-recreate "$SERVICE"
+recreate_produccion_fg "$target_image"
 wait_healthy
 [[ "$(docker inspect -f '{{.Image}}' "$CONTAINER")" == "$target_image_id" ]] ||
   fail "running image does not match target image"
@@ -318,6 +338,8 @@ mv "$APP_PARENT/RELEASE_MANIFEST.next-${timestamp}.txt" "$APP_PARENT/RELEASE_MAN
 
 [[ "$(grep -oE 'assets/index-[A-Za-z0-9_-]+\.js' "$APP_PARENT/frontend/index.html" | head -1)" == "$frontend_asset" ]] ||
   fail "published frontend asset does not match package"
+[[ -f "$APP_PARENT/frontend/$frontend_asset" ]] ||
+  fail "published frontend asset not found: $frontend_asset"
 wait_healthy
 
 indufor_after="$(docker inspect -f '{{.Id}}|{{.Image}}' registro_produccion_indufor)"

--- a/scripts/deploy_produccion_fg_main_fasa195.sh
+++ b/scripts/deploy_produccion_fg_main_fasa195.sh
@@ -74,8 +74,8 @@ previous_frontend=""
 failed_frontend=""
 previous_manifest=""
 failed_manifest=""
-frontend_switched=false
-manifest_switched=false
+frontend_previous_created=false
+manifest_previous_created=false
 deploy_started=false
 recovery_started=false
 
@@ -112,17 +112,25 @@ recover_and_exit() {
 
   printf 'ERROR: deploy failed; starting rollback\n' >&2
 
-  if [[ "$manifest_switched" == true ]]; then
-    if ! mv "$APP_PARENT/RELEASE_MANIFEST.txt" "$failed_manifest" ||
-       ! mv "$previous_manifest" "$APP_PARENT/RELEASE_MANIFEST.txt"; then
+  if [[ "$manifest_previous_created" == true ]]; then
+    if [[ -f "$APP_PARENT/RELEASE_MANIFEST.txt" ]] &&
+       ! mv "$APP_PARENT/RELEASE_MANIFEST.txt" "$failed_manifest"; then
+      printf 'ERROR: failed to preserve failed release manifest\n' >&2
+      recovery_failed=true
+    fi
+    if ! mv "$previous_manifest" "$APP_PARENT/RELEASE_MANIFEST.txt"; then
       printf 'ERROR: failed to restore release manifest\n' >&2
       recovery_failed=true
     fi
   fi
 
-  if [[ "$frontend_switched" == true ]]; then
-    if ! mv "$APP_PARENT/frontend" "$failed_frontend" ||
-       ! mv "$previous_frontend" "$APP_PARENT/frontend"; then
+  if [[ "$frontend_previous_created" == true ]]; then
+    if [[ -d "$APP_PARENT/frontend" ]] &&
+       ! mv "$APP_PARENT/frontend" "$failed_frontend"; then
+      printf 'ERROR: failed to preserve failed frontend\n' >&2
+      recovery_failed=true
+    fi
+    if ! mv "$previous_frontend" "$APP_PARENT/frontend"; then
       printf 'ERROR: failed to restore frontend\n' >&2
       recovery_failed=true
     fi
@@ -295,8 +303,8 @@ wait_healthy
   fail "running image does not match target image"
 
 mv "$APP_PARENT/frontend" "$previous_frontend"
+frontend_previous_created=true
 mv "$staging_frontend" "$APP_PARENT/frontend"
-frontend_switched=true
 
 printf '%s\n' \
   "name=registro_produccion" \
@@ -305,8 +313,8 @@ printf '%s\n' \
   "branch=$BRANCH" \
   "built_at=$timestamp" >"$APP_PARENT/RELEASE_MANIFEST.next-${timestamp}.txt"
 mv "$APP_PARENT/RELEASE_MANIFEST.txt" "$previous_manifest"
+manifest_previous_created=true
 mv "$APP_PARENT/RELEASE_MANIFEST.next-${timestamp}.txt" "$APP_PARENT/RELEASE_MANIFEST.txt"
-manifest_switched=true
 
 [[ "$(grep -oE 'assets/index-[A-Za-z0-9_-]+\.js' "$APP_PARENT/frontend/index.html" | head -1)" == "$frontend_asset" ]] ||
   fail "published frontend asset does not match package"

--- a/scripts/deploy_produccion_fg_main_fasa195.sh
+++ b/scripts/deploy_produccion_fg_main_fasa195.sh
@@ -21,7 +21,7 @@ usage() {
 
 fail() {
   printf 'ERROR: %s\n' "$*" >&2
-  exit 1
+  return 1
 }
 
 log() {


### PR DESCRIPTION
## Objetivo

Establecer el procedimiento canónico para desplegar exclusivamente `produccion_fg` en `fasa_195`, únicamente desde `origin/main`, con evidencia y rollback automáticos.

## Cambios

- agrega el runbook canónico `DEPLOY.md` y deja el runbook multiinstancia fuera del flujo normal;
- agrega `scripts/deploy_produccion_fg_main_fasa195.sh` con preflight, lock, backup, health checks, invariantes de servicios vecinos y rollback;
- usa una imagen inmutable mediante un override temporal exclusivo de `produccion_fg`, sin modificar `registro_produccion:latest`;
- materializa el commit exacto con `git archive`, ejecuta `npm ci`, tests y build en esa copia, y empaqueta sólo archivos pertenecientes al commit;
- valida físicamente el asset principal del frontend antes, durante y después de publicarlo;
- agrega pruebas dinámicas y contratos documentales del flujo.

## Tests / validaciones

- [x] `py -3.12 -m pytest backend -q` — 112 passed
- [x] `py -3.12 -m compileall -q backend/app`
- [x] `npm run test` — 23 archivos, 161 tests passed
- [x] `npm run build`
- [x] empaquetado completo desde commit materializado con `npm ci`
- [x] 23 pruebas enfocadas del deploy y contratos
- [x] parseo PowerShell de `build_deploy_package.ps1`
- [x] `bash -n` ejecutado mediante `fasa_195`
- [x] `git diff --check origin/main...HEAD`
- [x] revisión independiente sin hallazgos pendientes

## Fuera de alcance

- no despliega producción en este PR;
- no modifica `indufor`, `indufor_demo`, Nginx, `.env`, credenciales ni bases reales;
- no aplica migraciones: el preflight aborta si detecta cambios en `db_migrations/`.

## Riesgos / pendientes

- El `--check` real corresponde después del merge, porque el flujo rechaza por diseño cualquier commit que aún no sea `origin/main`.
- `npm ci` informa 19 vulnerabilidades ya existentes y Vite mantiene su advertencia de chunk mayor a 500 kB; no se alteraron dependencias en este alcance.
