### PR TITLE
ux(modal): ocultar campos y grupos vacios (null/0/empty) en el detalle (closes #129)

### DIFF
--- a/frontend/src/components/registros/RecordDetailModal.test.js
+++ b/frontend/src/components/registros/RecordDetailModal.test.js
@@ -166,3 +166,108 @@ describe('RecordDetailModal (issue #123)', () => {
     expect(api.get).not.toHaveBeenCalled()
   })
 })
+
+describe('RecordDetailModal (issue #129) oculta campos vacios', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  /** Helper: monta el modal, deja resolver el fetch y devuelve el wrapper. */
+  async function mountConDetalle(detalle) {
+    api.get.mockResolvedValueOnce({ data: detalle })
+    const wrapper = mount(RecordDetailModal, {
+      props: { modelValue: true, registroId: detalle.id },
+      global: { stubs: globalStubs },
+    })
+    await flushPromises()
+    await flushPromises()
+    return wrapper
+  }
+
+  it('omite campos con null/0/empty string del DOM', async () => {
+    const wrapper = await mountConDetalle({
+      id: 1,
+      operacion: 'Cosecha',
+      fecha: '2026-08-04',
+      // todos los demas campos null/0
+      hr_inicio: 0,
+      hr_fin: 0,
+      hrs_no_op: 0,
+      motivo_no_op: '',
+      produccion: 0,
+      combustible: 0,
+    })
+
+    expect(wrapper.find('[data-testid="record-detail-content"]').exists()).toBe(true)
+    // Titulo sigue mostrando operacion + fecha
+    expect(wrapper.text()).toContain('Cosecha')
+    expect(wrapper.text()).toContain('04/08/2026')
+    // Labels que NO deben aparecer (porque sus valores son 0/null/empty)
+    expect(wrapper.text()).not.toContain('Hora inicio')
+    expect(wrapper.text()).not.toContain('Hora fin')
+    expect(wrapper.text()).not.toContain('Horas no operativas')
+    expect(wrapper.text()).not.toContain('Motivo no operativo')
+    expect(wrapper.text()).not.toContain('Produccion')
+    expect(wrapper.text()).not.toContain('Combustible')
+  })
+
+  it('omite grupos enteros cuando todos sus campos son vacios', async () => {
+    const wrapper = await mountConDetalle({
+      id: 2,
+      operacion: 'Cosecha',
+      fecha: '2026-08-04',
+      // grupo Identificacion tiene al menos operacion + fecha con dato
+      // grupo Produccion queda 100% vacio
+      produccion: 0,
+      unitario: 0,
+      tn_despachadas: 0,
+      m3: 0,
+      has: 0,
+      // grupo Consumos queda 100% vacio
+      combustible: 0,
+      aceite_cadena: 0,
+      aceite_hidraulico: 0,
+      aceite_motor: 0,
+      aceite_embrague: 0,
+      aceite_transmision: 0,
+    })
+
+    // Header "Identificacion" aparece (tiene operacion + fecha)
+    expect(wrapper.text()).toContain('Identificacion')
+    // Headers de grupos vacios NO aparecen
+    expect(wrapper.text()).not.toContain('Produccion')
+    expect(wrapper.text()).not.toContain('Consumos')
+  })
+
+  it('sigue mostrando el ID del registro en el footer aunque el contenido este vacio', async () => {
+    const wrapper = await mountConDetalle({
+      id: 999,
+      operacion: 'X',
+      fecha: '2026-08-04',
+    })
+
+    // Aunque hipoteticamente todos los grupos quedaran vacios, el ID del
+    // footer siempre se ve.
+    expect(wrapper.text()).toContain('ID #999')
+  })
+
+  it('muestra un grupo que tiene al menos un campo con dato aunque otros esten vacios', async () => {
+    const wrapper = await mountConDetalle({
+      id: 3,
+      operacion: 'Cosecha',
+      fecha: '2026-08-04',
+      produccion: 0,
+      tn_despachadas: 150,  // unico campo con dato en grupo Produccion
+      m3: 0,
+    })
+
+    expect(wrapper.text()).toContain('Produccion')
+    expect(wrapper.text()).toContain('Toneladas')
+    expect(wrapper.text()).toContain('150')
+    // El resto del grupo Produccion esta vacio
+    expect(wrapper.text()).not.toContain('Hectareas')
+    expect(wrapper.text()).not.toContain('KM carreteo')
+  })
+})

--- a/frontend/src/components/registros/RecordDetailModal.vue
+++ b/frontend/src/components/registros/RecordDetailModal.vue
@@ -19,7 +19,7 @@
 
     <div v-else-if="detalle" class="space-y-4" data-testid="record-detail-content">
       <section
-        v-for="grupo in grupos"
+        v-for="grupo in gruposVisibles"
         :key="grupo.titulo"
         class="rounded-lg border border-neutral-200 p-3"
       >
@@ -73,6 +73,23 @@ const descripcion = computed(() => {
   const equipo = detalle.value.equipo || 'Sin equipo'
   const operador = detalle.value.operador || 'Sin operador'
   return `${operador} - ${equipo}`
+})
+
+/** Devuelve true si el valor se considera "vacio" y debe ocultarse del modal. */
+function campoVacio(valor) {
+  return valor === null || valor === undefined || valor === '' || valor === '0' || valor === 0
+}
+
+/** Filtra los grupos para mostrar solo los campos con dato cargado.
+ *  Si un grupo queda sin campos visibles, tambien se oculta. */
+const gruposVisibles = computed(() => {
+  if (!detalle.value) return []
+  return grupos
+    .map((grupo) => ({
+      ...grupo,
+      campos: grupo.campos.filter((campo) => !campoVacio(detalle.value[campo.key])),
+    }))
+    .filter((grupo) => grupo.campos.length > 0)
 })
 
 const grupos = [


### PR DESCRIPTION
## Objetivo

Closes #129

Tras el fix #127, el modal de detalle del registro muestra 7 secciones con
muchos campos en `-` (placeholder para NULL/0/empty). Mejora de UX: ocultar
los campos sin dato cargado y, si un grupo queda sin campos visibles,
tambien ocultar el grupo (evita headers vacios como "Ubicacion y
referencia:" sin contenido abajo).

## Cambios

- `frontend/src/components/registros/RecordDetailModal.vue`:
  - Helper `campoVacio(valor)` que considera vacio `null` / `undefined` /
    `''` / `'0'` / `0` (mismo criterio que ya usa `formatCampo`).
  - Computed `gruposVisibles` que filtra los campos vacios de cada grupo
    y descarta los grupos sin campos visibles.
  - Template usa `gruposVisibles` en lugar de `grupos`.
- `frontend/src/components/registros/RecordDetailModal.test.js`:
  - Describe nuevo "RecordDetailModal (issue #129) oculta campos vacios"
    con 4 casos.

## Tests / Validaciones

- [x] `git diff --check` limpio
- [x] `npx vitest run` — **200/200** OK (10 tests del modal: 6 del #123 + 4 del #129)
- [x] `npx vite build` — OK

## Comportamiento

Antes (con fix #127 pero sin este PR):
- Modal muestra 7 secciones con muchos `-` para campos NULL/0/empty.

Despues:
- Modal muestra solo los grupos con datos y solo los campos con dato.
- Titulo/descripcion/ID del footer siguen mostrandose siempre.
- Loading / error / sin registro: comportamiento sin cambios.

## Evidencia visual post-deploy

Pendiente: capturar pantalla del modal con un registro que tenga varios
campos NULL para mostrar que solo aparecen los grupos con dato. Se guarda
en `docs/screenshots/issue-129-modal-ocultar-vacios/01-produccion-solo-datos.png`.

## Fuera de alcance

- No se cambia `formatCampo`: sigue devolviendo `-` cuando se llama con
  un valor vacio (util si alguien quiere mostrar un valor explicito en
  el futuro).
- No se tocan los call-sites.

## Riesgos / pendientes

- Bajo. Cambio additive, no rompe consumidores existentes. Si un grupo
  entero queda vacio, simplemente no se renderiza — la informacion que
  estaba ahi (NULL) es la que se queria ocultar.
