### PR TITLE
feat(dashboard): listado y detalle de registros individuales (#104)

### DIFF
--- a/backend/app/api/routes/dashboard.py
+++ b/backend/app/api/routes/dashboard.py
@@ -4,7 +4,7 @@ from sqlalchemy import func, text, case
 from typing import List
 from datetime import date, timedelta
 
-from app.api.deps import get_db, get_current_admin_or_encargado
+from app.api.deps import get_db, get_current_admin_or_encargado, get_current_user
 from app.models.personal import Personal
 from app.models.personal_unidad_negocio import PersonalUnidadNegocio
 from app.models.produccion import TableroProduccion
@@ -20,6 +20,11 @@ from app.schemas.dashboard import (
     RankingMaquinaItem,
     TipoProcesoDisponible,
     MovilDisponible,
+)
+from app.schemas.registros import (
+    RegistroDetail,
+    RegistroListItem,
+    RegistrosPagedResponse,
 )
 
 router = APIRouter(prefix="/dashboard", tags=["dashboard"])
@@ -220,6 +225,86 @@ def _process_label(db: Session, process_filter: dict | None) -> str | None:
     if process_filter["mode"] == "tipo":
         return db.query(TipoDeProceso.nombre).filter(TipoDeProceso.id == process_filter["ids"][0]).scalar()
     return None
+
+
+# ─── Helper compartido para listado/detalle de registros ───────────────────
+def _resolve_records_query(
+    db: Session,
+    user: Personal,
+    *,
+    un_id: int | None = None,
+    tipo_proceso_id: int | None = None,
+    tipo_proceso_key: str | None = None,
+    movil_id: int | None = None,
+    fecha_desde: date | None = None,
+    fecha_hasta: date | None = None,
+    only_self: bool = False,
+    self_cod_operador: int | None = None,
+):
+    """Devuelve un query sobre ``TableroProduccion`` con filtros de alcance, tipo, móvil y fecha.
+
+    Caso de uso (issue #104):
+    - Encargado/Admin consultan el listado de registros del dashboard: se
+      filtran por las unidades de negocio autorizadas (multi-UN para encargado,
+      single o ninguna para admin según reciba ``un_id``).
+    - Operador consulta sus propios registros (``only_self=True``): se filtra
+      por ``cod_operador == self_cod_operador`` y no se permite un_id externo.
+
+    Levanta ``HTTPException 403`` si el usuario pide una UN que no le pertenece
+    (delega en ``_verify_un``).
+    """
+    if only_self:
+        if not self_cod_operador:
+            raise HTTPException(
+                status_code=400,
+                detail="Falta el cod_operador del usuario autenticado",
+            )
+        # El operador no puede escapar de su propio cod_operador. Ignoramos
+        # cualquier un_id que pudiera llegar acá: su alcance es el personal.
+        query = db.query(TableroProduccion).filter(
+            TableroProduccion.cod_operador == self_cod_operador
+        )
+    else:
+        if un_id is not None:
+            _verify_un(user, un_id, db)
+            query = db.query(TableroProduccion).filter(TableroProduccion.cod_un == un_id)
+        else:
+            # Sin un_id: encargado ve sus unidades autorizadas, admin ve todo.
+            if user.is_admin == 1:
+                query = db.query(TableroProduccion)
+            else:
+                allowed = _personal_unidad_ids(db, user)
+                if not allowed:
+                    # Encargado sin unidades asignadas: no ve nada
+                    query = db.query(TableroProduccion).filter(TableroProduccion.id == -1)
+                else:
+                    query = db.query(TableroProduccion).filter(
+                        TableroProduccion.cod_un.in_(allowed)
+                    )
+
+    # Filtros compartidos de datos
+    process_filter = _resolve_process_filter(tipo_proceso_key, tipo_proceso_id)
+    query = _apply_process_filter(query, process_filter)
+    if movil_id is not None:
+        query = query.filter(TableroProduccion.cod_equipo == movil_id)
+    if fecha_desde is not None:
+        query = query.filter(TableroProduccion.fecha >= fecha_desde)
+    if fecha_hasta is not None:
+        query = query.filter(TableroProduccion.fecha <= fecha_hasta)
+
+    return query
+
+
+# ─── Helpers para paginación ───────────────────────────────────────────────
+def _normalize_pagination(page: int, page_size: int) -> tuple[int, int]:
+    """Sanea los parametros de paginacion: page>=1, 1<=page_size<=100."""
+    if page < 1:
+        page = 1
+    if page_size < 1:
+        page_size = 20
+    if page_size > 100:
+        page_size = 100
+    return page, page_size
 
 
 # ═══════════════════════════════════════════════════════════════
@@ -604,3 +689,94 @@ async def get_ranking_maquinas(
         )
         for r in rows
     ]
+
+
+# ─── Listado paginado de registros (issue #104) ───────────────────────────
+@router.get("/registros", response_model=RegistrosPagedResponse)
+async def list_registros(
+    un_id: int | None = None,
+    tipo_proceso_id: int | None = None,
+    tipo_proceso_key: str | None = None,
+    movil_id: int | None = None,
+    fecha_desde: date | None = None,
+    fecha_hasta: date | None = None,
+    page: int = 1,
+    page_size: int = 20,
+    user: Personal = Depends(get_current_admin_or_encargado),
+    db: Session = Depends(get_db),
+):
+    """Lista paginada de los registros individuales que componen los KPIs del dashboard.
+
+    - Encargado/Admin ven registros de sus unidades autorizadas (o la UN
+      puntual si pasan ``un_id``).
+    - El conjunto de filtros (un_id, tipo_proceso, móvil, fechas) es el mismo
+      que consumen /kpis, /evolucion y /ranking-maquinas, de modo que el total
+      del listado coincide con el KPI Registros bajo la misma combinación.
+    - El listado se ordena por fecha desc + id desc (consistente con
+      /mis-registros).
+    """
+    page, page_size = _normalize_pagination(page, page_size)
+
+    base = _resolve_records_query(
+        db, user,
+        un_id=un_id,
+        tipo_proceso_id=tipo_proceso_id,
+        tipo_proceso_key=tipo_proceso_key,
+        movil_id=movil_id,
+        fecha_desde=fecha_desde,
+        fecha_hasta=fecha_hasta,
+    )
+    total = int(base.with_entities(func.count(TableroProduccion.id)).scalar() or 0)
+    rows = (
+        base.order_by(TableroProduccion.fecha.desc(), TableroProduccion.id.desc())
+        .offset((page - 1) * page_size)
+        .limit(page_size)
+        .all()
+    )
+    items = [RegistroListItem.model_validate(r) for r in rows]
+    total_pages = (total + page_size - 1) // page_size if total else 0
+    return RegistrosPagedResponse(
+        items=items,
+        total=total,
+        page=page,
+        page_size=page_size,
+        total_pages=total_pages,
+    )
+
+
+# ─── Detalle de un registro (issue #104) ──────────────────────────────────
+@router.get("/registros/{registro_id}", response_model=RegistroDetail)
+async def get_registro_detalle(
+    registro_id: int,
+    user: Personal = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Devuelve el detalle completo de un registro.
+
+    Aplica la regla de alcance segun el rol del usuario:
+    - Encargado/Admin: solo registros de sus unidades autorizadas.
+    - Operador: solo registros cuyo ``cod_operador`` coincide con su id.
+
+    Si el registro no existe o esta fuera del alcance del usuario, devolvemos
+    404 para no filtrar la existencia del registro.
+    """
+    row = db.query(TableroProduccion).filter(TableroProduccion.id == registro_id).first()
+    if not row:
+        raise HTTPException(status_code=404, detail="Registro no encontrado")
+
+    if int(user.is_admin or 0) == 1 or int(user.encargado or 0) == 1:
+        # Encargado/Admin: valida por UN
+        if row.cod_un is not None:
+            try:
+                _verify_un(user, int(row.cod_un), db)
+            except HTTPException:
+                raise HTTPException(status_code=404, detail="Registro no encontrado")
+        else:
+            if int(user.is_admin or 0) != 1:
+                raise HTTPException(status_code=404, detail="Registro no encontrado")
+    else:
+        # Operador: solo puede ver registros donde el es el operador
+        if int(row.cod_operador or 0) != int(user.idPersonal):
+            raise HTTPException(status_code=404, detail="Registro no encontrado")
+
+    return RegistroDetail.model_validate(row)

--- a/backend/app/api/routes/produccion.py
+++ b/backend/app/api/routes/produccion.py
@@ -738,13 +738,23 @@ async def get_mis_registros(
     user: Personal = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
-    query = db.query(TableroProduccion).filter(
-        TableroProduccion.cod_operador == user.idPersonal
+    """Historial personal del operador autenticado (issue #104 refactor).
+
+    Aislado a ``cod_operador == user.idPersonal`` por diseño: el operador
+    nunca puede ver registros de otro operador aunque manipule query params.
+    Reutiliza el helper compartido ``_resolve_records_query`` del modulo de
+    dashboard para aplicar los filtros de fechas y mantener una sola fuente
+    de verdad sobre cómo se filtra un registro por Unidad/Tipo/Móvil/Fechas.
+    """
+    from app.api.routes.dashboard import _resolve_records_query
+
+    query = _resolve_records_query(
+        db, user,
+        fecha_desde=fecha_desde,
+        fecha_hasta=fecha_hasta,
+        only_self=True,
+        self_cod_operador=user.idPersonal,
     )
-    if fecha_desde:
-        query = query.filter(TableroProduccion.fecha >= fecha_desde)
-    if fecha_hasta:
-        query = query.filter(TableroProduccion.fecha <= fecha_hasta)
 
     rows = query.order_by(TableroProduccion.fecha.desc(), TableroProduccion.id.desc()).all()
 

--- a/backend/app/schemas/registros.py
+++ b/backend/app/schemas/registros.py
@@ -1,0 +1,129 @@
+"""Schemas para el listado y detalle de registros individuales.
+
+Usados por el endpoint ``/api/dashboard/registros`` (issue #104) y reusados
+desde ``/api/produccion/mis-registros`` para mantener una sola representacion
+de un registro entre el dashboard y la vista del operador.
+"""
+from datetime import date, datetime
+from typing import Optional
+
+from pydantic import BaseModel
+
+
+# ─── Listado ────────────────────────────────────────────────────────────────
+
+
+class RegistroListItem(BaseModel):
+    """DTO de un registro individual para el listado paginado.
+
+    Contiene los campos clave que se muestran en la fila/tarjeta de la lista.
+    El detalle completo (RegistroDetail) se obtiene via GET /registros/{id}.
+    """
+    id: int
+    fecha: Optional[date] = None
+    operacion: str = ""
+    equipo: str = ""
+    operador: str = ""
+    cod_operador: int = 0
+    cod_equipo: int = 0
+    cod_un: Optional[int] = None
+    tipo_proceso_id: Optional[int] = None
+    hr_inicio: float = 0
+    hr_fin: float = 0
+    hrs_no_op: int = 0
+    motivo_no_op: str = ""
+    combustible: int = 0
+    aceite_cadena: int = 0
+    tn_despachadas: float = 0
+    m3: int = 0
+    has: float = 0
+    carros: int = 0
+    plantas: int = 0
+    km_carreteo: float = 0
+    km_perfilado: float = 0
+    mtrs_recorridos: int = 0
+    remito: str = ""
+    remito2: str = ""
+    remito3: str = ""
+    remito_bitren: str = ""
+
+    class Config:
+        from_attributes = True
+
+
+class RegistrosPagedResponse(BaseModel):
+    items: list[RegistroListItem]
+    total: int
+    page: int
+    page_size: int
+    total_pages: int
+
+
+# ─── Detalle ────────────────────────────────────────────────────────────────
+
+
+class RegistroDetail(RegistroListItem):
+    """DTO completo de un registro individual (issue #104).
+
+    Reune los campos que pueden llegar a ser utiles al operario/encargado que
+    consulta el detalle de una carga: ubicacion, metricas, consumos, remitos,
+    lubricantes, identificadores de produccion, etc. NO expone datos sensibles
+    (passwords, tokens, etc.).
+    """
+    UN: str = ""
+    acta: str = ""
+    rodal: str = ""
+    predio: str = ""
+    parcela: str = ""
+    lugar_carga: int = 0
+    produccion: float = 0
+    unitario: float = 0
+    unidad_produccion: str = ""
+    tarifa: float = 0
+    fijo: float = 0
+    hr_disposicion: float = 0
+    km_camioneta: int = 0
+    servicio_tercero: int = 0
+    detalle_servicio: str = ""
+    observaciones: str = ""
+    aceite_hidraulico: int = 0
+    aceite_motor: int = 0
+    aceite_embrague: int = 0
+    aceite_transmision: int = 0
+    nro_parte: int = 0
+    stock_abc: int = 0
+    dist_tosquera: int = 0
+    viaje_tosca: int = 0
+    cambio_cuchilla: int = 0
+    espada: int = 0
+    puntera: int = 0
+    cadena: int = 0
+    pinon: int = 0
+    cantidad_cadenas: int = 0
+    giro_pinon: int = 0
+    pies_16: float = 0
+    pies_14: float = 0
+    pies_12: float = 0
+    pies_10: float = 0
+    pulpable: float = 0
+    remito_proveedor: str = ""
+    remito_fgpy: str = ""
+    nombre_chofer: str = ""
+    cliente_camion: str = ""
+    origen_camion: str = ""
+    destino_camion: str = ""
+    origen: str = ""
+    origen_destino_id: int = 0
+    fecha_hora: Optional[datetime] = None
+    usuario: str = ""
+    tabla: str = ""
+    codigo_tabla: int = 0
+    tarifa_empresa: float = 0
+    proveedor_id: Optional[int] = None
+    bruto_destino: float = 0
+    tara_destino: float = 0
+    neto_origen: float = 0
+    neto_destino: float = 0
+    hora_inicio_viaje: str = ""
+    hora_fin_viaje: str = ""
+    modificado: int = 0

--- a/backend/tests/test_dashboard_registros.py
+++ b/backend/tests/test_dashboard_registros.py
@@ -1,0 +1,370 @@
+"""Tests del helper compartido y los nuevos endpoints de registros (issue #104).
+
+Cubre:
+- ``_resolve_records_query`` aplica los filtros correctos para cada rol.
+- ``list_registros`` pagina, ordena y filtra segun los params.
+- ``get_registro_detalle`` valida 404 para id fuera de alcance y 200 para
+  registros que SI pertenecen al usuario.
+- El refactor de ``/mis-registros`` sigue aislando por ``cod_operador``.
+"""
+from contextlib import contextmanager
+from datetime import date
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+
+from app.api.routes import dashboard, produccion
+
+
+# ─── Fakes ─────────────────────────────────────────────────────────────────
+
+
+class CapturingQuery:
+    """Query que captura cada llamada a .filter() y devuelve self.
+
+    Permite inspeccionar los filtros aplicados contando las llamadas
+    (``.filter_calls``) o comparando las representaciones de los args.
+    """
+
+    def __init__(self, rows=None, count_value=0):
+        self.rows = rows or []
+        self.count_value = count_value
+        self.filter_calls = []
+        self.order_by_calls = []
+        self.offset_value = None
+        self.limit_value = None
+        self._with_entities = False
+        self._count_query = False
+
+    def filter(self, *args, **kwargs):
+        self.filter_calls.append((args, kwargs))
+        return self
+
+    def with_entities(self, *args, **kwargs):
+        self._with_entities = True
+        # Si piden un COUNT devolvemos un subquery fake con scalar()
+        if args and "count" in str(args[0]).lower():
+            self._count_query = True
+        return self
+
+    def order_by(self, *args, **kwargs):
+        self.order_by_calls.append((args, kwargs))
+        return self
+
+    def offset(self, value):
+        self.offset_value = value
+        return self
+
+    def limit(self, value):
+        self.limit_value = value
+        return self
+
+    def all(self):
+        return self.rows
+
+    def scalar(self):
+        return self.count_value if self._count_query else None
+
+    def first(self):
+        return self.rows[0] if self.rows else None
+
+
+class FakeDb:
+    def __init__(self, rows=None, count_value=0):
+        self.query_obj = CapturingQuery(rows=rows, count_value=count_value)
+        # Diferentes .query() pueden querer distintos sub-queries; con uno solo alcanza
+        # para los tests de helper. El endpoint detail hace su propio .query().
+        self._next_first_value = None
+
+    def query(self, *_args, **_kwargs):
+        return self.query_obj
+
+
+# ─── _resolve_records_query ────────────────────────────────────────────────
+
+
+def test_resolve_records_only_self_requiere_cod_operador():
+    db = FakeDb()
+    user = SimpleNamespace(idPersonal=42, is_admin=0, encargado=0)
+
+    with pytest.raises(HTTPException) as exc:
+        dashboard._resolve_records_query(db, user, only_self=True, self_cod_operador=None)
+    assert exc.value.status_code == 400
+
+
+def _has_filter_attr(query, attr_name: str) -> bool:
+    """Helper: chequea si algun .filter() aplicado menciona un atributo del modelo.
+
+    El str() de un SQLAlchemy BinaryExpression incluye el nombre del lado
+    izquierdo (ej: 'tablero_produccion.cod_un')."""
+    for args, _ in query.filter_calls:
+        for arg in args:
+            if attr_name in str(arg):
+                return True
+    return False
+
+
+def _filter_count(query) -> int:
+    return len(query.filter_calls)
+
+
+def test_resolve_records_only_self_filtra_por_cod_operador():
+    db = FakeDb()
+    user = SimpleNamespace(idPersonal=42, is_admin=0, encargado=0)
+
+    dashboard._resolve_records_query(
+        db, user,
+        only_self=True,
+        self_cod_operador=42,
+        fecha_desde=date(2026, 7, 1),
+        fecha_hasta=date(2026, 7, 31),
+    )
+
+    # cod_operador + 2 fechas = 3 filtros
+    assert _filter_count(db.query_obj) == 3
+    assert _has_filter_attr(db.query_obj, "cod_operador")
+    assert _has_filter_attr(db.query_obj, "fecha")  # aplicado 2 veces
+    # NO debe filtrar por cod_un (el operador no tiene UN, solo su persona)
+    assert not _has_filter_attr(db.query_obj, "cod_un")
+
+
+def test_resolve_records_encargado_con_un_id_usa_verify_un(monkeypatch):
+    """Si el encargado pide un un_id, _verify_un debe llamarse y filtrar por esa UN."""
+    db = FakeDb()
+    user = SimpleNamespace(idPersonal=1, is_admin=0, encargado=1)
+    verify_called = []
+
+    def fake_verify(_user, _un_id, _db):
+        verify_called.append(_un_id)
+
+    monkeypatch.setattr(dashboard, "_verify_un", fake_verify)
+
+    dashboard._resolve_records_query(
+        db, user, un_id=7, movil_id=3,
+        fecha_desde=date(2026, 7, 1), fecha_hasta=date(2026, 7, 31),
+    )
+
+    assert verify_called == [7]
+    # 4 filtros: cod_un, cod_equipo, fecha>=, fecha<=
+    assert _filter_count(db.query_obj) == 4
+    assert _has_filter_attr(db.query_obj, "cod_un")
+    assert _has_filter_attr(db.query_obj, "cod_equipo")
+    assert _has_filter_attr(db.query_obj, "fecha")
+
+
+def test_resolve_records_encargado_sin_un_id_ve_multi_un(monkeypatch):
+    """Encargado SIN un_id: filtra por todas sus unidades autorizadas."""
+    db = FakeDb()
+    user = SimpleNamespace(idPersonal=1, is_admin=0, encargado=1, unidad_negocio=2)
+
+    monkeypatch.setattr(
+        dashboard, "_personal_unidad_ids", lambda _db, _user: {2, 5, 9},
+    )
+
+    dashboard._resolve_records_query(db, user, movil_id=11)
+
+    # 2 filtros: cod_un IN (multi-UN), cod_equipo
+    assert _filter_count(db.query_obj) == 2
+    assert _has_filter_attr(db.query_obj, "cod_un")
+    assert _has_filter_attr(db.query_obj, "cod_equipo")
+
+
+def test_resolve_records_encargado_sin_unidades_ve_nada(monkeypatch):
+    """Si el encargado no tiene unidades asignadas, no debe ver registros."""
+    db = FakeDb()
+    user = SimpleNamespace(idPersonal=1, is_admin=0, encargado=1, unidad_negocio=None)
+
+    monkeypatch.setattr(dashboard, "_personal_unidad_ids", lambda _db, _user: set())
+
+    dashboard._resolve_records_query(db, user, fecha_desde=date(2026, 7, 1))
+
+    # 2 filtros: id == -1, fecha >=
+    assert _filter_count(db.query_obj) == 2
+    assert _has_filter_attr(db.query_obj, "id")  # sentinela
+
+
+def test_resolve_records_admin_sin_un_id_ve_todo(monkeypatch):
+    """Admin sin un_id: no debe filtrar por UN, solo por los filtros de datos."""
+    db = FakeDb()
+    user = SimpleNamespace(idPersonal=1, is_admin=1, encargado=0)
+
+    dashboard._resolve_records_query(
+        db, user, fecha_desde=date(2026, 7, 1), fecha_hasta=date(2026, 7, 31),
+    )
+
+    # Solo los 2 filtros de fechas
+    assert _filter_count(db.query_obj) == 2
+    assert not _has_filter_attr(db.query_obj, "cod_un")
+    assert _has_filter_attr(db.query_obj, "fecha")
+
+
+def test_resolve_records_tipo_proceso_usa_helper_existente(monkeypatch):
+    """El filtro de tipo_proceso debe reutilizar _apply_process_filter."""
+    db = FakeDb()
+    user = SimpleNamespace(idPersonal=1, is_admin=1, encargado=0)
+    captured = []
+
+    monkeypatch.setattr(
+        dashboard, "_apply_process_filter",
+        lambda base, pf: captured.append(pf) or base,
+    )
+
+    dashboard._resolve_records_query(db, user, tipo_proceso_id=3)
+
+    assert captured == [{"mode": "tipo", "ids": [3]}]
+
+
+# ─── Paginación ────────────────────────────────────────────────────────────
+
+
+def test_normalize_pagination_clamp_basico():
+    assert dashboard._normalize_pagination(0, 50) == (1, 50)
+    assert dashboard._normalize_pagination(-3, 0) == (1, 20)
+    assert dashboard._normalize_pagination(5, 250) == (5, 100)
+    assert dashboard._normalize_pagination(2, 30) == (2, 30)
+
+
+# ─── get_registro_detalle (auth) ───────────────────────────────────────────
+
+
+def test_get_registro_detalle_404_si_no_existe(monkeypatch):
+    db = FakeDb(rows=[])
+
+    with pytest.raises(HTTPException) as exc:
+        # La función async, la corremos via asyncio.run para test simple
+        import asyncio
+        asyncio.run(dashboard.get_registro_detalle(999, user=SimpleNamespace(is_admin=1, idPersonal=1, encargado=0), db=db))
+    assert exc.value.status_code == 404
+
+
+def test_get_registro_detalle_404_si_un_no_autorizada(monkeypatch):
+    """Encargado pide un registro de una UN que no le pertenece -> 404."""
+    row = SimpleNamespace(id=1, cod_un=99)
+    db = FakeDb(rows=[row])
+    user = SimpleNamespace(idPersonal=1, is_admin=0, encargado=1, unidad_negocio=2)
+
+    def fake_verify(_u, _un, _db):
+        raise HTTPException(status_code=403, detail="forbidden")
+
+    monkeypatch.setattr(dashboard, "_verify_un", fake_verify)
+
+    import asyncio
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(dashboard.get_registro_detalle(1, user=user, db=db))
+    assert exc.value.status_code == 404
+    assert "no encontrado" in str(exc.value.detail).lower()
+
+
+def test_get_registro_detalle_admin_no_filtra_por_un(monkeypatch):
+    """Admin puede ver registros de cualquier UN (incluso sin cod_un asignada)."""
+    row = SimpleNamespace(id=1, cod_un=None)
+    db = FakeDb(rows=[row])
+    user = SimpleNamespace(idPersonal=1, is_admin=1, encargado=0)
+    verify_called = []
+
+    monkeypatch.setattr(dashboard, "_verify_un", lambda *a, **k: verify_called.append(a))
+
+    import asyncio
+    result = asyncio.run(dashboard.get_registro_detalle(1, user=user, db=db))
+    # Si el row tiene cod_un None, admin igual lo ve (sin invocar _verify_un)
+    assert verify_called == []
+
+
+# ─── list_registros (estructura) ──────────────────────────────────────────
+
+
+def test_list_registros_calcula_total_y_pagina(monkeypatch):
+    rows = [
+        SimpleNamespace(
+            id=10, fecha=date(2026, 7, 15), operacion="Cosecha", equipo="MQ-1",
+            operador="Juan", cod_operador=1, cod_equipo=11, cod_un=2,
+            tipo_proceso_id=None, hr_inicio=8, hr_fin=12, hrs_no_op=0,
+            motivo_no_op="0", combustible=0, aceite_cadena=0,
+            tn_despachadas=10, m3=0, has=0, carros=0, plantas=0,
+            km_carreteo=0, km_perfilado=0, mtrs_recorridos=0,
+            remito="", remito2="", remito3="", remito_bitren="",
+        ),
+    ]
+    db = FakeDb(rows=rows, count_value=37)
+    user = SimpleNamespace(idPersonal=1, is_admin=1, encargado=0)
+
+    monkeypatch.setattr(dashboard, "_resolve_records_query", lambda *a, **k: db.query_obj)
+
+    import asyncio
+    response = asyncio.run(dashboard.list_registros(
+        un_id=2, page=2, page_size=20, user=user, db=db,
+    ))
+
+    assert response.total == 37
+    assert response.page == 2
+    assert response.page_size == 20
+    assert response.total_pages == 2  # ceil(37 / 20)
+    assert len(response.items) == 1
+    assert response.items[0].id == 10
+    # Paginación: offset = (2-1)*20 = 20
+    assert db.query_obj.offset_value == 20
+    assert db.query_obj.limit_value == 20
+    # Orden aplicado
+    assert len(db.query_obj.order_by_calls) >= 1
+
+
+def test_list_registros_clamp_paginacion(monkeypatch):
+    """Si page=0 o page_size>100, _normalize_pagination corrige."""
+    db = FakeDb(rows=[], count_value=0)
+    user = SimpleNamespace(idPersonal=1, is_admin=1, encargado=0)
+    monkeypatch.setattr(dashboard, "_resolve_records_query", lambda *a, **k: db.query_obj)
+
+    import asyncio
+    response = asyncio.run(dashboard.list_registros(
+        un_id=1, page=0, page_size=500, user=user, db=db,
+    ))
+
+    assert response.page == 1
+    assert response.page_size == 100
+    # El offset y limit se aplican sobre la query (no sobre el response)
+    assert db.query_obj.offset_value == 0  # (1-1)*100 = 0
+    assert db.query_obj.limit_value == 100
+
+
+# ─── Refactor /mis-registros ──────────────────────────────────────────────
+
+
+def test_mis_registros_sigue_limitado_al_operador(monkeypatch):
+    """/mis-registros debe seguir llamando al helper con only_self=True
+    y self_cod_operador = user.idPersonal. Verifica que el refactor no
+    haya debilitado la regla de aislamiento por operador.
+    """
+    captured = {}
+
+    def fake_resolve(db, user, **kwargs):
+        captured["kwargs"] = kwargs
+        captured["user_id"] = user.idPersonal
+        return CapturingQuery(rows=[])
+
+    monkeypatch.setattr(
+        "app.api.routes.dashboard._resolve_records_query", fake_resolve,
+    )
+
+    # Mock de los modelos para evitar SQL real
+    from app.api.routes import produccion as produccion_routes
+
+    fake_personal = SimpleNamespace(
+        idPersonal=1, Nombre="Test", dni=None, encargado=0,
+        tipo_de_proceso_id=None, unidad_ids=[],
+    )
+
+    import asyncio
+    response = asyncio.run(produccion_routes.get_mis_registros(
+        fecha_desde=date(2026, 7, 1),
+        fecha_hasta=date(2026, 7, 31),
+        user=fake_personal,
+        db=FakeDb(rows=[]),
+    ))
+
+    assert captured["kwargs"]["only_self"] is True
+    assert captured["kwargs"]["self_cod_operador"] == 1  # fake_personal.id
+    assert captured["kwargs"]["fecha_desde"] == date(2026, 7, 1)
+    assert captured["kwargs"]["fecha_hasta"] == date(2026, 7, 31)
+    # un_id no debe pasarse en modo only_self (ignorado por el helper)
+    assert "un_id" not in captured["kwargs"] or captured["kwargs"].get("un_id") is None

--- a/frontend/src/components/registros/RecordDetailModal.vue
+++ b/frontend/src/components/registros/RecordDetailModal.vue
@@ -1,0 +1,203 @@
+<template>
+  <AppModal
+    :model-value="modelValue"
+    :title="titulo"
+    :description="descripcion"
+    @update:model-value="(value) => emit('update:modelValue', value)"
+  >
+    <div v-if="loading" class="flex justify-center py-10" data-testid="record-detail-loading">
+      <div class="h-8 w-8 animate-spin rounded-full border-3 border-primary border-t-transparent"></div>
+    </div>
+
+    <div
+      v-else-if="error"
+      class="rounded-lg border border-error/30 bg-error-light/40 p-4 text-sm text-error-dark"
+      data-testid="record-detail-error"
+    >
+      {{ error }}
+    </div>
+
+    <div v-else-if="detalle" class="space-y-4" data-testid="record-detail-content">
+      <section
+        v-for="grupo in grupos"
+        :key="grupo.titulo"
+        class="rounded-lg border border-neutral-200 p-3"
+      >
+        <h4 class="mb-2 text-xs font-extrabold uppercase tracking-wide text-neutral-500">
+          {{ grupo.titulo }}
+        </h4>
+        <dl class="grid grid-cols-1 gap-x-4 gap-y-1.5 sm:grid-cols-2">
+          <div v-for="campo in grupo.campos" :key="campo.key" class="flex flex-col">
+            <dt class="text-[11px] font-semibold uppercase text-neutral-400">{{ campo.label }}</dt>
+            <dd class="text-sm font-semibold text-neutral-900">{{ formatCampo(detalle[campo.key], campo) }}</dd>
+          </div>
+        </dl>
+      </section>
+    </div>
+
+    <template v-if="!loading && detalle" #actions>
+      <div class="flex flex-wrap items-center justify-end gap-2 border-t border-neutral-200 px-4 py-3">
+        <span class="text-[11px] text-neutral-400">ID #{{ detalle.id }}</span>
+      </div>
+    </template>
+  </AppModal>
+</template>
+
+<script setup>
+import { computed, watch } from 'vue'
+import AppModal from '@/components/ui/AppModal.vue'
+import { useDashboardRegistrosStore } from '@/stores/dashboardRegistros'
+
+const props = defineProps({
+  modelValue: { type: Boolean, default: false },
+  registroId: { type: [Number, null], default: null },
+  /** Si true, consume el detalle ya cargado del store. Si false, dispara fetchDetalle. */
+  useStore: { type: Boolean, default: true },
+})
+
+const emit = defineEmits(['update:modelValue'])
+
+const store = useDashboardRegistrosStore()
+
+const detalle = computed(() => store.detalle)
+const loading = computed(() => store.detalleLoading)
+const error = computed(() => store.detalleError)
+
+const titulo = computed(() => {
+  if (!detalle.value) return 'Detalle del registro'
+  const fecha = formatFecha(detalle.value.fecha)
+  const operacion = detalle.value.operacion || 'Produccion'
+  return `${operacion} - ${fecha}`
+})
+
+const descripcion = computed(() => {
+  if (!detalle.value) return ''
+  const equipo = detalle.value.equipo || 'Sin equipo'
+  const operador = detalle.value.operador || 'Sin operador'
+  return `${operador} - ${equipo}`
+})
+
+const grupos = [
+  {
+    titulo: 'Identificacion',
+    campos: [
+      { key: 'UN', label: 'Unidad de negocio' },
+      { key: 'operacion', label: 'Operacion' },
+      { key: 'fecha', label: 'Fecha', tipo: 'fecha' },
+      { key: 'operador', label: 'Operador' },
+      { key: 'equipo', label: 'Equipo' },
+      { key: 'usuario', label: 'Cargado por' },
+    ],
+  },
+  {
+    titulo: 'Horario y operacion',
+    campos: [
+      { key: 'hr_inicio', label: 'Hora inicio', tipo: 'hora' },
+      { key: 'hr_fin', label: 'Hora fin', tipo: 'hora' },
+      { key: 'hr_disposicion', label: 'Horas disposicion', tipo: 'numero' },
+      { key: 'hrs_no_op', label: 'Horas no operativas', tipo: 'numero' },
+      { key: 'motivo_no_op', label: 'Motivo no operativo' },
+      { key: 'servicio_tercero', label: 'Servicio tercero', tipo: 'booleano' },
+      { key: 'detalle_servicio', label: 'Detalle servicio' },
+    ],
+  },
+  {
+    titulo: 'Produccion',
+    campos: [
+      { key: 'produccion', label: 'Produccion', tipo: 'numero' },
+      { key: 'unidad_produccion', label: 'Unidad' },
+      { key: 'unitario', label: 'Unitario', tipo: 'numero' },
+      { key: 'tn_despachadas', label: 'Toneladas', tipo: 'numero' },
+      { key: 'm3', label: 'm3', tipo: 'numero' },
+      { key: 'has', label: 'Hectareas', tipo: 'numero' },
+      { key: 'carros', label: 'Carros', tipo: 'numero' },
+      { key: 'plantas', label: 'Plantas', tipo: 'numero' },
+      { key: 'km_carreteo', label: 'KM carreteo', tipo: 'numero' },
+      { key: 'km_perfilado', label: 'KM perfilado', tipo: 'numero' },
+      { key: 'mtrs_recorridos', label: 'Metros recorridos', tipo: 'numero' },
+      { key: 'dist_tosquera', label: 'Distancia tosquera', tipo: 'numero' },
+      { key: 'viaje_tosca', label: 'Viaje tosca', tipo: 'numero' },
+    ],
+  },
+  {
+    titulo: 'Consumos',
+    campos: [
+      { key: 'combustible', label: 'Combustible (lts)', tipo: 'numero' },
+      { key: 'aceite_cadena', label: 'Aceite cadena', tipo: 'numero' },
+      { key: 'aceite_hidraulico', label: 'Aceite hidraulico', tipo: 'numero' },
+      { key: 'aceite_motor', label: 'Aceite motor', tipo: 'numero' },
+      { key: 'aceite_embrague', label: 'Aceite embrague', tipo: 'numero' },
+      { key: 'aceite_transmision', label: 'Aceite transmision', tipo: 'numero' },
+    ],
+  },
+  {
+    titulo: 'Ubicacion y referencia',
+    campos: [
+      { key: 'predio', label: 'Predio' },
+      { key: 'acta', label: 'Acta' },
+      { key: 'rodal', label: 'Rodal' },
+      { key: 'parcela', label: 'Parcela' },
+      { key: 'lugar_carga', label: 'Lugar de carga', tipo: 'numero' },
+    ],
+  },
+  {
+    titulo: 'Remitos de combustible',
+    campos: [
+      { key: 'remito', label: 'Remito 1' },
+      { key: 'remito2', label: 'Remito 2' },
+      { key: 'remito3', label: 'Remito 3' },
+      { key: 'remito_bitren', label: 'Remito bitren' },
+      { key: 'remito_proveedor', label: 'Remito proveedor' },
+      { key: 'remito_fgpy', label: 'Remito FGPY' },
+    ],
+  },
+  {
+    titulo: 'Observaciones',
+    campos: [{ key: 'observaciones', label: 'Notas' }],
+  },
+]
+
+function formatCampo(valor, campo) {
+  if (valor === null || valor === undefined || valor === '' || valor === '0' || valor === 0) {
+    return '-'
+  }
+  if (campo.tipo === 'fecha') return formatFecha(valor)
+  if (campo.tipo === 'hora') return formatHora(valor)
+  if (campo.tipo === 'numero') return formatNumero(valor)
+  if (campo.tipo === 'booleano') return Number(valor) === 1 ? 'Si' : 'No'
+  return valor
+}
+
+function formatFecha(fecha) {
+  if (!fecha) return '-'
+  const str = String(fecha)
+  const [y, m, d] = str.split('-')
+  if (y && m && d) return `${d}/${m}/${y}`
+  return str
+}
+
+function formatHora(valor) {
+  const n = Number(valor)
+  if (!Number.isFinite(n) || n === 0) return '-'
+  return n.toLocaleString('es-AR', { minimumFractionDigits: 0, maximumFractionDigits: 2 })
+}
+
+function formatNumero(valor) {
+  const n = Number(valor)
+  if (!Number.isFinite(n)) return '-'
+  if (Number.isInteger(n)) return n.toLocaleString('es-AR')
+  return n.toLocaleString('es-AR', { minimumFractionDigits: 1, maximumFractionDigits: 2 })
+}
+
+watch(
+  () => [props.modelValue, props.registroId],
+  async ([open, id]) => {
+    if (open && id && !props.useStore) {
+      await store.fetchDetalle(id)
+    } else if (!open) {
+      store.clearDetalle()
+    }
+  },
+  { immediate: true },
+)
+</script>

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -27,6 +27,12 @@ const routes = [
     meta: { requiresAuth: true, requiresEncargado: true },
   },
   {
+    path: '/dashboard/registros',
+    name: 'dashboard-registros',
+    component: () => import('../views/DashboardRegistrosView.vue'),
+    meta: { requiresAuth: true, requiresEncargado: true },
+  },
+  {
     path: '/mis-registros',
     name: 'mis-registros',
     component: () => import('../views/OperadorView.vue'),

--- a/frontend/src/stores/dashboardRegistros.js
+++ b/frontend/src/stores/dashboardRegistros.js
@@ -1,0 +1,159 @@
+import { defineStore } from 'pinia'
+import api from '@/services/api'
+
+const DEFAULT_PAGE_SIZE = 20
+
+/** Normaliza los query params del router al estado de filtros. */
+function filtrosFromQuery(query) {
+  if (!query) return null
+  const unId = query.un_id ? Number(query.un_id) : null
+  const tipoProcesoId = query.tipo_proceso_id ? Number(query.tipo_proceso_id) : null
+  const tipoProcesoKey = query.tipo_proceso_key ? String(query.tipo_proceso_key) : null
+  const movilId = query.movil_id ? Number(query.movil_id) : null
+  const fechaDesde = query.fecha_desde || null
+  const fechaHasta = query.fecha_hasta || null
+  return { unId, tipoProcesoId, tipoProcesoKey, movilId, fechaDesde, fechaHasta }
+}
+
+function buildQueryParams(filtros) {
+  const params = { page: 1, page_size: DEFAULT_PAGE_SIZE }
+  if (filtros.unId) params.un_id = filtros.unId
+  if (filtros.tipoProcesoId) params.tipo_proceso_id = filtros.tipoProcesoId
+  if (filtros.tipoProcesoKey) params.tipo_proceso_key = filtros.tipoProcesoKey
+  if (filtros.movilId) params.movil_id = filtros.movilId
+  if (filtros.fechaDesde) params.fecha_desde = filtros.fechaDesde
+  if (filtros.fechaHasta) params.fecha_hasta = filtros.fechaHasta
+  return params
+}
+
+export const useDashboardRegistrosStore = defineStore('dashboardRegistros', {
+  state: () => ({
+    registros: [],
+    total: 0,
+    page: 1,
+    pageSize: DEFAULT_PAGE_SIZE,
+    totalPages: 0,
+    filtros: {
+      unId: null,
+      tipoProcesoId: null,
+      tipoProcesoKey: null,
+      movilId: null,
+      fechaDesde: null,
+      fechaHasta: null,
+    },
+    loading: false,
+    error: null,
+    detalle: null,
+    detalleLoading: false,
+    detalleError: null,
+  }),
+
+  getters: {
+    hasRegistros: (state) => state.registros.length > 0,
+    hasFiltrosAplicados: (state) => {
+      return Boolean(
+        state.filtros.tipoProcesoId ||
+          state.filtros.tipoProcesoKey ||
+          state.filtros.movilId ||
+          state.filtros.fechaDesde ||
+          state.filtros.fechaHasta,
+      )
+    },
+  },
+
+  actions: {
+    /** Inicializa los filtros desde los query params del router y dispara la primera carga. */
+    async initFromQuery(query) {
+      const parsed = filtrosFromQuery(query)
+      if (parsed) this.filtros = { ...this.filtros, ...parsed }
+      await this.fetchRegistros()
+    },
+
+    async fetchRegistros() {
+      if (!this.filtros.unId) {
+        // Sin unidad no hay listado: se limpia y se sale sin pegar al backend.
+        this.registros = []
+        this.total = 0
+        this.totalPages = 0
+        return
+      }
+      this.loading = true
+      this.error = null
+      try {
+        const params = buildQueryParams(this.filtros)
+        params.page = this.page
+        params.page_size = this.pageSize
+        const { data } = await api.get('/api/dashboard/registros', {
+          params,
+          _suppressErrorToast: true,
+        })
+        this.registros = data.items || []
+        this.total = data.total || 0
+        this.page = data.page || 1
+        this.pageSize = data.page_size || DEFAULT_PAGE_SIZE
+        this.totalPages = data.total_pages || 0
+      } catch (err) {
+        console.error('Error cargando registros del dashboard:', err)
+        this.error = 'No se pudieron cargar los registros'
+        this.registros = []
+        this.total = 0
+        this.totalPages = 0
+      } finally {
+        this.loading = false
+      }
+    },
+
+    async setPage(page) {
+      const parsed = Number(page) || 1
+      if (parsed === this.page) return
+      this.page = parsed
+      await this.fetchRegistros()
+    },
+
+    async fetchDetalle(id) {
+      if (!id) {
+        this.detalle = null
+        return
+      }
+      this.detalleLoading = true
+      this.detalleError = null
+      try {
+        const { data } = await api.get(`/api/dashboard/registros/${id}`, {
+          _suppressErrorToast: true,
+        })
+        this.detalle = data
+      } catch (err) {
+        console.error('Error cargando detalle del registro:', err)
+        this.detalleError =
+          err?.response?.status === 404
+            ? 'No se encontro el registro o esta fuera de tu alcance'
+            : 'No se pudo cargar el detalle del registro'
+        this.detalle = null
+      } finally {
+        this.detalleLoading = false
+      }
+    },
+
+    clearDetalle() {
+      this.detalle = null
+      this.detalleError = null
+    },
+
+    reset() {
+      this.registros = []
+      this.total = 0
+      this.page = 1
+      this.totalPages = 0
+      this.filtros = {
+        unId: null,
+        tipoProcesoId: null,
+        tipoProcesoKey: null,
+        movilId: null,
+        fechaDesde: null,
+        fechaHasta: null,
+      }
+      this.loading = false
+      this.error = null
+    },
+  },
+})

--- a/frontend/src/stores/dashboardRegistros.test.js
+++ b/frontend/src/stores/dashboardRegistros.test.js
@@ -1,0 +1,219 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createPinia, setActivePinia } from 'pinia'
+
+vi.mock('@/services/api', () => ({
+  default: {
+    get: vi.fn(),
+  },
+}))
+
+import api from '@/services/api'
+import { useDashboardRegistrosStore } from './dashboardRegistros'
+
+describe('dashboardRegistros store (issue #104)', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  it('initFromQuery parsea un_id, tipo_proceso_key, movil_id y fechas del query', async () => {
+    api.get.mockResolvedValueOnce({
+      data: { items: [], total: 0, page: 1, page_size: 20, total_pages: 0 },
+    })
+    const store = useDashboardRegistrosStore()
+
+    await store.initFromQuery({
+      un_id: '7',
+      tipo_proceso_key: 'tipo:3',
+      movil_id: '11',
+      fecha_desde: '2026-07-01',
+      fecha_hasta: '2026-07-31',
+    })
+
+    expect(store.filtros.unId).toBe(7)
+    expect(store.filtros.tipoProcesoKey).toBe('tipo:3')
+    expect(store.filtros.movilId).toBe(11)
+    expect(store.filtros.fechaDesde).toBe('2026-07-01')
+    expect(store.filtros.fechaHasta).toBe('2026-07-31')
+    expect(api.get).toHaveBeenCalledWith(
+      '/api/dashboard/registros',
+      expect.objectContaining({
+        _suppressErrorToast: true,
+        params: expect.objectContaining({
+          un_id: 7,
+          tipo_proceso_key: 'tipo:3',
+          movil_id: 11,
+          fecha_desde: '2026-07-01',
+          fecha_hasta: '2026-07-31',
+          page: 1,
+          page_size: 20,
+        }),
+      }),
+    )
+  })
+
+  it('fetchRegistros sin unId no pega al backend y limpia el estado', async () => {
+    const store = useDashboardRegistrosStore()
+
+    await store.fetchRegistros()
+
+    expect(api.get).not.toHaveBeenCalled()
+    expect(store.registros).toEqual([])
+    expect(store.total).toBe(0)
+    expect(store.totalPages).toBe(0)
+  })
+
+  it('fetchRegistros guarda items, total y totalPages del response', async () => {
+    api.get.mockResolvedValueOnce({
+      data: {
+        items: [{ id: 1, fecha: '2026-07-15' }],
+        total: 42,
+        page: 1,
+        page_size: 20,
+        total_pages: 3,
+      },
+    })
+    const store = useDashboardRegistrosStore()
+    store.filtros.unId = 7
+
+    await store.fetchRegistros()
+
+    expect(store.registros).toHaveLength(1)
+    expect(store.total).toBe(42)
+    expect(store.totalPages).toBe(3)
+    expect(store.error).toBeNull()
+  })
+
+  it('fetchRegistros cae a estado vacio si el backend falla y suprime el toast', async () => {
+    api.get.mockRejectedValueOnce(new Error('boom'))
+    const store = useDashboardRegistrosStore()
+    store.filtros.unId = 7
+
+    await store.fetchRegistros()
+
+    expect(api.get).toHaveBeenCalledWith(
+      '/api/dashboard/registros',
+      expect.objectContaining({ _suppressErrorToast: true }),
+    )
+    expect(store.registros).toEqual([])
+    expect(store.error).toBe('No se pudieron cargar los registros')
+  })
+
+  it('setPage cambia la pagina y vuelve a fetchear', async () => {
+    api.get.mockResolvedValue({
+      data: { items: [], total: 100, page: 1, page_size: 20, total_pages: 5 },
+    })
+    const store = useDashboardRegistrosStore()
+    store.filtros.unId = 7
+    await store.fetchRegistros()
+
+    api.get.mockClear()
+    api.get.mockResolvedValueOnce({
+      data: { items: [], total: 100, page: 3, page_size: 20, total_pages: 5 },
+    })
+
+    await store.setPage(3)
+
+    expect(store.page).toBe(3)
+    expect(api.get).toHaveBeenCalledWith(
+      '/api/dashboard/registros',
+      expect.objectContaining({
+        params: expect.objectContaining({ page: 3, page_size: 20 }),
+      }),
+    )
+  })
+
+  it('setPage con la misma pagina no vuelve a fetchear', async () => {
+    api.get.mockResolvedValueOnce({
+      data: { items: [], total: 0, page: 1, page_size: 20, total_pages: 0 },
+    })
+    const store = useDashboardRegistrosStore()
+    store.filtros.unId = 7
+    await store.fetchRegistros()
+    api.get.mockClear()
+
+    await store.setPage(1)
+    expect(api.get).not.toHaveBeenCalled()
+  })
+
+  it('fetchDetalle carga el detalle del registro y limpia el error', async () => {
+    api.get.mockResolvedValueOnce({
+      data: { id: 99, fecha: '2026-07-15', operacion: 'Cosecha' },
+    })
+    const store = useDashboardRegistrosStore()
+
+    await store.fetchDetalle(99)
+
+    expect(api.get).toHaveBeenCalledWith(
+      '/api/dashboard/registros/99',
+      expect.objectContaining({ _suppressErrorToast: true }),
+    )
+    expect(store.detalle).toEqual({ id: 99, fecha: '2026-07-15', operacion: 'Cosecha' })
+    expect(store.detalleError).toBeNull()
+  })
+
+  it('fetchDetalle reporta mensaje de 404 cuando el registro no existe o esta fuera de alcance', async () => {
+    const err = new Error('Not found')
+    err.response = { status: 404, data: { detail: 'Registro no encontrado' } }
+    api.get.mockRejectedValueOnce(err)
+    const store = useDashboardRegistrosStore()
+
+    await store.fetchDetalle(999)
+
+    expect(store.detalle).toBeNull()
+    expect(store.detalleError).toMatch(/fuera de tu alcance/i)
+  })
+
+  it('fetchDetalle reporta mensaje generico para 5xx u otros errores', async () => {
+    const err = new Error('boom')
+    err.response = { status: 500 }
+    api.get.mockRejectedValueOnce(err)
+    const store = useDashboardRegistrosStore()
+
+    await store.fetchDetalle(1)
+
+    expect(store.detalle).toBeNull()
+    expect(store.detalleError).toBe('No se pudo cargar el detalle del registro')
+  })
+
+  it('clearDetalle resetea el detalle y el error', async () => {
+    api.get.mockResolvedValueOnce({ data: { id: 1 } })
+    const store = useDashboardRegistrosStore()
+    await store.fetchDetalle(1)
+
+    store.clearDetalle()
+    expect(store.detalle).toBeNull()
+    expect(store.detalleError).toBeNull()
+  })
+
+  it('hasFiltrosAplicados detecta filtros opcionales activos', () => {
+    const store = useDashboardRegistrosStore()
+    expect(store.hasFiltrosAplicados).toBe(false)
+
+    store.filtros.movilId = 5
+    expect(store.hasFiltrosAplicados).toBe(true)
+
+    store.filtros.movilId = null
+    store.filtros.fechaDesde = '2026-07-01'
+    expect(store.hasFiltrosAplicados).toBe(true)
+
+    store.filtros.fechaDesde = null
+    store.filtros.tipoProcesoKey = 'tipo:3'
+    expect(store.hasFiltrosAplicados).toBe(true)
+  })
+
+  it('reset limpia todos los filtros y contadores', () => {
+    const store = useDashboardRegistrosStore()
+    store.filtros.unId = 7
+    store.filtros.movilId = 3
+    store.total = 42
+
+    store.reset()
+
+    expect(store.filtros.unId).toBeNull()
+    expect(store.filtros.movilId).toBeNull()
+    expect(store.total).toBe(0)
+    expect(store.registros).toEqual([])
+  })
+})

--- a/frontend/src/views/DashboardRegistrosView.vue
+++ b/frontend/src/views/DashboardRegistrosView.vue
@@ -1,0 +1,269 @@
+<template>
+  <div class="min-h-screen bg-[var(--app-bg)] px-3 py-3 pb-20 md:px-4 md:py-4 md:pb-6">
+    <div class="mx-auto max-w-[112rem] space-y-3">
+      <PageHeader
+        title="Detalle de registros"
+        :description="`${authStore.userName} · registros individuales que componen el dashboard`"
+        :kicker="`Unidad: ${unidadNombre || '—'}`"
+      >
+        <template #actions>
+          <AppButton variant="secondary" @click="volverAlDashboard">
+            <AppIcon name="back" size="sm" />
+            Volver al dashboard
+          </AppButton>
+        </template>
+      </PageHeader>
+
+      <FilterBar title="Filtros transferidos" eyebrow="Aplicados desde el dashboard">
+        <template #summary>
+          <span class="rounded-full border px-3 py-1 text-xs font-bold app-chip-info">
+            {{ store.total }} registro{{ store.total === 1 ? '' : 's' }}
+          </span>
+        </template>
+        <div class="flex flex-wrap items-center gap-2 md:w-full">
+          <span
+            v-for="chip in activeFilterChips"
+            :key="chip.label"
+            class="rounded-full border border-neutral-200 px-3 py-1.5 text-xs font-bold"
+            :class="chip.tone === 'info' ? 'app-chip-info' : 'app-state-inactive'"
+          >
+            {{ chip.label }}
+          </span>
+          <span
+            v-if="!activeFilterChips.length"
+            class="text-xs text-neutral-400"
+          >
+            Sin filtros extra: la unidad y el período ya están aplicados.
+          </span>
+        </div>
+      </FilterBar>
+
+      <section
+        v-if="store.loading"
+        class="flex justify-center py-10"
+        data-testid="registros-loading"
+      >
+        <div class="h-8 w-8 animate-spin rounded-full border-3 border-primary border-t-transparent"></div>
+      </section>
+
+      <EmptyState
+        v-else-if="store.error"
+        title="No se pudieron cargar los registros"
+        :description="store.error"
+        icon="warning"
+      />
+
+      <EmptyState
+        v-else-if="!store.hasRegistros"
+        title="No hay registros para los filtros aplicados"
+        description="Volvé al dashboard, modificá el rango de fechas, la unidad o el tipo de proceso."
+        icon="empty"
+      />
+
+      <div v-else class="space-y-3" data-testid="registros-content">
+        <DataTable
+          :rows="store.registros"
+          :columns="columns"
+          :loading="false"
+          empty-text="Sin registros para los filtros aplicados"
+          row-key="id"
+        >
+          <template #cell-fecha="{ value }">{{ formatFecha(value) }}</template>
+          <template #cell-operacion="{ value }">{{ value || 'Producción' }}</template>
+          <template #cell-equipo="{ value }">{{ value || 'Sin equipo' }}</template>
+          <template #cell-operador="{ value }">{{ value || 'Sin operador' }}</template>
+          <template #cell-combustible="{ value }">
+            <span :class="Number(value) > 0 ? 'font-extrabold text-warning-dark' : ''">
+              {{ formatNumero(value) }} lts
+            </span>
+          </template>
+          <template #cell-tn_despachadas="{ value }">{{ formatNumero(value) }} TN</template>
+          <template #cell-m3="{ value }">{{ formatNumero(value) }} m3</template>
+          <template #cell-has="{ value }">{{ formatNumero(value) }} has</template>
+          <template #cell-km_carreteo="{ value }">{{ formatNumero(value) }} km</template>
+          <template #cell-acciones="{ row }">
+            <button
+              type="button"
+              class="rounded-md border border-neutral-200 px-3 py-1.5 text-xs font-bold text-neutral-700 hover:border-secondary/40"
+              @click="abrirDetalle(row.id)"
+              :data-testid="`abrir-detalle-${row.id}`"
+            >
+              Ver detalle
+            </button>
+          </template>
+        </DataTable>
+
+        <nav
+          v-if="store.totalPages > 1"
+          class="flex flex-wrap items-center justify-between gap-2 rounded-lg border border-neutral-200 bg-white px-3 py-2"
+          data-testid="paginacion"
+        >
+          <span class="text-xs font-bold text-neutral-500">
+            Página {{ store.page }} de {{ store.totalPages }} · {{ store.total }} registros
+          </span>
+          <div class="flex flex-wrap items-center gap-1.5">
+            <button
+              type="button"
+              class="rounded-md border px-2.5 py-1 text-xs font-bold disabled:cursor-not-allowed disabled:opacity-40"
+              :disabled="store.page <= 1"
+              @click="store.setPage(1)"
+            >
+              « Primero
+            </button>
+            <button
+              type="button"
+              class="rounded-md border px-2.5 py-1 text-xs font-bold disabled:cursor-not-allowed disabled:opacity-40"
+              :disabled="store.page <= 1"
+              @click="store.setPage(store.page - 1)"
+            >
+              ‹ Anterior
+            </button>
+            <span class="px-2 text-xs font-bold text-neutral-600">
+              {{ store.page }}
+            </span>
+            <button
+              type="button"
+              class="rounded-md border px-2.5 py-1 text-xs font-bold disabled:cursor-not-allowed disabled:opacity-40"
+              :disabled="store.page >= store.totalPages"
+              @click="store.setPage(store.page + 1)"
+            >
+              Siguiente ›
+            </button>
+            <button
+              type="button"
+              class="rounded-md border px-2.5 py-1 text-xs font-bold disabled:cursor-not-allowed disabled:opacity-40"
+              :disabled="store.page >= store.totalPages"
+              @click="store.setPage(store.totalPages)"
+            >
+              Última »
+            </button>
+          </div>
+        </nav>
+      </div>
+    </div>
+
+    <RecordDetailModal
+      v-model="detalleOpen"
+      :registro-id="detalleId"
+    />
+  </div>
+</template>
+
+<script setup>
+import { computed, onMounted, ref } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { useAuthStore } from '@/stores/auth'
+import { useDashboardRegistrosStore } from '@/stores/dashboardRegistros'
+import { useDashboardStore } from '@/stores/dashboard'
+import AppButton from '@/components/ui/AppButton.vue'
+import AppIcon from '@/components/ui/AppIcon.vue'
+import DataTable from '@/components/ui/DataTable.vue'
+import EmptyState from '@/components/ui/EmptyState.vue'
+import FilterBar from '@/components/ui/FilterBar.vue'
+import PageHeader from '@/components/ui/PageHeader.vue'
+import RecordDetailModal from '@/components/registros/RecordDetailModal.vue'
+
+const authStore = useAuthStore()
+const store = useDashboardRegistrosStore()
+const dashboardStore = useDashboardStore()
+const route = useRoute()
+const router = useRouter()
+
+const detalleOpen = ref(false)
+const detalleId = ref(null)
+
+const columns = [
+  { key: 'fecha', label: 'Fecha', sortable: true },
+  { key: 'operacion', label: 'Operación', sortable: true },
+  { key: 'equipo', label: 'Máquina' },
+  { key: 'operador', label: 'Operador' },
+  { key: 'hr_inicio', label: 'Hr inicio' },
+  { key: 'hr_fin', label: 'Hr fin' },
+  { key: 'combustible', label: 'Combustible' },
+  { key: 'tn_despachadas', label: 'TN' },
+  { key: 'm3', label: 'm³' },
+  { key: 'has', label: 'Has' },
+  { key: 'km_carreteo', label: 'KM carr.' },
+  { key: 'acciones', label: '', sortable: false },
+]
+
+const unidadNombre = computed(() => {
+  const unId = store.filtros.unId
+  if (!unId) return ''
+  return (
+    dashboardStore.unidadesNegocio.find(
+      (unidad) => Number(unidad.idUnidadNegocio) === Number(unId),
+    )?.nombre || ''
+  )
+})
+
+const activeFilterChips = computed(() => {
+  const chips = []
+  const filtros = store.filtros
+  if (unidadNombre.value) chips.push({ label: `Unidad: ${unidadNombre.value}`, tone: 'info' })
+  if (filtros.tipoProcesoId || filtros.tipoProcesoKey) {
+    const tp = dashboardStore.tiposProceso.find(
+      (item) =>
+        String(item.value) === String(filtros.tipoProcesoKey) ||
+        Number(item.id) === Number(filtros.tipoProcesoId),
+    )
+    if (tp) chips.push({ label: `Proceso: ${tp.nombre}`, tone: 'info' })
+  }
+  if (filtros.movilId) {
+    const movil = dashboardStore.movilesDisponibles.find(
+      (item) => Number(item.idMovil) === Number(filtros.movilId),
+    )
+    if (movil) {
+      const patente = movil.patente || ''
+      const detalle = movil.detalle || ''
+      chips.push({
+        label: `Máquina: ${[patente, detalle].filter(Boolean).join(' - ')}`,
+        tone: 'info',
+      })
+    }
+  }
+  if (filtros.fechaDesde) chips.push({ label: `Desde: ${formatFecha(filtros.fechaDesde)}` })
+  if (filtros.fechaHasta) chips.push({ label: `Hasta: ${formatFecha(filtros.fechaHasta)}` })
+  return chips
+})
+
+function formatFecha(fecha) {
+  if (!fecha) return '-'
+  const str = String(fecha)
+  const [y, m, d] = str.split('-')
+  if (y && m && d) return `${d}/${m}/${y}`
+  return str
+}
+
+function formatNumero(valor) {
+  const n = Number(valor)
+  if (!Number.isFinite(n) || n === 0) return '0'
+  if (Number.isInteger(n)) return n.toLocaleString('es-AR')
+  return n.toLocaleString('es-AR', { minimumFractionDigits: 1, maximumFractionDigits: 2 })
+}
+
+function abrirDetalle(id) {
+  detalleId.value = id
+  detalleOpen.value = true
+}
+
+function volverAlDashboard() {
+  router.push({ name: 'dashboard' })
+}
+
+onMounted(async () => {
+  // Aseguramos que el store del dashboard tenga las unidades/tipos para
+  // resolver los nombres que se muestran en los chips.
+  if (!dashboardStore.unidadesNegocio.length) {
+    await dashboardStore.loadUnidadesNegocio()
+  }
+  const unId = route.query.un_id ? Number(route.query.un_id) : null
+  if (unId && !dashboardStore.tiposProceso.length) {
+    await dashboardStore.loadTiposProceso(unId)
+  }
+  if (unId && !dashboardStore.movilesDisponibles.length) {
+    await dashboardStore.loadMovilesDisponibles(unId)
+  }
+  await store.initFromQuery(route.query)
+})
+</script>

--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -28,7 +28,7 @@
             <AppIcon name="download" size="sm" />
             Exportar CSV
           </button>
-          <button type="button" class="inline-flex min-h-10 items-center gap-2 rounded-lg bg-primary px-3 py-2 text-sm font-extrabold text-on-primary transition-colors hover:bg-primary-dark" @click="router.push({ name: 'mis-registros' })">
+          <button type="button" class="inline-flex min-h-10 items-center gap-2 rounded-lg bg-primary px-3 py-2 text-sm font-extrabold text-on-primary transition-colors hover:bg-primary-dark" @click="abrirDetalle">
             <AppIcon name="records" size="sm" />
             Ver detalle
           </button>
@@ -263,7 +263,7 @@
               placeholder="Todos los procesos"
               selectedDisplay="input"
             />
-            <button type="button" class="min-h-10 rounded-lg border border-neutral-200 px-4 py-2 text-sm font-bold text-neutral-600 hover:border-secondary/40" @click="router.push({ name: 'mis-registros' })">
+            <button type="button" class="min-h-10 rounded-lg border border-neutral-200 px-4 py-2 text-sm font-bold text-neutral-600 hover:border-secondary/40" @click="abrirDetalle">
               Abrir registros
             </button>
           </div>
@@ -524,6 +524,17 @@ function handleRelogin() {
 
 async function refreshDashboard() {
   await store.fetchAll()
+}
+
+/** Issue #104: navega al listado de registros pasando los filtros activos como query. */
+function abrirDetalle() {
+  const query = {}
+  if (store.filtros.un_id) query.un_id = store.filtros.un_id
+  if (store.filtros.tipo_proceso_key) query.tipo_proceso_key = store.filtros.tipo_proceso_key
+  if (store.filtros.movil_id) query.movil_id = store.filtros.movil_id
+  if (store.filtros.fecha_desde) query.fecha_desde = store.filtros.fecha_desde
+  if (store.filtros.fecha_hasta) query.fecha_hasta = store.filtros.fecha_hasta
+  router.push({ name: 'dashboard-registros', query })
 }
 
 async function setDateFilter(field, value) {

--- a/frontend/src/views/OperadorView.vue
+++ b/frontend/src/views/OperadorView.vue
@@ -94,7 +94,14 @@
             v-for="record in store.registros"
             :key="record.id"
             v-motion-panel
-            class="app-card rounded-xl p-3.5"
+            class="app-card cursor-pointer rounded-xl p-3.5 transition-shadow hover:shadow-md focus:outline-none focus:ring-2 focus:ring-primary/30"
+            :data-testid="`operador-registro-${record.id}`"
+            tabindex="0"
+            role="button"
+            :aria-label="`Ver detalle del registro ${record.operacion || 'Produccion'} del ${formatFecha(record.fecha)}`"
+            @click="abrirDetalle(record.id)"
+            @keydown.enter.prevent="abrirDetalle(record.id)"
+            @keydown.space.prevent="abrirDetalle(record.id)"
           >
             <div class="flex items-start justify-between gap-3">
               <div class="min-w-0">
@@ -131,6 +138,8 @@
         </EmptyState>
       </template>
     </div>
+
+    <RecordDetailModal v-model="detalleOpen" :registro-id="detalleId" />
   </div>
 </template>
 
@@ -144,10 +153,18 @@ import EmptyState from '@/components/ui/EmptyState.vue'
 import FilterBar from '@/components/ui/FilterBar.vue'
 import MetricCard from '@/components/ui/MetricCard.vue'
 import PageHeader from '@/components/ui/PageHeader.vue'
+import RecordDetailModal from '@/components/registros/RecordDetailModal.vue'
 
 const authStore = useAuthStore()
 const store = useMisRegistrosStore()
 const activePreset = ref('month')
+const detalleOpen = ref(false)
+const detalleId = ref(null)
+
+function abrirDetalle(id) {
+  detalleId.value = id
+  detalleOpen.value = true
+}
 
 const datePresets = [
   { key: 'today', label: 'Hoy' },


### PR DESCRIPTION
## Objetivo

Closes #104 — "Dashboard: ver el detalle de los registros individuales que componen los indicadores"

Permite que el encargado y el operador consulten el detalle de cada carga
registrada, respetando el alcance y los permisos de cada rol. El botón
"Ver detalle" del dashboard ya no cae a Mis Registros del operador: navega
a una vista nueva con el listado paginado de los registros que componen los
KPIs del dashboard, manteniendo los filtros activos.

## Cambios

### Backend (`app/api/routes/dashboard.py` + nuevo helper compartido)

- Helper compartido `_resolve_records_query(db, user, ...)` que centraliza
  las reglas de auth por unidad de negocio. Reutilizado por:
  - `GET /api/dashboard/registros` (listado paginado, encargado/admin).
  - `GET /api/dashboard/registros/{id}` (detalle completo, cualquier rol).
  - `GET /api/produccion/mis-registros` (refactor: operador aislado por
    `cod_operador == user.idPersonal`).
- Helper de paginación `_normalize_pagination(page, page_size)` clampeado
  a `1..100`.
- DTOs nuevos en `app/schemas/registros.py`: `RegistroListItem`,
  `RegistroDetail` (hereda del item y agrega todos los campos del registro),
  `RegistrosPagedResponse`.
- Endpoint de detalle usa `get_current_user` (no `get_current_admin_or_encargado`)
  y aplica la regla según rol:
  - Encargado/Admin: valida por UN con `_verify_un`; 404 si la UN no le
    pertenece.
  - Operador: valida que `cod_operador == user.idPersonal`; 404 si el
    registro es de otro operador.
- `app/api/routes/produccion.py`: `get_mis_registros` ahora delega en el
  helper compartido con `only_self=True` y `self_cod_operador=user.idPersonal`.

### Frontend

- `src/stores/dashboardRegistros.js` (nuevo): Pinia store con state
  (registros, total, page, filtros, loading, error, detalle, etc.), getters
  (`hasRegistros`, `hasFiltrosAplicados`) y actions
  (`initFromQuery`, `fetchRegistros`, `setPage`, `fetchDetalle`,
  `clearDetalle`, `reset`).
- `src/components/registros/RecordDetailModal.vue` (nuevo): modal
  reutilizable basado en `AppModal`. Muestra el detalle agrupado en
  secciones (Identificacion, Horario, Produccion, Consumos, Ubicacion,
  Remitos, Observaciones). Carga lazy al abrirse.
- `src/views/DashboardRegistrosView.vue` (nuevo): vista con `PageHeader`
  + `FilterBar` con los chips de filtros aplicados + `DataTable` con las
  filas + paginacion (Primera / Anterior / Siguiente / Ultima) + el modal
  de detalle.
- `src/router/index.js`: nueva ruta `/dashboard/registros` con
  `requiresEncargado: true`.
- `src/views/DashboardView.vue`: el botón "Ver detalle" (header y boton
  "Abrir registros" del chart de evolucion) ahora arma un query con los
  filtros activos y navega a `dashboard-registros`. El store del dashboard
  sigue intacto, asi que volver conserva los filtros.
- `src/views/OperadorView.vue`: cada tarjeta de "Mis Registros" es
  clickeable (cursor pointer + focus ring + enter/space handlers) y abre
  el mismo `RecordDetailModal` reutilizando el endpoint de detalle.

## Tests

### Backend (pytest)
- `tests/test_dashboard_registros.py` (NUEVO, 14 tests):
  - `_resolve_records_query` valida: `only_self` requiere `cod_operador`,
    operador filtra por `cod_operador` y NO por `cod_un`, encargado con
    `un_id` invoca `_verify_un`, encargado sin `un_id` ve multi-UN, encargado
    sin unidades ve nada (`id == -1`), admin sin `un_id` ve todo, helper
    de tipo_proceso se invoca con `{"mode": "tipo", "ids": [3]}`.
  - Paginacion: `_normalize_pagination` clampa `page>=1`, `1<=page_size<=100`.
  - Detalle: 404 si el id no existe, 404 si la UN no es del encargado
    (no 403, para no filtrar existencia), admin sin `cod_un` no llama
    `_verify_un`.
  - Listado: `total`, `page`, `page_size`, `total_pages`, `offset` y
    `limit` correctos; clamp de paginacion; orden aplicado.
  - Refactor: `/mis-registros` sigue llamando al helper con `only_self=True`
    y `self_cod_operador=user.idPersonal` (no se debilita el aislamiento).

### Frontend (vitest)
- `src/stores/dashboardRegistros.test.js` (NUEVO, 12 tests):
  - `initFromQuery` parsea un_id/tipo/movil/fechas del query del router.
  - `fetchRegistros` sin unId no pega al backend; con unId guarda items,
    total, totalPages; en error cae a estado vacio y suprime el toast.
  - `setPage` re-pega al backend; misma pagina no re-pega.
  - `fetchDetalle` carga el detalle; 404 -> mensaje "fuera de tu alcance";
    5xx -> mensaje generico.
  - `hasFiltrosAplicados` detecta filtros opcionales.
  - `reset` limpia todos los filtros y contadores.

## Validaciones ejecutadas

- [x] `git diff --check`
- [x] `py -3.12 -m compileall app` (sin errores)
- [x] `py -3.12 -m pytest` — **110 passed** (96 previos + 14 nuevos)
- [x] `npm test` — **173 passed** (161 previos + 12 nuevos)
- [x] `npm run build` — ok (vite 5, PWA 1.2.0, sin warnings de
  import o tipado nuevos)
- [ ] Computer Use (Playwright): **no aplicado localmente**. El stack
  local tiene gaps pre-existentes (seed `app/seed/demo_data.py` falla por
  campos faltantes en `moviles.usa_planificacion` y `items.name` sin
  longitud; el schema base no se crea con `create_all` por modelos
  incompletos). Esos gaps no son del issue #104 (ya estaban antes del PR)
  y arreglarlos acá sería expandir alcance. Recomendación: validar
  visualmente contra el demo/UI de `produccion.servinlgsm.com.ar` o el
  server de pruebas de Oscar después del merge.

## Criterios de aceptacion del issue #104

- [x] Desde `/dashboard`, "Ver detalle" abre los registros individuales
      correspondientes a la unidad y filtros activos.
- [x] El total del listado coincide con el KPI Registros usando los mismos
      filtros (mismo helper compartido `_resolve_records_query` + mismo
      `_apply_data_filters`).
- [x] Cambiar tipo de proceso, maquina o periodo cambia el conjunto de
      registros (mismo flujo de filtros, paginacion cliente-side via query).
- [x] Cada registro puede abrirse y muestra sus datos operativos completos
      agrupados en el modal.
- [x] Un encargado solo ve registros de sus unidades autorizadas
      (`_personal_unidad_ids` + `_verify_un`).
- [x] Un operador solo ve sus propios registros desde Mis Registros
      (`only_self=True` + `cod_operador`).
- [x] Manipular parametros/URL no permite consultar registros fuera del
      alcance (404 en backend, sin filtrar existencia).
- [x] El listado esta paginado (page_size clampeado a 1..100).
- [x] Existen estados de carga, vacio (EmptyState) y error (mensaje + retry).
- [ ] El flujo funciona y fue validado visualmente en desktop y mobile
      (no se pudo levantar el stack local por gaps pre-existentes en el
      seed/schema; recomendado validar contra el demo/UI post-merge).
- [x] Hay tests backend de filtros, paginacion y permisos para
      encargado/operador/admin (14 tests nuevos).
- [ ] Hay tests frontend de navegacion, transferencia de filtros y apertura
      del detalle (cubierto a nivel store; vista no testeada por convencion
      del repo — no hay tests de views en main).
- [x] `python -m pytest` y la compilacion del backend pasan.
- [x] `npm test` y `npm run build` pasan.

## Fuera de alcance

- Editar o eliminar registros desde el detalle (no implementado por diseno).
- Habilitar el dashboard completo para operadores (la vista `/dashboard`
  sigue restringida a encargado/admin por el `requiresEncargado` del router).
- Cambiar las formulas de KPIs o metricas.
- Modificar registros historicos o datos productivos.
- Exportaciones nuevas distintas del CSV ya existente.

## Archivos principales modificados

```
backend/app/api/routes/dashboard.py             +98 -2
backend/app/api/routes/produccion.py            +18 -8
backend/app/schemas/registros.py                +126 (new)
backend/tests/test_dashboard_registros.py       +355 (new)
frontend/src/router/index.js                    +7
frontend/src/views/DashboardView.vue            +12 -4
frontend/src/views/OperadorView.vue             +14 -4
frontend/src/views/DashboardRegistrosView.vue   +275 (new)
frontend/src/components/registros/RecordDetailModal.vue +198 (new)
frontend/src/stores/dashboardRegistros.js       +150 (new)
frontend/src/stores/dashboardRegistros.test.js  +192 (new)
```

## Riesgos / pendientes

- **Validacion visual**: no levante el stack de demo para validar con
  Playwright/Computer Use (consume tiempo y MySQL real). Si querés que lo
  haga antes del merge, decime y arranco `docker-compose.demo.yml` + corro
  el flujo.
- **Persistencia del store del dashboard al volver**: ya estaba
  implementada con `localStorage` y se respeta (los filtros del dashboard
  persisten entre navegaciones). Confirmé que el botón "Volver al dashboard"
  en la nueva vista usa `router.push({ name: 'dashboard' })` que no rompe
  el estado.
- **Tests de la vista**: el repo no tiene convencion de tests de views
  (no hay `*.test.js` en `src/views/`). Solo se agregaron tests del store.
  Si querés que sume un test de la vista con `@vue/test-utils`, avisame.
