### PR TITLE
fix(pwa): agregar fallback de instalación para Mi Browser

### DIFF
--- a/frontend/src/composables/usePwaInstallStatus.js
+++ b/frontend/src/composables/usePwaInstallStatus.js
@@ -1,0 +1,64 @@
+import { computed, onMounted, onUnmounted, ref, unref } from 'vue'
+
+export const PWA_DISPLAY_MODE_QUERY = '(display-mode: standalone)'
+export const CHROME_PLAY_STORE_URL =
+  'https://play.google.com/store/apps/details?id=com.android.chrome'
+
+export function isXiaomiBrowserUserAgent(userAgent = '') {
+  return /MiuiBrowser|Mi Browser|Mint Browser/i.test(userAgent)
+}
+
+export function isStandaloneDisplay(windowObject, navigatorObject) {
+  const matchesStandalone =
+    typeof windowObject?.matchMedia === 'function' &&
+    windowObject.matchMedia(PWA_DISPLAY_MODE_QUERY).matches
+
+  return Boolean(matchesStandalone || navigatorObject?.standalone === true)
+}
+
+export function usePwaInstallStatus(
+  pwaInstall,
+  {
+    windowObject = typeof window !== 'undefined' ? window : undefined,
+    navigatorObject = typeof navigator !== 'undefined' ? navigator : undefined,
+  } = {},
+) {
+  const displayModeQuery =
+    typeof windowObject?.matchMedia === 'function'
+      ? windowObject.matchMedia(PWA_DISPLAY_MODE_QUERY)
+      : null
+
+  const isStandalone = ref(isStandaloneDisplay(windowObject, navigatorObject))
+  const isXiaomiBrowser = ref(
+    isXiaomiBrowserUserAgent(navigatorObject?.userAgent || ''),
+  )
+  const canInstall = computed(
+    () => !isStandalone.value && Boolean(unref(pwaInstall?.deferredInstallPrompt)),
+  )
+
+  function updateDisplayMode() {
+    isStandalone.value = isStandaloneDisplay(windowObject, navigatorObject)
+  }
+
+  onMounted(() => {
+    if (typeof displayModeQuery?.addEventListener === 'function') {
+      displayModeQuery.addEventListener('change', updateDisplayMode)
+    } else if (typeof displayModeQuery?.addListener === 'function') {
+      displayModeQuery.addListener(updateDisplayMode)
+    }
+  })
+
+  onUnmounted(() => {
+    if (typeof displayModeQuery?.removeEventListener === 'function') {
+      displayModeQuery.removeEventListener('change', updateDisplayMode)
+    } else if (typeof displayModeQuery?.removeListener === 'function') {
+      displayModeQuery.removeListener(updateDisplayMode)
+    }
+  })
+
+  return {
+    canInstall,
+    isStandalone,
+    isXiaomiBrowser,
+  }
+}

--- a/frontend/src/views/ConfiguracionView.test.js
+++ b/frontend/src/views/ConfiguracionView.test.js
@@ -1,0 +1,121 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { ref } from 'vue'
+
+const routerPush = vi.hoisted(() => vi.fn())
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push: routerPush }),
+}))
+
+import { CHROME_PLAY_STORE_URL } from '@/composables/usePwaInstallStatus'
+import ConfiguracionView from './ConfiguracionView.vue'
+
+const originalMatchMediaDescriptor = Object.getOwnPropertyDescriptor(window, 'matchMedia')
+const originalUserAgentDescriptor = Object.getOwnPropertyDescriptor(
+  window.navigator,
+  'userAgent',
+)
+
+function setBrowser({ standalone = false, userAgent = 'Mozilla/5.0 Chrome/126.0' } = {}) {
+  Object.defineProperty(window, 'matchMedia', {
+    configurable: true,
+    writable: true,
+    value: vi.fn(() => ({
+      matches: standalone,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    })),
+  })
+  Object.defineProperty(window.navigator, 'userAgent', {
+    configurable: true,
+    get: () => userAgent,
+  })
+}
+
+function mountView({ installPrompt = null, installApp = vi.fn() } = {}) {
+  return mount(ConfiguracionView, {
+    global: {
+      provide: {
+        pwaInstall: {
+          deferredInstallPrompt: ref(installPrompt),
+          installApp,
+        },
+      },
+      stubs: {
+        AppIcon: true,
+        PageHeader: true,
+      },
+    },
+  })
+}
+
+describe('ConfiguracionView PWA installation', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    routerPush.mockReset()
+    setBrowser()
+  })
+
+  afterEach(() => {
+    if (originalMatchMediaDescriptor) {
+      Object.defineProperty(window, 'matchMedia', originalMatchMediaDescriptor)
+    } else {
+      delete window.matchMedia
+    }
+    if (originalUserAgentDescriptor) {
+      Object.defineProperty(window.navigator, 'userAgent', originalUserAgentDescriptor)
+    } else {
+      delete window.navigator.userAgent
+    }
+  })
+
+  it('shows the native install action when beforeinstallprompt is available', async () => {
+    const installApp = vi.fn()
+    const beforeInstallPrompt = {
+      prompt: vi.fn(),
+      userChoice: Promise.resolve({ outcome: 'accepted' }),
+    }
+    const wrapper = mountView({ installPrompt: beforeInstallPrompt, installApp })
+
+    expect(wrapper.find('[data-testid="pwa-install-button"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="pwa-manual-install"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="chrome-play-link"]').attributes('href')).toBe(
+      CHROME_PLAY_STORE_URL,
+    )
+
+    await wrapper.find('[data-testid="pwa-install-button"]').trigger('click')
+    expect(installApp).toHaveBeenCalledOnce()
+  })
+
+  it('shows the installed state when running in standalone mode', () => {
+    setBrowser({ standalone: true })
+    const wrapper = mountView()
+
+    expect(wrapper.find('[data-testid="pwa-installed-message"]').text()).toContain(
+      'Ya tenés la app instalada en tu pantalla de inicio.',
+    )
+    expect(wrapper.find('[data-testid="pwa-install-button"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="pwa-manual-install"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="chrome-play-link"]').exists()).toBe(false)
+  })
+
+  it('shows Mi Browser instructions and the Chrome workaround without a native prompt', () => {
+    setBrowser({
+      userAgent:
+        'Mozilla/5.0 (Linux; U; Android 15) AppleWebKit/537.36 MiuiBrowser/18.5.120514 Mobile Safari/537.36',
+    })
+    const wrapper = mountView()
+    const manualFallback = wrapper.find('[data-testid="pwa-manual-install"]')
+    const chromeLink = wrapper.find('[data-testid="chrome-play-link"]')
+
+    expect(manualFallback.text()).toContain(
+      'Mi Browser no ofrece el botón automático de instalación.',
+    )
+    expect(manualFallback.text()).toContain('Agregar a la pantalla de inicio')
+    expect(chromeLink.attributes('href')).toBe(CHROME_PLAY_STORE_URL)
+    expect(chromeLink.attributes('target')).toBe('_blank')
+    expect(chromeLink.attributes('rel')).toBe('noopener noreferrer')
+  })
+})

--- a/frontend/src/views/ConfiguracionView.vue
+++ b/frontend/src/views/ConfiguracionView.vue
@@ -52,20 +52,69 @@
           </div>
         </div>
 
-        <template v-if="pwaInstall?.deferredInstallPrompt?.value">
-          <AppButton block @click="pwaInstall.installApp()">
-            <AppIcon name="download" :stroke-width="2.5" />
-            Instalar App
-          </AppButton>
+        <template v-if="isPwaStandalone">
+          <div
+            data-testid="pwa-installed-message"
+            class="app-surface-muted flex w-full items-center gap-3 rounded-lg border px-3.5 py-2.5"
+          >
+            <AppIcon name="success" :stroke-width="2.5" class="flex-shrink-0 text-success" />
+            <span class="text-sm font-semibold text-neutral-600">
+              Ya tenés la app instalada en tu pantalla de inicio.
+            </span>
+          </div>
         </template>
 
         <template v-else>
-          <div class="app-surface-muted flex w-full items-center gap-3 rounded-lg border px-3.5 py-2.5">
-            <AppIcon name="success" :stroke-width="2.5" class="flex-shrink-0 text-success" />
-            <span class="text-sm text-neutral-600">
-              La aplicación ya está instalada o la instalación no está disponible en este navegador.
-            </span>
+          <AppButton
+            v-if="canInstallPwa"
+            data-testid="pwa-install-button"
+            block
+            @click="pwaInstall?.installApp()"
+          >
+            <AppIcon name="download" :stroke-width="2.5" />
+            Instalar App
+          </AppButton>
+
+          <div
+            v-else
+            data-testid="pwa-manual-install"
+            class="app-surface-muted w-full rounded-lg border px-3.5 py-3"
+          >
+            <div class="flex items-start gap-3">
+              <AppIcon
+                name="warning"
+                :stroke-width="2.5"
+                class="mt-0.5 flex-shrink-0 text-warning-dark"
+              />
+              <div class="min-w-0 text-sm text-neutral-600">
+                <p class="font-bold text-neutral-800">
+                  {{ isXiaomiBrowser
+                    ? 'Mi Browser no ofrece el botón automático de instalación.'
+                    : 'Este navegador no ofrece el botón automático de instalación.'
+                  }}
+                </p>
+                <p class="mt-1">Podés agregar la app manualmente:</p>
+                <ol class="mt-2 list-decimal space-y-1 pl-5">
+                  <li>Tocá el menú <span aria-label="tres puntos verticales">⋮</span> del navegador.</li>
+                  <li>Elegí <strong>Agregar a la pantalla de inicio</strong>.</li>
+                  <li>Confirmá el acceso directo.</li>
+                </ol>
+              </div>
+            </div>
           </div>
+
+          <a
+            data-testid="chrome-play-link"
+            :href="CHROME_PLAY_STORE_URL"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="app-button-soft mt-3 flex min-h-11 w-full items-center justify-center gap-2 rounded-lg border px-3.5 py-2.5 text-center text-sm font-bold transition hover:-translate-y-px hover:border-primary/35 focus:outline-none focus:ring-2 focus:ring-primary/20 active:translate-y-0"
+          >
+            <AppIcon name="download" size="sm" />
+            <span>
+              Si no podés instalar la app desde este navegador, instalá Chrome desde Google Play
+            </span>
+          </a>
         </template>
       </section>
 
@@ -88,14 +137,23 @@ import { inject } from 'vue'
 import { useRouter } from 'vue-router'
 import { useAuthStore } from '@/stores/auth'
 import { useTheme } from '@/composables/useTheme'
+import {
+  CHROME_PLAY_STORE_URL,
+  usePwaInstallStatus,
+} from '@/composables/usePwaInstallStatus'
 import AppButton from '@/components/ui/AppButton.vue'
 import AppIcon from '@/components/ui/AppIcon.vue'
 import PageHeader from '@/components/ui/PageHeader.vue'
 
 const router = useRouter()
 const authStore = useAuthStore()
-const pwaInstall = inject('pwaInstall')
+const pwaInstall = inject('pwaInstall', null)
 const { isDark, toggleTheme } = useTheme()
+const {
+  canInstall: canInstallPwa,
+  isStandalone: isPwaStandalone,
+  isXiaomiBrowser,
+} = usePwaInstallStatus(pwaInstall)
 
 function handleLogout() {
   authStore.logout()

--- a/frontend/src/views/HomeView.vue
+++ b/frontend/src/views/HomeView.vue
@@ -178,8 +178,9 @@
             <RecentRecordsPanel />
             <QuickActions
               :actions="adminActions"
-              :show-install="Boolean(pwaInstall?.deferredInstallPrompt?.value)"
-              @install="pwaInstall?.installApp"
+              :show-install="!isPwaStandalone"
+              :install-available="canInstallPwa"
+              @install="handlePwaInstallAction"
             />
           </aside>
         </section>
@@ -231,8 +232,9 @@
             <SyncCard />
             <QuickActions
               :actions="operatorSecondaryActions"
-              :show-install="Boolean(pwaInstall?.deferredInstallPrompt?.value)"
-              @install="pwaInstall?.installApp"
+              :show-install="!isPwaStandalone"
+              :install-available="canInstallPwa"
+              @install="handlePwaInstallAction"
             />
           </aside>
         </section>
@@ -249,6 +251,7 @@ import { useProduccionStore } from '@/stores/produccion'
 import { useMisRegistrosStore } from '@/stores/misRegistros'
 import { useAdminStore } from '@/stores/admin'
 import { useConnectivityStore } from '@/stores/connectivity'
+import { usePwaInstallStatus } from '@/composables/usePwaInstallStatus'
 import AppIcon from '@/components/ui/AppIcon.vue'
 
 const authStore = useAuthStore()
@@ -258,6 +261,10 @@ const adminStore = useAdminStore()
 const connectivityStore = useConnectivityStore()
 const router = useRouter()
 const pwaInstall = inject('pwaInstall', null)
+const {
+  canInstall: canInstallPwa,
+  isStandalone: isPwaStandalone,
+} = usePwaInstallStatus(pwaInstall)
 const isOnline = computed(() => connectivityStore.isOnline)
 const backendReachable = computed(() => connectivityStore.isOnline && connectivityStore.isBackendUp)
 const backendConnectionLabel = computed(() => {
@@ -545,6 +552,7 @@ const QuickActions = defineComponent({
   props: {
     actions: { type: Array, required: true },
     showInstall: { type: Boolean, default: false },
+    installAvailable: { type: Boolean, default: false },
   },
   emits: ['install'],
   setup(props, { emit }) {
@@ -571,12 +579,23 @@ const QuickActions = defineComponent({
           onClick: () => emit('install'),
         }, h('span', [
           h('span', { class: 'block text-sm font-bold text-neutral-800' }, 'Instalar app'),
-          h('span', { class: 'block text-xs text-neutral-400' }, 'Acceso rapido y soporte offline.'),
+          h('span', { class: 'block text-xs text-neutral-400' }, props.installAvailable
+            ? 'Acceso rápido y soporte offline.'
+            : 'Ver opciones para este navegador.'),
         ])) : null,
       ]),
     ])
   },
 })
+
+function handlePwaInstallAction() {
+  if (canInstallPwa.value) {
+    pwaInstall?.installApp()
+    return
+  }
+
+  router.push({ name: 'configuracion' })
+}
 
 const LastPersonalRecord = defineComponent({
   setup() {


### PR DESCRIPTION
## Objetivo

Cuando el operador entra desde Mi Browser (Xiaomi) el botón nativo `beforeinstallprompt` no se dispara, así que la app no se podía instalar desde el dashboard ni desde la pantalla de Configuración. El PR agrega un fallback visual con instrucciones manuales y un link a Chrome en Google Play para esos casos, sin tocar el flujo nativo de Chrome/Edge.

## Cambios

- Nuevo composable `frontend/src/composables/usePwaInstallStatus.js`:
  - Detecta modo standalone (`display-mode: standalone` o `navigator.standalone`).
  - Detecta Mi Browser/MiuiBrowser/Mint Browser por user agent.
  - Expone `canInstall`, `isStandalone`, `isXiaomiBrowser` y la constante `CHROME_PLAY_STORE_URL`.
- `frontend/src/views/ConfiguracionView.vue`:
  - Si la app ya está instalada, mensaje "Ya tenés la app instalada en tu pantalla de inicio".
  - Si hay `beforeinstallprompt`, botón nativo "Instalar App".
  - Si no, fallback con instrucciones paso a paso (menú ⋮ → Agregar a la pantalla de inicio) más link a Chrome en Google Play.
- `frontend/src/views/HomeView.vue`:
  - `QuickActions` recibe `installAvailable` además de `showInstall`.
  - Si el navegador no puede instalar, el click en "Instalar app" navega a `/configuracion` en vez de mostrar un error silencioso.
- Tests nuevos en `frontend/src/views/ConfiguracionView.test.js` (3 casos: prompt nativo, standalone, Mi Browser).

## Tests / Validaciones

- [x] `npm test` — 26 archivos, 193 tests pasaron (incluye los 3 nuevos)
- [x] `npm run build` — OK, PWA SW regenerado
- [x] `gh pr view 118` — mergeable CLEAN, sin conflictos

## Fuera de alcance

- No cambia el service worker, ni la estrategia de cache, ni la auto-actualización.
- No agrega detección para otros navegadores chinos (Baidu, UC, Vivo). Solo Mi Browser.
- No modifica el backend.

## Riesgos / pendientes

- El botón "Instalar App" del Home sigue mostrando "Acceso rápido y soporte offline" como subtítulo cuando hay prompt nativo, y "Ver opciones para este navegador" cuando no. Validar visualmente con Computer Use si querés confirmar el copy en mobile.
- La detección de Mi Browser se hace por user agent; si Xiaomi cambia el string hay que actualizar la regex.