### PR TITLE
fix(ui): listado de /dashboard/registros mobile-friendly con cards densas

### DIFF
--- a/frontend/src/views/DashboardRegistrosView.vue
+++ b/frontend/src/views/DashboardRegistrosView.vue
@@ -61,37 +61,107 @@
       />
 
       <div v-else class="space-y-3" data-testid="registros-content">
-        <DataTable
-          :rows="store.registros"
-          :columns="columns"
-          :loading="false"
-          empty-text="Sin registros para los filtros aplicados"
-          row-key="id"
+        <div class="hidden md:block">
+          <DataTable
+            :rows="store.registros"
+            :columns="columns"
+            :loading="false"
+            empty-text="Sin registros para los filtros aplicados"
+            row-key="id"
+          >
+            <template #cell-fecha="{ value }">{{ formatFecha(value) }}</template>
+            <template #cell-operacion="{ value }">{{ value || 'Producción' }}</template>
+            <template #cell-equipo="{ value }">{{ value || 'Sin equipo' }}</template>
+            <template #cell-operador="{ value }">{{ value || 'Sin operador' }}</template>
+            <template #cell-combustible="{ value }">
+              <span :class="Number(value) > 0 ? 'font-extrabold text-warning-dark' : ''">
+                {{ formatNumero(value) }} lts
+              </span>
+            </template>
+            <template #cell-tn_despachadas="{ value }">{{ formatNumero(value) }} TN</template>
+            <template #cell-m3="{ value }">{{ formatNumero(value) }} m3</template>
+            <template #cell-has="{ value }">{{ formatNumero(value) }} has</template>
+            <template #cell-km_carreteo="{ value }">{{ formatNumero(value) }} km</template>
+            <template #cell-acciones="{ row }">
+              <button
+                type="button"
+                class="rounded-md border border-neutral-200 px-3 py-1.5 text-xs font-bold text-neutral-700 hover:border-secondary/40"
+                @click="abrirDetalle(row.id)"
+                :data-testid="`abrir-detalle-${row.id}`"
+              >
+                Ver detalle
+              </button>
+            </template>
+          </DataTable>
+        </div>
+
+        <section
+          class="space-y-2 md:hidden"
+          data-testid="registros-cards"
         >
-          <template #cell-fecha="{ value }">{{ formatFecha(value) }}</template>
-          <template #cell-operacion="{ value }">{{ value || 'Producción' }}</template>
-          <template #cell-equipo="{ value }">{{ value || 'Sin equipo' }}</template>
-          <template #cell-operador="{ value }">{{ value || 'Sin operador' }}</template>
-          <template #cell-combustible="{ value }">
-            <span :class="Number(value) > 0 ? 'font-extrabold text-warning-dark' : ''">
-              {{ formatNumero(value) }} lts
-            </span>
-          </template>
-          <template #cell-tn_despachadas="{ value }">{{ formatNumero(value) }} TN</template>
-          <template #cell-m3="{ value }">{{ formatNumero(value) }} m3</template>
-          <template #cell-has="{ value }">{{ formatNumero(value) }} has</template>
-          <template #cell-km_carreteo="{ value }">{{ formatNumero(value) }} km</template>
-          <template #cell-acciones="{ row }">
-            <button
-              type="button"
-              class="rounded-md border border-neutral-200 px-3 py-1.5 text-xs font-bold text-neutral-700 hover:border-secondary/40"
-              @click="abrirDetalle(row.id)"
-              :data-testid="`abrir-detalle-${row.id}`"
-            >
-              Ver detalle
-            </button>
-          </template>
-        </DataTable>
+          <article
+            v-for="record in store.registros"
+            :key="`card-${record.id}`"
+            v-motion-panel
+            class="app-card cursor-pointer rounded-xl p-3 transition-shadow hover:shadow-md focus:outline-none focus:ring-2 focus:ring-primary/30"
+            :data-testid="`abrir-detalle-card-${record.id}`"
+            tabindex="0"
+            role="button"
+            :aria-label="`Ver detalle del registro ${record.operacion || 'Produccion'} del ${formatFecha(record.fecha)}`"
+            @click="abrirDetalle(record.id)"
+            @keydown.enter.prevent="abrirDetalle(record.id)"
+            @keydown.space.prevent="abrirDetalle(record.id)"
+          >
+            <div class="flex items-start justify-between gap-2">
+              <div class="min-w-0 flex-1">
+                <div class="flex flex-wrap items-center gap-x-2 gap-y-1">
+                  <span class="inline-flex max-w-full rounded-lg bg-info-light px-2 py-0.5 text-xs font-bold uppercase tracking-wide text-info-dark">
+                    <span class="truncate">{{ record.operacion || 'Producción' }}</span>
+                  </span>
+                  <span class="text-xs font-semibold text-neutral-400">{{ formatFecha(record.fecha) }}</span>
+                </div>
+                <p class="mt-1.5 truncate text-sm font-bold text-neutral-900">{{ record.equipo || 'Sin equipo' }}</p>
+                <p class="truncate text-xs font-semibold text-neutral-500">{{ record.operador || 'Sin operador' }}</p>
+              </div>
+              <span class="shrink-0 text-right text-[11px] font-bold text-neutral-500">
+                {{ formatHora(record.hr_inicio) }} – {{ formatHora(record.hr_fin) }}
+              </span>
+            </div>
+
+            <div class="mt-2.5 flex flex-wrap gap-1.5">
+              <span
+                v-if="Number(record.combustible) > 0"
+                class="rounded-lg bg-warning-light px-2 py-0.5 text-xs font-extrabold text-warning-dark"
+              >
+                ⛽ {{ formatNumero(record.combustible) }} lts
+              </span>
+              <span
+                v-if="Number(record.tn_despachadas) > 0"
+                class="rounded-lg border app-state-inactive px-2 py-0.5 text-xs font-extrabold text-neutral-700"
+              >
+                {{ formatNumero(record.tn_despachadas) }} TN
+              </span>
+              <span
+                v-if="Number(record.m3) > 0"
+                class="rounded-lg border app-state-inactive px-2 py-0.5 text-xs font-extrabold text-neutral-700"
+              >
+                {{ formatNumero(record.m3) }} m³
+              </span>
+              <span
+                v-if="Number(record.has) > 0"
+                class="rounded-lg border app-state-inactive px-2 py-0.5 text-xs font-extrabold text-neutral-700"
+              >
+                {{ formatNumero(record.has) }} has
+              </span>
+              <span
+                v-if="Number(record.km_carreteo) > 0"
+                class="rounded-lg border app-state-inactive px-2 py-0.5 text-xs font-extrabold text-neutral-700"
+              >
+                {{ formatNumero(record.km_carreteo) }} km
+              </span>
+            </div>
+          </article>
+        </section>
 
         <nav
           v-if="store.totalPages > 1"
@@ -240,6 +310,12 @@ function formatNumero(valor) {
   if (!Number.isFinite(n) || n === 0) return '0'
   if (Number.isInteger(n)) return n.toLocaleString('es-AR')
   return n.toLocaleString('es-AR', { minimumFractionDigits: 1, maximumFractionDigits: 2 })
+}
+
+function formatHora(valor) {
+  const n = Number(valor)
+  if (!Number.isFinite(n) || n === 0) return '—'
+  return n.toLocaleString('es-AR', { minimumFractionDigits: 0, maximumFractionDigits: 2 })
 }
 
 function abrirDetalle(id) {


### PR DESCRIPTION
## Contexto

El listado de `/dashboard/registros` (issue #104, deployado en PR #111/#113) usa una `DataTable` que en mobile se renderizaba mal: las celdas de Máquina y Operador tienen texto largo (patente + detalle + nombre completo) que no trunca bien y la tabla se sale del viewport.

Screenshot del problema enviado por Oscar (visto en celular, viewport ~360px).

## Cambio

Cambio localizado en `frontend/src/views/DashboardRegistrosView.vue`:

- Envuelvo la `DataTable` en un `<div class="hidden md:block">` para que solo se muestre en desktop (>= 768px).
- Agrego un `<section class="md:hidden">` con **cards densas** que se muestra solo en mobile (< 768px). Cada card incluye:
  - Header: badge de operación + fecha + equipo + operador (todo con `truncate` para no desbordar).
  - Lado derecho del header: `hr_inicio – hr_fin` (con `formatHora` que muestra 0 como `—`).
  - Chips de métricas solo si el valor es > 0: combustible (con icono ⛽ y color warning), TN, m³, has, km carreteo. Esto evita ruido visual cuando una métrica no aplica al registro.
- Cada card es clickeable: `cursor-pointer`, `hover:shadow-md`, `focus:ring`, `tabindex="0"`, handlers `@click` + `@keydown.enter/space`. Abre el mismo `RecordDetailModal` que ya existía, vía `abrirDetalle(record.id)`.
- `data-testid="abrir-detalle-card-${id}"` para los tests E2E.
- La paginación queda compartida entre desktop y mobile (mismo `store.dashboardRegistros`).

No se cambia el store, el endpoint, ni el modal. Es un fix puramente visual.

## Por qué `--md` y no JS

Tailwind tiene el breakpoint `md` en 768px por convención. La detección por CSS (no JS) evita:
- Flicker en el cambio de viewport.
- Overhead de un listener de `resize`.
- Hidratación distinta entre server-side rendering y cliente.

## Patrón usado

Mismo patrón de `OperadorView.vue` (la vista de Mis Registros) que ya era mobile-friendly y gustó. Reusar el patrón existente mantiene la consistencia visual y reduce la deuda cognitiva.

## Validaciones

- [x] `git diff --check` (sin warnings de espacios/whitespace)
- [x] `npx vitest run` — **190 passed** (sin cambios, los tests del store siguen pasando)
- [x] `npm run build` — ok. Bundle de `DashboardRegistrosView` pasa de 9.01 kB a 11.68 kB (+2.67 kB gzip 4.17 kB) por las cards mobile.
- [ ] Validación visual: se necesita probar en un dispositivo móvil o con DevTools en modo responsive. **No levantado localmente** porque el stack local tiene gaps pre-existentes del seed/schema (issue separado). Oscar lo prueba en `produccion.servinlgsm.com.ar` después del deploy.

## Fuera de alcance

- No se cambia el store `dashboardRegistros` ni el endpoint `/api/dashboard/registros`.
- No se cambia el modal `RecordDetailModal`.
- No se modifica la versión desktop (la tabla sigue funcionando igual).
- No se hacen tests de Playwright (el repo no tiene convención de tests E2E).

## Riesgos

- El breakpoint `md` (768px) es estándar pero podría ajustarse si en tu PWA el layout pide un breakpoint distinto.
- Si el operador quiere ver las horas en formato `HH:MM` en vez de decimal (`8.5` en vez de `08:30`), eso es un follow-up aparte (hay que transformar la lógica de formato de horas, no es solo CSS).

## Después del merge

Deployamos con el procedimiento canónico del PR #110 (`scripts/deploy_produccion_fg_main_fasa195.sh --check + --deploy --yes`).
