### PR TITLE
fix(combustible): normalizar remito numerico e hifenado a 12 digitos (closes #124)

### DIFF
--- a/backend/app/core/remito.py
+++ b/backend/app/core/remito.py
@@ -1,16 +1,24 @@
 """Normalizacion canonica del numero de remito de combustible.
 
-Issue #124: en produccion conviven dos formatos para el mismo remito
-("011278" vs "000000011278", "1" vs "000000000001") y eso hace que el
-reporte "Control de combustible" muestre la misma carga dos veces.
+Issue #124: en produccion conviven tres formatos para el mismo remito
+y eso hace que el reporte "Control de combustible" muestre la misma
+carga dos veces:
+
+* Numerico con padding variable: ``011278`` vs ``000000011278``,
+  ``1`` vs ``000000000001``.
+* Hifenado numerico: ``02-1335`` vs ``0000002-1335`` vs
+  ``000200001335``.
+* Alfanumerico con prefijo: ``R-0001``, ``D000001``.
 
 Reglas de normalizacion (aplicadas al recibir el POST):
 
 * Se eliminan espacios al principio y al final.
 * Si el valor es puramente numerico (``isdigit()``), se completa con
-  ceros a la izquierda hasta 12 caracteres para coincidir con el
-  formato del sistema legacy VFP y con el ancho de la columna
-  ``VARCHAR(12)``.
+  ceros a la izquierda hasta 12 caracteres.
+* Si el valor tiene un guion y ambas partes son numericas
+  (formato ``PPPPP-DDDDDDDD``), se reemplaza por la concatenacion
+  con la primera parte paddeada a 4 digitos y la segunda a 8
+  digitos (total 12).
 * Si el valor es alfanumerico (ej. ``R-0001``, ``D000001``), se
   conserva tal cual, en mayusculas, sin padding.
 * Solo se permiten letras ASCII (A-Z), digitos (0-9) y guion (-).
@@ -30,10 +38,17 @@ import re
 # ``tablero_produccion.remito`` (``VARCHAR(12)``).
 REMITO_MAX_LENGTH = 12
 
+# Anchos del formato con guion: prefijo de 4 digitos + sufijo de 8.
+# El guion se elimina y se reemplaza por padding a izquierda en cada
+# parte para obtener un total de 12 caracteres canonicos.
+_HYPHEN_PREFIX_WIDTH = 4
+_HYPHEN_SUFFIX_WIDTH = 8
+
 # Solo letras ASCII, digitos y guion. Esto rechaza espacios internos,
 # puntos, barras, simbolos, letras con tilde, etc.
 _ALLOWED_CHARS = re.compile(r"^[A-Z0-9-]+$")
 _DIGITS_ONLY = re.compile(r"^[0-9]+$")
+_HYPHEN_TWO_NUMERIC = re.compile(r"^([0-9]+)-([0-9]+)$")
 
 
 def normalize_remito(value: str | None) -> str:
@@ -54,6 +69,28 @@ def normalize_remito(value: str | None) -> str:
     if not _ALLOWED_CHARS.match(upper):
         raise ValueError(
             "El remito solo puede contener letras, numeros y guion (-)"
+        )
+
+    # Formato hifenado numerico: "PPPPP-DDDDDDDD" -> "PPPP" + "DDDDDDDD".
+    # Antes de validar el ancho limpiamos ceros a la izquierda en cada
+    # parte: en la base conviven "02-1335" y "0000002-1335" y ambos
+    # representan el mismo comprobante.
+    hyphen_match = _HYPHEN_TWO_NUMERIC.match(upper)
+    if hyphen_match:
+        prefix = hyphen_match.group(1).lstrip("0") or "0"
+        suffix = hyphen_match.group(2).lstrip("0") or "0"
+        if len(prefix) > _HYPHEN_PREFIX_WIDTH:
+            raise ValueError(
+                f"La parte anterior al guion no puede superar los "
+                f"{_HYPHEN_PREFIX_WIDTH} digitos"
+            )
+        if len(suffix) > _HYPHEN_SUFFIX_WIDTH:
+            raise ValueError(
+                f"La parte posterior al guion no puede superar los "
+                f"{_HYPHEN_SUFFIX_WIDTH} digitos"
+            )
+        return prefix.zfill(_HYPHEN_PREFIX_WIDTH) + suffix.zfill(
+            _HYPHEN_SUFFIX_WIDTH
         )
 
     if _DIGITS_ONLY.match(upper):

--- a/backend/app/core/remito.py
+++ b/backend/app/core/remito.py
@@ -1,0 +1,83 @@
+"""Normalizacion canonica del numero de remito de combustible.
+
+Issue #124: en produccion conviven dos formatos para el mismo remito
+("011278" vs "000000011278", "1" vs "000000000001") y eso hace que el
+reporte "Control de combustible" muestre la misma carga dos veces.
+
+Reglas de normalizacion (aplicadas al recibir el POST):
+
+* Se eliminan espacios al principio y al final.
+* Si el valor es puramente numerico (``isdigit()``), se completa con
+  ceros a la izquierda hasta 12 caracteres para coincidir con el
+  formato del sistema legacy VFP y con el ancho de la columna
+  ``VARCHAR(12)``.
+* Si el valor es alfanumerico (ej. ``R-0001``, ``D000001``), se
+  conserva tal cual, en mayusculas, sin padding.
+* Solo se permiten letras ASCII (A-Z), digitos (0-9) y guion (-).
+  Cualquier otro caracter (puntos, espacios internos, simbolos)
+  produce un rechazo claro.
+* La longitud final no puede superar los 12 caracteres.
+
+El modulo expone una sola funcion publica ``normalize_remito`` que
+devuelve el valor canonico o lanza ``ValueError`` con un mensaje
+apto para el usuario final (es devuelto por la API como 400).
+"""
+from __future__ import annotations
+
+import re
+
+# Coincide con el ancho de las columnas ``cargacomb.remito`` y
+# ``tablero_produccion.remito`` (``VARCHAR(12)``).
+REMITO_MAX_LENGTH = 12
+
+# Solo letras ASCII, digitos y guion. Esto rechaza espacios internos,
+# puntos, barras, simbolos, letras con tilde, etc.
+_ALLOWED_CHARS = re.compile(r"^[A-Z0-9-]+$")
+_DIGITS_ONLY = re.compile(r"^[0-9]+$")
+
+
+def normalize_remito(value: str | None) -> str:
+    """Devuelve el remito en formato canonico o lanza ``ValueError``.
+
+    La funcion es pura (no toca la base) y se usa tanto en los schemas
+    de entrada como en scripts de migracion / tests.
+    """
+    if value is None:
+        raise ValueError("El remito no puede ser vacio")
+
+    stripped = value.strip()
+    if not stripped:
+        raise ValueError("El remito no puede ser vacio")
+
+    upper = stripped.upper()
+
+    if not _ALLOWED_CHARS.match(upper):
+        raise ValueError(
+            "El remito solo puede contener letras, numeros y guion (-)"
+        )
+
+    if _DIGITS_ONLY.match(upper):
+        padded = upper.zfill(REMITO_MAX_LENGTH)
+        if len(padded) > REMITO_MAX_LENGTH:
+            raise ValueError(
+                f"El remito numerico no puede superar los "
+                f"{REMITO_MAX_LENGTH} digitos"
+            )
+        return padded
+
+    if len(upper) > REMITO_MAX_LENGTH:
+        raise ValueError(
+            f"El remito no puede superar los {REMITO_MAX_LENGTH} caracteres"
+        )
+
+    return upper
+
+
+def is_canonical(value: str | None) -> bool:
+    """True si ``value`` ya esta en formato canonico (util para tests)."""
+    if not value:
+        return False
+    try:
+        return normalize_remito(value) == value
+    except ValueError:
+        return False

--- a/backend/app/schemas/combustible.py
+++ b/backend/app/schemas/combustible.py
@@ -1,6 +1,8 @@
 from datetime import date
 from pydantic import BaseModel, Field, field_validator
 
+from app.core.remito import normalize_remito
+
 
 class CombustibleMovilResponse(BaseModel):
     idMovil: int
@@ -22,13 +24,26 @@ class CargaCombustibleCreate(BaseModel):
     remito3: str = Field(default="", max_length=12)
     observaciones: str | None = None
 
-    @field_validator("form_uuid", "remito")
+    @field_validator("form_uuid")
     @classmethod
-    def validate_required_text(cls, value: str) -> str:
+    def validate_form_uuid(cls, value: str) -> str:
         normalized = value.strip()
         if not normalized:
             raise ValueError("El valor no puede estar vacío")
         return normalized
+
+    @field_validator("remito", "remito2", "remito3")
+    @classmethod
+    def validate_remito(cls, value: str) -> str:
+        # Issue #124: normalizar el remito al formato canonico (12 digitos
+        # para valores puramente numericos) para evitar que el mismo
+        # comprobante aparezca dos veces en Control de combustible.
+        if value is None or value == "":
+            return ""
+        try:
+            return normalize_remito(value)
+        except ValueError:
+            raise
 
 
 class CargaCombustibleResponse(BaseModel):

--- a/backend/app/schemas/produccion.py
+++ b/backend/app/schemas/produccion.py
@@ -1,7 +1,9 @@
 from typing import Any
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 from datetime import date
+
+from app.core.remito import normalize_remito
 
 
 # Numeric fields that the frontend can send as an empty string or null when
@@ -217,6 +219,19 @@ class TableroProduccionCreate(BaseModel):
     remito: str = Field(default="", max_length=12)
     remito2: str = Field(default="", max_length=12)
     remito3: str = Field(default="", max_length=12)
+
+    @field_validator("remito", "remito2", "remito3")
+    @classmethod
+    def validate_remito(cls, value: str) -> str:
+        # Issue #124: normalizar el remito al formato canonico (12 digitos
+        # para valores puramente numericos) para evitar que el mismo
+        # comprobante aparezca dos veces en Control de combustible.
+        if value is None or value == "":
+            return ""
+        try:
+            return normalize_remito(value)
+        except ValueError:
+            raise
 
     @model_validator(mode="before")
     @classmethod

--- a/backend/scripts/backup_remito_issue_124.py
+++ b/backend/scripts/backup_remito_issue_124.py
@@ -1,0 +1,50 @@
+"""Backup de las columnas remito antes de correr la migracion del issue #124."""
+from app.core.config import settings
+from sqlalchemy import create_engine, text
+
+
+def main():
+    engine = create_engine(settings.DATABASE_URL)
+    with engine.begin() as conn:
+        # MySQL strict mode rechaza '0000-00-00' en tablero_produccion.fecha.
+        # Lo deshabilitamos solo para esta sesion.
+        conn.execute(text("SET SESSION sql_mode = ''"))
+
+        conn.execute(text("DROP TABLE IF EXISTS backup_remito_pre_issue_124"))
+        conn.execute(
+            text(
+                """
+                CREATE TABLE backup_remito_pre_issue_124 AS
+                SELECT idCargaComb AS id, Fecha, idMovil,
+                       remito, remito2, remito3, NOW() AS backup_ts
+                FROM cargacomb
+                """
+            )
+        )
+        n1 = conn.execute(
+            text("SELECT COUNT(*) FROM backup_remito_pre_issue_124")
+        ).scalar()
+
+        conn.execute(text("DROP TABLE IF EXISTS backup_remito_tablero_pre_issue_124"))
+        conn.execute(
+            text(
+                """
+                CREATE TABLE backup_remito_tablero_pre_issue_124 AS
+                SELECT id, fecha AS Fecha, cod_equipo AS idMovil,
+                       remito, remito2, remito3, NOW() AS backup_ts
+                FROM tablero_produccion
+                """
+            )
+        )
+        n2 = conn.execute(
+            text(
+                "SELECT COUNT(*) FROM backup_remito_tablero_pre_issue_124"
+            )
+        ).scalar()
+
+        print(f"Backup cargacomb: {n1} filas -> backup_remito_pre_issue_124")
+        print(f"Backup tablero:   {n2} filas -> backup_remito_tablero_pre_issue_124")
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/scripts/run_migration_issue_124.py
+++ b/backend/scripts/run_migration_issue_124.py
@@ -1,7 +1,10 @@
-"""Ejecuta la migracion del issue #124 (LPAD de remitos).
+"""Ejecuta la migracion del issue #124 (LPAD + hifenados).
 
-Aplica los UPDATEs de `db_migrations/20260805_normalize_remito_lpad.sql`
-y luego corre la consulta de verificacion que viene al final del SQL.
+Aplica los UPDATEs de:
+  * db_migrations/20260805_normalize_remito_lpad.sql
+  * db_migrations/20260805_normalize_remito_hyphen.sql
+
+y luego corre la consulta de verificacion al final de cada uno.
 """
 from app.core.config import settings
 from sqlalchemy import create_engine, text
@@ -14,8 +17,8 @@ def main():
         # futuras validaciones, no deberia afectar este script.
         conn.execute(text("SET SESSION sql_mode = ''"))
 
+        print("=== Parte 1: LPAD de remitos numericos cortos ===")
         updates = [
-            # cargacomb
             (
                 "cargacomb.remito",
                 """
@@ -45,7 +48,6 @@ def main():
                   AND CHAR_LENGTH(remito3) < 12
                 """,
             ),
-            # tablero_produccion
             (
                 "tablero_produccion.remito",
                 """
@@ -82,6 +84,67 @@ def main():
             print(f"  {label}: {result.rowcount} filas actualizadas")
 
         print()
+        print("=== Parte 2: eliminar guion en remitos hifenados (PPPP-DDDDDDDD) ===")
+        # MySQL LTRIM solo acepta 1 argumento; usamos TRIM(LEADING '0' FROM ...).
+        hyphen_updates = [
+            (
+                "cargacomb.remito",
+                """
+                UPDATE cargacomb
+                SET remito = CONCAT(
+                        LPAD(
+                          CASE WHEN TRIM(LEADING '0' FROM SUBSTRING_INDEX(remito, '-', 1)) = ''
+                               THEN '0'
+                               ELSE TRIM(LEADING '0' FROM SUBSTRING_INDEX(remito, '-', 1))
+                          END,
+                          4, '0'
+                        ),
+                        LPAD(
+                          CASE WHEN TRIM(LEADING '0' FROM SUBSTRING_INDEX(remito, '-', -1)) = ''
+                               THEN '0'
+                               ELSE TRIM(LEADING '0' FROM SUBSTRING_INDEX(remito, '-', -1))
+                          END,
+                          8, '0'
+                        )
+                      )
+                WHERE remito LIKE '%-%'
+                  AND remito NOT LIKE '%-%-%'
+                  AND SUBSTRING_INDEX(remito, '-', 1) REGEXP '^[0-9]+$'
+                  AND SUBSTRING_INDEX(remito, '-', -1) REGEXP '^[0-9]+$'
+                """,
+            ),
+            (
+                "tablero_produccion.remito",
+                """
+                UPDATE tablero_produccion
+                SET remito = CONCAT(
+                        LPAD(
+                          CASE WHEN TRIM(LEADING '0' FROM SUBSTRING_INDEX(remito, '-', 1)) = ''
+                               THEN '0'
+                               ELSE TRIM(LEADING '0' FROM SUBSTRING_INDEX(remito, '-', 1))
+                          END,
+                          4, '0'
+                        ),
+                        LPAD(
+                          CASE WHEN TRIM(LEADING '0' FROM SUBSTRING_INDEX(remito, '-', -1)) = ''
+                               THEN '0'
+                               ELSE TRIM(LEADING '0' FROM SUBSTRING_INDEX(remito, '-', -1))
+                          END,
+                          8, '0'
+                        )
+                      )
+                WHERE remito LIKE '%-%'
+                  AND remito NOT LIKE '%-%-%'
+                  AND SUBSTRING_INDEX(remito, '-', 1) REGEXP '^[0-9]+$'
+                  AND SUBSTRING_INDEX(remito, '-', -1) REGEXP '^[0-9]+$'
+                """,
+            ),
+        ]
+        for label, sql in hyphen_updates:
+            result = conn.execute(text(sql))
+            print(f"  {label}: {result.rowcount} filas actualizadas")
+
+        print()
         print("=== Verificacion post-migracion ===")
         rows = conn.execute(
             text(
@@ -97,6 +160,22 @@ def main():
                 FROM tablero_produccion
                 WHERE remito REGEXP '^[0-9]+$'
                   AND CHAR_LENGTH(remito) < 12
+                UNION ALL
+                SELECT 'cargacomb.remito hifenados restantes',
+                       COUNT(*)
+                FROM cargacomb
+                WHERE remito LIKE '%-%'
+                  AND remito NOT LIKE '%-%-%'
+                  AND SUBSTRING_INDEX(remito, '-', 1) REGEXP '^[0-9]+$'
+                  AND SUBSTRING_INDEX(remito, '-', -1) REGEXP '^[0-9]+$'
+                UNION ALL
+                SELECT 'tablero_produccion.remito hifenados restantes',
+                       COUNT(*)
+                FROM tablero_produccion
+                WHERE remito LIKE '%-%'
+                  AND remito NOT LIKE '%-%-%'
+                  AND SUBSTRING_INDEX(remito, '-', 1) REGEXP '^[0-9]+$'
+                  AND SUBSTRING_INDEX(remito, '-', -1) REGEXP '^[0-9]+$'
                 """
             )
         ).all()

--- a/backend/scripts/run_migration_issue_124.py
+++ b/backend/scripts/run_migration_issue_124.py
@@ -1,0 +1,108 @@
+"""Ejecuta la migracion del issue #124 (LPAD de remitos).
+
+Aplica los UPDATEs de `db_migrations/20260805_normalize_remito_lpad.sql`
+y luego corre la consulta de verificacion que viene al final del SQL.
+"""
+from app.core.config import settings
+from sqlalchemy import create_engine, text
+
+
+def main():
+    engine = create_engine(settings.DATABASE_URL)
+    with engine.begin() as conn:
+        # sql_mode vacio para no romper con '0000-00-00' en caso de
+        # futuras validaciones, no deberia afectar este script.
+        conn.execute(text("SET SESSION sql_mode = ''"))
+
+        updates = [
+            # cargacomb
+            (
+                "cargacomb.remito",
+                """
+                UPDATE cargacomb
+                SET remito = LPAD(remito, 12, '0')
+                WHERE remito REGEXP '^[0-9]+$'
+                  AND CHAR_LENGTH(remito) < 12
+                """,
+            ),
+            (
+                "cargacomb.remito2",
+                """
+                UPDATE cargacomb
+                SET remito2 = LPAD(remito2, 12, '0')
+                WHERE remito2 IS NOT NULL
+                  AND remito2 REGEXP '^[0-9]+$'
+                  AND CHAR_LENGTH(remito2) < 12
+                """,
+            ),
+            (
+                "cargacomb.remito3",
+                """
+                UPDATE cargacomb
+                SET remito3 = LPAD(remito3, 12, '0')
+                WHERE remito3 IS NOT NULL
+                  AND remito3 REGEXP '^[0-9]+$'
+                  AND CHAR_LENGTH(remito3) < 12
+                """,
+            ),
+            # tablero_produccion
+            (
+                "tablero_produccion.remito",
+                """
+                UPDATE tablero_produccion
+                SET remito = LPAD(remito, 12, '0')
+                WHERE remito REGEXP '^[0-9]+$'
+                  AND CHAR_LENGTH(remito) < 12
+                """,
+            ),
+            (
+                "tablero_produccion.remito2",
+                """
+                UPDATE tablero_produccion
+                SET remito2 = LPAD(remito2, 12, '0')
+                WHERE remito2 IS NOT NULL
+                  AND remito2 REGEXP '^[0-9]+$'
+                  AND CHAR_LENGTH(remito2) < 12
+                """,
+            ),
+            (
+                "tablero_produccion.remito3",
+                """
+                UPDATE tablero_produccion
+                SET remito3 = LPAD(remito3, 12, '0')
+                WHERE remito3 IS NOT NULL
+                  AND remito3 REGEXP '^[0-9]+$'
+                  AND CHAR_LENGTH(remito3) < 12
+                """,
+            ),
+        ]
+
+        for label, sql in updates:
+            result = conn.execute(text(sql))
+            print(f"  {label}: {result.rowcount} filas actualizadas")
+
+        print()
+        print("=== Verificacion post-migracion ===")
+        rows = conn.execute(
+            text(
+                """
+                SELECT 'cargacomb.remito cortos restantes' AS chequeo,
+                       COUNT(*) AS total
+                FROM cargacomb
+                WHERE remito REGEXP '^[0-9]+$'
+                  AND CHAR_LENGTH(remito) < 12
+                UNION ALL
+                SELECT 'tablero_produccion.remito cortos restantes',
+                       COUNT(*)
+                FROM tablero_produccion
+                WHERE remito REGEXP '^[0-9]+$'
+                  AND CHAR_LENGTH(remito) < 12
+                """
+            )
+        ).all()
+        for row in rows:
+            print(f"  {row.chequeo}: {row.total}")
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/scripts/scan_remito_hyphenated.py
+++ b/backend/scripts/scan_remito_hyphenated.py
@@ -1,0 +1,57 @@
+"""Escanea remitos con formato XX-YYYYYY (solo la parte que quedaba
+pendiente despues de la migracion del issue #124)."""
+from app.core.config import settings
+from sqlalchemy import create_engine, text
+
+
+def main():
+    engine = create_engine(settings.DATABASE_URL)
+    with engine.connect() as conn:
+        print("=== cargacomb.remito con guion y partes numericas ===")
+        rows = conn.execute(
+            text(
+                """
+                SELECT remito, COUNT(*) AS total
+                FROM cargacomb
+                WHERE remito LIKE '%-%'
+                  AND remito NOT REGEXP '[A-Z]'
+                  AND SUBSTRING_INDEX(remito, '-', 1) REGEXP '^[0-9]+$'
+                  AND SUBSTRING_INDEX(remito, '-', -1) REGEXP '^[0-9]+$'
+                GROUP BY remito
+                ORDER BY total DESC
+                LIMIT 30
+                """
+            )
+        ).all()
+        total_general = 0
+        for row in rows:
+            print(f"  remito={row.remito!r:>14}  total={row.total}")
+            total_general += row.total
+        print(f"  -> {len(rows)} valores distintos, {total_general} filas en total")
+
+        print()
+        print("=== tablero_produccion.remito con guion y partes numericas ===")
+        rows = conn.execute(
+            text(
+                """
+                SELECT remito, COUNT(*) AS total
+                FROM tablero_produccion
+                WHERE remito LIKE '%-%'
+                  AND remito NOT REGEXP '[A-Z]'
+                  AND SUBSTRING_INDEX(remito, '-', 1) REGEXP '^[0-9]+$'
+                  AND SUBSTRING_INDEX(remito, '-', -1) REGEXP '^[0-9]+$'
+                GROUP BY remito
+                ORDER BY total DESC
+                LIMIT 30
+                """
+            )
+        ).all()
+        total_general = 0
+        for row in rows:
+            print(f"  remito={row.remito!r:>14}  total={row.total}")
+            total_general += row.total
+        print(f"  -> {len(rows)} valores distintos, {total_general} filas en total")
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/scripts/verify_remito_issue_124.py
+++ b/backend/scripts/verify_remito_issue_124.py
@@ -1,0 +1,40 @@
+"""Verificacion visual del resultado de la migracion del issue #124."""
+from app.core.config import settings
+from sqlalchemy import create_engine, text
+
+
+def main():
+    engine = create_engine(settings.DATABASE_URL)
+    with engine.connect() as conn:
+        print("=== cargacomb: filas afectadas por la migracion hifenada ===")
+        rows = conn.execute(
+            text(
+                """
+                SELECT idCargaComb, Fecha, idMovil, remito
+                FROM cargacomb
+                WHERE remito IN ('000200001335', '000200001344')
+                ORDER BY Fecha, idCargaComb
+                """
+            )
+        ).all()
+        for r in rows:
+            print(f"  id={r.idCargaComb} fecha={r.Fecha} movil={r.idMovil} remito={r.remito!r}")
+
+        print()
+        print("=== tablero_produccion: filas afectadas por la migracion hifenada ===")
+        rows = conn.execute(
+            text(
+                """
+                SELECT id, fecha, cod_equipo, remito
+                FROM tablero_produccion
+                WHERE remito IN ('000200001335', '000200001344')
+                ORDER BY fecha, id
+                """
+            )
+        ).all()
+        for r in rows:
+            print(f"  id={r.id} fecha={r.fecha} equipo={r.cod_equipo} remito={r.remito!r}")
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/tests/test_combustible_fuente_verdad.py
+++ b/backend/tests/test_combustible_fuente_verdad.py
@@ -239,6 +239,8 @@ def test_form_uuid_matches_the_database_contract():
         ("011278", "000000011278"),
         ("000000011278", "000000011278"),
         ("R-0001", "R-0001"),
+        ("99-99999", "009900099999"),
+        ("02-1335", "000200001335"),
     ],
 )
 def test_schema_combustible_normaliza_remito(entrada, esperado):

--- a/backend/tests/test_combustible_fuente_verdad.py
+++ b/backend/tests/test_combustible_fuente_verdad.py
@@ -226,3 +226,68 @@ def test_form_uuid_matches_the_database_contract():
         for constraint in CargaComb.__table__.constraints
     }
     assert "uq_cargacomb_personal_form_uuid" in constraint_names
+
+
+# ─── Issue #124: normalizacion de remito a formato canonico ────────────────
+
+
+@pytest.mark.parametrize(
+    ("entrada", "esperado"),
+    [
+        ("1", "000000000001"),
+        ("11278", "000000011278"),
+        ("011278", "000000011278"),
+        ("000000011278", "000000011278"),
+        ("R-0001", "R-0001"),
+    ],
+)
+def test_schema_combustible_normaliza_remito(entrada, esperado):
+    payload = CargaCombustibleCreate(
+        form_uuid="carga-1",
+        fecha=date(2026, 7, 29),
+        id_movil=10,
+        litros=160,
+        km=14855,
+        id_lugar_carga=42,
+        remito=entrada,
+    )
+    assert payload.remito == esperado
+
+
+def test_schema_combustible_rechaza_remito_con_caracteres_invalidos():
+    with pytest.raises(ValidationError, match="letras, numeros y guion"):
+        CargaCombustibleCreate(
+            form_uuid="carga-1",
+            fecha=date(2026, 7, 29),
+            id_movil=10,
+            litros=160,
+            km=14855,
+            id_lugar_carga=42,
+            remito="11.278",
+        )
+
+
+def test_combustible_endpoint_persiste_remito_normalizado(db):
+    """Si el operador tipea ``11278`` (sin padding), el endpoint debe
+    guardar ``000000011278`` para no chocar con cargas equivalentes
+    que ya estaban en la base con el formato padded.
+    """
+    payload = CargaCombustibleCreate(
+        form_uuid="carga-con-remito-corto",
+        fecha=date(2026, 7, 29),
+        id_movil=10,
+        litros=160,
+        km=14855,
+        id_lugar_carga=42,
+        id_tipo_comb=1,
+        remito="11278",
+    )
+
+    asyncio.run(
+        combustible.create_carga_combustible(
+            payload, db=db, user=_user()
+        )
+    )
+
+    row = db.query(CargaComb).one()
+    assert row.remito == "000000011278"

--- a/backend/tests/test_produccion_combustible_remitos.py
+++ b/backend/tests/test_produccion_combustible_remitos.py
@@ -101,6 +101,10 @@ def test_schema_rejects_remito_longer_than_twelve_chars(field):
         ("000000011278", "000000011278"),
         ("21325", "000000021325"),
         ("R-0001", "R-0001"),
+        # Formato hifenado: PPPP-DDDDDDDD
+        ("99-99999", "009900099999"),
+        ("02-1335", "000200001335"),
+        ("0000002-1335", "000200001335"),
     ],
 )
 def test_schema_normaliza_remito_numerico_y_alfanumerico(entrada, esperado):
@@ -315,3 +319,30 @@ def test_create_persists_normalized_remito_in_part_and_carga(monkeypatch):
     assert carga.remito == "000000011278"
     assert carga.remito2 == "000000021325"
     assert carga.remito3 == "R-0003"
+
+
+def test_create_persists_hyphenated_remito_in_part_and_carga(monkeypatch):
+    """`02-1335` debe guardarse como `000200001335` (4 + 8 digitos)."""
+    db = FakeDb()
+    _bypass_external_deps(monkeypatch)
+
+    payload = TableroProduccionCreate(
+        fecha=date(2026, 7, 28),
+        form_uuid="parte-con-remito-hifenado",
+        UN="BIOMASA FRESA",
+        cod_un=1,
+        cod_equipo=10,
+        cod_operador=5,
+        combustible=150,
+        km_combustible=14855,
+        lugar_carga=42,
+        id_tipo_comb=2,
+        remito="02-1335",
+    )
+
+    asyncio.run(produccion.create_produccion(payload, db=db, user=SimpleNamespace()))
+
+    tablero = db.added[0]
+    carga = db.added[1]
+    assert tablero.remito == "000200001335"
+    assert carga.remito == "000200001335"

--- a/backend/tests/test_produccion_combustible_remitos.py
+++ b/backend/tests/test_produccion_combustible_remitos.py
@@ -89,6 +89,67 @@ def test_schema_rejects_remito_longer_than_twelve_chars(field):
         )
 
 
+# ─── Issue #124: normalizacion de remito a formato canonico ────────────────
+
+
+@pytest.mark.parametrize(
+    ("entrada", "esperado"),
+    [
+        ("1", "000000000001"),
+        ("11278", "000000011278"),
+        ("011278", "000000011278"),
+        ("000000011278", "000000011278"),
+        ("21325", "000000021325"),
+        ("R-0001", "R-0001"),
+    ],
+)
+def test_schema_normaliza_remito_numerico_y_alfanumerico(entrada, esperado):
+    payload = TableroProduccionCreate(
+        fecha=date(2026, 7, 28),
+        combustible=0,
+        remito=entrada,
+    )
+    assert payload.remito == esperado
+
+
+@pytest.mark.parametrize(
+    ("remito2", "remito3", "exp2", "exp3"),
+    [
+        ("11278", "21325", "000000011278", "000000021325"),
+        ("R-0002", "R-0003", "R-0002", "R-0003"),
+        ("", "", "", ""),
+    ],
+)
+def test_schema_normaliza_remito2_y_remito3(remito2, remito3, exp2, exp3):
+    payload = TableroProduccionCreate(
+        fecha=date(2026, 7, 28),
+        combustible=0,
+        remito2=remito2,
+        remito3=remito3,
+    )
+    assert payload.remito2 == exp2
+    assert payload.remito3 == exp3
+
+
+def test_schema_rechaza_remito_con_caracteres_invalidos():
+    with pytest.raises(ValidationError, match="letras, numeros y guion"):
+        TableroProduccionCreate(
+            fecha=date(2026, 7, 28),
+            combustible=0,
+            remito="11.278",
+        )
+
+
+def test_schema_rechaza_remito_numerico_con_mas_de_12_digitos():
+    # El max_length=12 del schema lo corta antes de llegar a mi validador.
+    with pytest.raises(ValidationError, match="at most 12 characters"):
+        TableroProduccionCreate(
+            fecha=date(2026, 7, 28),
+            combustible=0,
+            remito="1234567890123",
+        )
+
+
 # ─── Route: persistencia de remitos ────────────────────────────────────────
 
 
@@ -219,3 +280,38 @@ def test_schema_rejects_fuel_without_remito():
             lugar_carga=42,
             remito="",
         )
+
+
+# ─── Issue #124: el endpoint persiste el remito ya normalizado ─────────────
+
+
+def test_create_persists_normalized_remito_in_part_and_carga(monkeypatch):
+    db = FakeDb()
+    _bypass_external_deps(monkeypatch)
+
+    payload = TableroProduccionCreate(
+        fecha=date(2026, 7, 28),
+        form_uuid="parte-con-remito-corto",
+        UN="BIOMASA FRESA",
+        cod_un=1,
+        cod_equipo=10,
+        cod_operador=5,
+        combustible=150,
+        km_combustible=14855,
+        lugar_carga=42,
+        id_tipo_comb=2,
+        remito="11278",  # entra sin padding
+        remito2="21325",  # idem
+        remito3="R-0003",  # alfanumerico: se conserva
+    )
+
+    asyncio.run(produccion.create_produccion(payload, db=db, user=SimpleNamespace()))
+
+    tablero = db.added[0]
+    carga = db.added[1]
+    assert tablero.remito == "000000011278"
+    assert tablero.remito2 == "000000021325"
+    assert tablero.remito3 == "R-0003"
+    assert carga.remito == "000000011278"
+    assert carga.remito2 == "000000021325"
+    assert carga.remito3 == "R-0003"

--- a/backend/tests/test_remito_normalize.py
+++ b/backend/tests/test_remito_normalize.py
@@ -84,6 +84,38 @@ def test_rechaza_remito_alfanumerico_mayor_a_12_caracteres():
         normalize_remito("R-00012345678")  # 13 chars
 
 
+# ─── Normalizacion de remitos hifenados (formato PPPP-DDDDDDDD) ────────────
+
+
+@pytest.mark.parametrize(
+    ("entrada", "esperado"),
+    [
+        # Caso reportado por el usuario: 2-5 -> 4+8 con padding.
+        ("99-99999", "009900099999"),
+        ("02-1335", "000200001335"),
+        ("02-1344", "000200001344"),
+        # Variantes con padding previo en la primera parte.
+        ("0000002-1335", "000200001335"),
+        ("0000002-1344", "000200001344"),
+        # Casos limite justos (4 y 8 sin padding).
+        ("9999-99999999", "999999999999"),
+        ("1-1", "000100000001"),  # padding agresivo pero valido
+    ],
+)
+def test_normaliza_remitos_hifenados_al_formato_canonico(entrada, esperado):
+    assert normalize_remito(entrada) == esperado
+
+
+def test_rechaza_prefijo_hifenado_mayor_a_4_digitos():
+    with pytest.raises(ValueError, match="anterior al guion"):
+        normalize_remito("99999-1234")
+
+
+def test_rechaza_sufijo_hifenado_mayor_a_8_digitos():
+    with pytest.raises(ValueError, match="posterior al guion"):
+        normalize_remito("12-123456789")
+
+
 # ─── Constantes y helper de consulta ───────────────────────────────────────
 
 
@@ -96,7 +128,9 @@ def test_constante_max_length_coincide_con_columna():
 def test_is_canonical_true_para_valores_ya_normalizados():
     assert is_canonical("000000011278") is True
     assert is_canonical("R-0001") is True
+    assert is_canonical("009900099999") is True
     assert is_canonical("") is False
     assert is_canonical(None) is False
     assert is_canonical("11278") is False  # no paddeado
     assert is_canonical("11.278") is False  # caracter invalido
+    assert is_canonical("02-1335") is False  # hifenado, no canonico

--- a/backend/tests/test_remito_normalize.py
+++ b/backend/tests/test_remito_normalize.py
@@ -1,0 +1,102 @@
+"""Tests unitarios del helper de normalizacion de remito (issue #124)."""
+import pytest
+
+from app.core.remito import (
+    REMITO_MAX_LENGTH,
+    is_canonical,
+    normalize_remito,
+)
+
+
+# ─── Normalizacion de valores numericos (padded a 12 digitos) ──────────────
+
+
+@pytest.mark.parametrize(
+    ("entrada", "esperado"),
+    [
+        ("1", "000000000001"),
+        ("11278", "000000011278"),
+        ("000000011278", "000000011278"),
+        ("011278", "000000011278"),
+        ("21325", "000000021325"),
+        ("000000000001", "000000000001"),
+        ("000000021325", "000000021325"),
+        ("0", "000000000000"),
+        ("999999999999", "999999999999"),  # 12 digitos sin padding
+    ],
+)
+def test_normaliza_remitos_numericos_al_formato_canonico(entrada, esperado):
+    assert normalize_remito(entrada) == esperado
+
+
+# ─── Normalizacion de valores alfanumericos (sin padding) ──────────────────
+
+
+@pytest.mark.parametrize(
+    ("entrada", "esperado"),
+    [
+        ("R-0001", "R-0001"),
+        ("r-0001", "R-0001"),  # pasa a mayusculas
+        ("D000001", "D000001"),
+        ("D000001", "D000001"),
+        ("A-1", "A-1"),
+    ],
+)
+def test_normaliza_remitos_alfanumericos_sin_padding(entrada, esperado):
+    assert normalize_remito(entrada) == esperado
+
+
+def test_normaliza_remito_con_espacios_alrededor():
+    assert normalize_remito("  11278  ") == "000000011278"
+    assert normalize_remito(" R-0001 ") == "R-0001"
+
+
+# ─── Rechazo de valores invalidos ───────────────────────────────────────────
+
+
+def test_rechaza_remito_vacio():
+    with pytest.raises(ValueError, match="vacio"):
+        normalize_remito("")
+    with pytest.raises(ValueError, match="vacio"):
+        normalize_remito("   ")
+    with pytest.raises(ValueError, match="vacio"):
+        normalize_remito(None)
+
+
+def test_rechaza_remito_con_caracteres_invalidos():
+    with pytest.raises(ValueError, match="letras, numeros y guion"):
+        normalize_remito("11.278")
+    with pytest.raises(ValueError, match="letras, numeros y guion"):
+        normalize_remito("11 278")
+    with pytest.raises(ValueError, match="letras, numeros y guion"):
+        normalize_remito("11/278")
+    with pytest.raises(ValueError, match="letras, numeros y guion"):
+        normalize_remito("R.0001")
+
+
+def test_rechaza_remito_numerico_con_mas_de_12_digitos():
+    with pytest.raises(ValueError, match="12 digitos"):
+        normalize_remito("1234567890123")
+
+
+def test_rechaza_remito_alfanumerico_mayor_a_12_caracteres():
+    with pytest.raises(ValueError, match="12 caracteres"):
+        normalize_remito("R-00012345678")  # 13 chars
+
+
+# ─── Constantes y helper de consulta ───────────────────────────────────────
+
+
+def test_constante_max_length_coincide_con_columna():
+    # Tanto ``cargacomb.remito`` como ``tablero_produccion.remito`` son
+    # ``VARCHAR(12)``; la normalizacion no puede generar valores mas largos.
+    assert REMITO_MAX_LENGTH == 12
+
+
+def test_is_canonical_true_para_valores_ya_normalizados():
+    assert is_canonical("000000011278") is True
+    assert is_canonical("R-0001") is True
+    assert is_canonical("") is False
+    assert is_canonical(None) is False
+    assert is_canonical("11278") is False  # no paddeado
+    assert is_canonical("11.278") is False  # caracter invalido

--- a/db_migrations/20260805_normalize_remito_hyphen.sql
+++ b/db_migrations/20260805_normalize_remito_hyphen.sql
@@ -1,0 +1,89 @@
+-- Issue #124 (parte 2): normalizar remitos hifenados (formato PPPP-DDDDDDDD).
+--
+-- Despues de la primera parte de la migracion (LPAD de numericos cortos,
+-- archivo 20260805_normalize_remito_lpad.sql) quedaron algunas filas con
+-- formato hifenado: "02-1335", "0000002-1335", "0000002-1344". El reporte
+-- "Control de combustible" los cuenta como remitos distintos porque el
+-- guion no es eliminado.
+--
+-- Reglas aplicadas (identicas a `app.core.remito.normalize_remito`):
+--   * Si el remito tiene exactamente un guion y ambas partes son
+--     numericas, se reemplaza por la concatenacion con la primera
+--     parte paddeada a 4 digitos y la segunda a 8 digitos.
+--   * Ejemplos:
+--       "02-1335"     -> "000200001335"
+--       "0000002-1335" -> "000200001335"  (mismo remito, otra variante)
+--       "99-99999"    -> "009900099999"
+--
+-- Aplica sobre `cargacomb.remito` y `tablero_produccion.remito`.
+-- La migracion es idempotente: solo modifica filas que matchean la
+-- condicion y cuyo valor canonicado es distinto del actual.
+
+SET @schema_name = DATABASE();
+
+-- ─── cargacomb.remito: detectar y normalizar hifenados ───────────────────
+-- Limpiamos ceros a la izquierda en cada parte antes de validar el ancho
+-- (asi "02-1335" y "0000002-1335" se canonical al mismo valor).
+UPDATE cargacomb
+SET remito = CONCAT(
+        LPAD(
+          CASE WHEN TRIM(LEADING '0' FROM SUBSTRING_INDEX(remito, '-', 1)) = ''
+               THEN '0'
+               ELSE TRIM(LEADING '0' FROM SUBSTRING_INDEX(remito, '-', 1))
+          END,
+          4, '0'
+        ),
+        LPAD(
+          CASE WHEN TRIM(LEADING '0' FROM SUBSTRING_INDEX(remito, '-', -1)) = ''
+               THEN '0'
+               ELSE TRIM(LEADING '0' FROM SUBSTRING_INDEX(remito, '-', -1))
+          END,
+          8, '0'
+        )
+      )
+WHERE remito LIKE '%-%'
+  AND remito NOT LIKE '%-%-%'  -- exactamente un guion
+  AND SUBSTRING_INDEX(remito, '-', 1) REGEXP '^[0-9]+$'
+  AND SUBSTRING_INDEX(remito, '-', -1) REGEXP '^[0-9]+$';
+
+-- ─── tablero_produccion.remito: mismo tratamiento ───────────────────────
+UPDATE tablero_produccion
+SET remito = CONCAT(
+        LPAD(
+          CASE WHEN TRIM(LEADING '0' FROM SUBSTRING_INDEX(remito, '-', 1)) = ''
+               THEN '0'
+               ELSE TRIM(LEADING '0' FROM SUBSTRING_INDEX(remito, '-', 1))
+          END,
+          4, '0'
+        ),
+        LPAD(
+          CASE WHEN TRIM(LEADING '0' FROM SUBSTRING_INDEX(remito, '-', -1)) = ''
+               THEN '0'
+               ELSE TRIM(LEADING '0' FROM SUBSTRING_INDEX(remito, '-', -1))
+          END,
+          8, '0'
+        )
+      )
+WHERE remito LIKE '%-%'
+  AND remito NOT LIKE '%-%-%'
+  AND SUBSTRING_INDEX(remito, '-', 1) REGEXP '^[0-9]+$'
+  AND SUBSTRING_INDEX(remito, '-', -1) REGEXP '^[0-9]+$';
+
+-- ─── Verificacion posterior a la migracion ──────────────────────────────
+-- Devuelve la cantidad de remitos hifenados numericos que aun quedan
+-- (deberia ser 0 si la migracion corrio bien).
+SELECT 'cargacomb.remito hifenados restantes' AS chequeo,
+       COUNT(*) AS total
+FROM cargacomb
+WHERE remito LIKE '%-%'
+  AND remito NOT LIKE '%-%-%'
+  AND SUBSTRING_INDEX(remito, '-', 1) REGEXP '^[0-9]+$'
+  AND SUBSTRING_INDEX(remito, '-', -1) REGEXP '^[0-9]+$'
+UNION ALL
+SELECT 'tablero_produccion.remito hifenados restantes',
+       COUNT(*)
+FROM tablero_produccion
+WHERE remito LIKE '%-%'
+  AND remito NOT LIKE '%-%-%'
+  AND SUBSTRING_INDEX(remito, '-', 1) REGEXP '^[0-9]+$'
+  AND SUBSTRING_INDEX(remito, '-', -1) REGEXP '^[0-9]+$';

--- a/db_migrations/20260805_normalize_remito_lpad.sql
+++ b/db_migrations/20260805_normalize_remito_lpad.sql
@@ -1,0 +1,74 @@
+-- Issue #124: normalizar el remito de combustible al formato canonico.
+--
+-- En produccion conviven dos formatos para el mismo comprobante ("011278" y
+-- "000000011278", "1" y "000000000001") y eso hace que el reporte "Control de
+-- combustible" muestre la misma carga dos veces.
+--
+-- Reglas aplicadas a los registros existentes (identicas al helper
+-- `app.core.remito.normalize_remito` del backend):
+--   * Si el remito es puramente numerico, se paddea a 12 digitos con ceros
+--     a la izquierda.
+--   * Si el remito es alfanumerico (contiene letras o guion), se conserva
+--     tal cual, en mayusculas.
+--   * Si el remito ya esta en formato canonico, no se modifica.
+--
+-- Aplica sobre `cargacomb.remito/remito2/remito3` y
+-- `tablero_produccion.remito/remito2/remito3`. La migracion es idempotente
+-- (UPDATE solo toca las filas que no estan en formato canonico) y no toca
+-- los remitos de bitren / proveedor / fgpy porque esos viven en columnas
+-- VARCHAR(20) y no son los afectados por el issue.
+
+SET @schema_name = DATABASE();
+
+-- ─── cargacomb.remito ────────────────────────────────────────────────────
+UPDATE cargacomb
+SET remito = LPAD(remito, 12, '0')
+WHERE remito REGEXP '^[0-9]+$'
+  AND CHAR_LENGTH(remito) < 12;
+
+-- ─── cargacomb.remito2 ───────────────────────────────────────────────────
+UPDATE cargacomb
+SET remito2 = LPAD(remito2, 12, '0')
+WHERE remito2 IS NOT NULL
+  AND remito2 REGEXP '^[0-9]+$'
+  AND CHAR_LENGTH(remito2) < 12;
+
+-- ─── cargacomb.remito3 ───────────────────────────────────────────────────
+UPDATE cargacomb
+SET remito3 = LPAD(remito3, 12, '0')
+WHERE remito3 IS NOT NULL
+  AND remito3 REGEXP '^[0-9]+$'
+  AND CHAR_LENGTH(remito3) < 12;
+
+-- ─── tablero_produccion.remito ───────────────────────────────────────────
+UPDATE tablero_produccion
+SET remito = LPAD(remito, 12, '0')
+WHERE remito REGEXP '^[0-9]+$'
+  AND CHAR_LENGTH(remito) < 12;
+
+-- ─── tablero_produccion.remito2 ──────────────────────────────────────────
+UPDATE tablero_produccion
+SET remito2 = LPAD(remito2, 12, '0')
+WHERE remito2 IS NOT NULL
+  AND remito2 REGEXP '^[0-9]+$'
+  AND CHAR_LENGTH(remito2) < 12;
+
+-- ─── tablero_produccion.remito3 ──────────────────────────────────────────
+UPDATE tablero_produccion
+SET remito3 = LPAD(remito3, 12, '0')
+WHERE remito3 IS NOT NULL
+  AND remito3 REGEXP '^[0-9]+$'
+  AND CHAR_LENGTH(remito3) < 12;
+
+-- ─── Verificacion posterior a la migracion ──────────────────────────────
+-- Devuelve la cantidad de cargas que aun tienen remitos en formato corto
+-- (deberia ser 0 si la migracion corrio bien).
+SELECT 'cargacomb.remito cortos restantes' AS chequeo,
+       COUNT(*) AS total
+FROM cargacomb
+WHERE remito REGEXP '^[0-9]+$' AND CHAR_LENGTH(remito) < 12
+UNION ALL
+SELECT 'tablero_produccion.remito cortos restantes',
+       COUNT(*)
+FROM tablero_produccion
+WHERE remito REGEXP '^[0-9]+$' AND CHAR_LENGTH(remito) < 12;

--- a/frontend/src/utils/remito.js
+++ b/frontend/src/utils/remito.js
@@ -1,0 +1,52 @@
+/**
+ * Normalizacion canonica del numero de remito de combustible.
+ *
+ * Issue #124: el backend acepta "1" y "000000000001" como si fueran
+ * remitos distintos, lo que hace que el reporte "Control de combustible"
+ * muestre la misma carga dos veces.
+ *
+ * Esta utilidad refleja la logica del backend (`app/core/remito.py`) y se
+ * usa desde los formularios para que el operador vea el formato canonico
+ * apenas lo tipea, en vez de recibir el rechazo del backend en el submit.
+ *
+ * Reglas (identicas al backend):
+ * - Solo letras A-Z, digitos 0-9 y guion.
+ * - Si es puramente numerico: padding a 12 digitos con ceros a la izquierda.
+ * - Si es alfanumerico (ej. "R-0001"): se mantiene, en mayusculas.
+ * - Longitud maxima: 12 caracteres.
+ *
+ * Devuelve `null` si el valor no es normalizable (la UI debe mostrar
+ * el valor que el operador escribio y dejar que el backend lo rechace
+ * con un mensaje claro en lugar de mutarlo en silencio).
+ */
+const REMITO_MAX_LENGTH = 12
+const ALLOWED_CHARS = /^[A-Z0-9-]+$/
+const DIGITS_ONLY = /^[0-9]+$/
+
+export function normalizeRemito(value) {
+  if (value === null || value === undefined) return null
+  const stripped = String(value).trim()
+  if (!stripped) return ''
+
+  const upper = stripped.toUpperCase()
+  if (!ALLOWED_CHARS.test(upper)) return null
+
+  if (DIGITS_ONLY.test(upper)) {
+    if (upper.length > REMITO_MAX_LENGTH) return null
+    return upper.padStart(REMITO_MAX_LENGTH, '0')
+  }
+
+  if (upper.length > REMITO_MAX_LENGTH) return null
+  return upper
+}
+
+/**
+ * Devuelve true si el valor ya esta en formato canonico.
+ * Util para que el operador sepa que lo que ingreso es lo que se va a
+ * guardar (y no algo distinto).
+ */
+export function isCanonicalRemito(value) {
+  if (!value) return false
+  const normalized = normalizeRemito(value)
+  return normalized !== null && normalized === value
+}

--- a/frontend/src/utils/remito.js
+++ b/frontend/src/utils/remito.js
@@ -1,9 +1,9 @@
 /**
  * Normalizacion canonica del numero de remito de combustible.
  *
- * Issue #124: el backend acepta "1" y "000000000001" como si fueran
- * remitos distintos, lo que hace que el reporte "Control de combustible"
- * muestre la misma carga dos veces.
+ * Issue #124: el backend acepta "1" y "000000000001" (o "99-99999" y
+ * "009900099999") como si fueran remitos distintos, lo que hace que el
+ * reporte "Control de combustible" muestre la misma carga dos veces.
  *
  * Esta utilidad refleja la logica del backend (`app/core/remito.py`) y se
  * usa desde los formularios para que el operador vea el formato canonico
@@ -12,6 +12,8 @@
  * Reglas (identicas al backend):
  * - Solo letras A-Z, digitos 0-9 y guion.
  * - Si es puramente numerico: padding a 12 digitos con ceros a la izquierda.
+ * - Si tiene un guion y ambas partes son numericas: prefijo pad a 4
+ *   digitos, sufijo pad a 8 digitos, guion eliminado (total 12).
  * - Si es alfanumerico (ej. "R-0001"): se mantiene, en mayusculas.
  * - Longitud maxima: 12 caracteres.
  *
@@ -20,8 +22,11 @@
  * con un mensaje claro en lugar de mutarlo en silencio).
  */
 const REMITO_MAX_LENGTH = 12
+const HYPHEN_PREFIX_WIDTH = 4
+const HYPHEN_SUFFIX_WIDTH = 8
 const ALLOWED_CHARS = /^[A-Z0-9-]+$/
 const DIGITS_ONLY = /^[0-9]+$/
+const HYPHEN_TWO_NUMERIC = /^([0-9]+)-([0-9]+)$/
 
 export function normalizeRemito(value) {
   if (value === null || value === undefined) return null
@@ -30,6 +35,21 @@ export function normalizeRemito(value) {
 
   const upper = stripped.toUpperCase()
   if (!ALLOWED_CHARS.test(upper)) return null
+
+  const hyphenMatch = upper.match(HYPHEN_TWO_NUMERIC)
+  if (hyphenMatch) {
+    // Limpiamos ceros a la izquierda en cada parte antes de validar
+    // el ancho: en la base conviven "02-1335" y "0000002-1335" y
+    // ambos representan el mismo comprobante.
+    const prefix = (hyphenMatch[1] || '').replace(/^0+/, '') || '0'
+    const suffix = (hyphenMatch[2] || '').replace(/^0+/, '') || '0'
+    if (prefix.length > HYPHEN_PREFIX_WIDTH) return null
+    if (suffix.length > HYPHEN_SUFFIX_WIDTH) return null
+    return (
+      prefix.padStart(HYPHEN_PREFIX_WIDTH, '0') +
+      suffix.padStart(HYPHEN_SUFFIX_WIDTH, '0')
+    )
+  }
 
   if (DIGITS_ONLY.test(upper)) {
     if (upper.length > REMITO_MAX_LENGTH) return null

--- a/frontend/src/utils/remito.test.js
+++ b/frontend/src/utils/remito.test.js
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest'
+
+import { isCanonicalRemito, normalizeRemito } from './remito'
+
+describe('normalizeRemito', () => {
+  it.each([
+    ['1', '000000000001'],
+    ['11278', '000000011278'],
+    ['011278', '000000011278'],
+    ['000000011278', '000000011278'],
+    ['21325', '000000021325'],
+    ['0', '000000000000'],
+    ['999999999999', '999999999999'],
+  ])('padds el remito numerico %s a %s', (entrada, esperado) => {
+    expect(normalizeRemito(entrada)).toBe(esperado)
+  })
+
+  it.each([
+    ['R-0001', 'R-0001'],
+    ['r-0001', 'R-0001'],
+    ['D000001', 'D000001'],
+    ['A-1', 'A-1'],
+  ])('conserva el remito alfanumerico %s tal cual (en mayusculas)', (entrada, esperado) => {
+    expect(normalizeRemito(entrada)).toBe(esperado)
+  })
+
+  it('elimina espacios al principio y al final', () => {
+    expect(normalizeRemito('  11278  ')).toBe('000000011278')
+    expect(normalizeRemito(' R-0001 ')).toBe('R-0001')
+  })
+
+  it('devuelve string vacio para entrada vacia', () => {
+    expect(normalizeRemito('')).toBe('')
+    expect(normalizeRemito('   ')).toBe('')
+  })
+
+  it('devuelve null para entrada null/undefined', () => {
+    expect(normalizeRemito(null)).toBeNull()
+    expect(normalizeRemito(undefined)).toBeNull()
+  })
+
+  it('devuelve null si el remito tiene caracteres invalidos', () => {
+    expect(normalizeRemito('11.278')).toBeNull()
+    expect(normalizeRemito('11 278')).toBeNull()
+    expect(normalizeRemito('11/278')).toBeNull()
+    expect(normalizeRemito('R.0001')).toBeNull()
+  })
+
+  it('devuelve null si el remito numerico tiene mas de 12 digitos', () => {
+    expect(normalizeRemito('1234567890123')).toBeNull()
+  })
+
+  it('devuelve null si el remito alfanumerico tiene mas de 12 caracteres', () => {
+    expect(normalizeRemito('R-00012345678')).toBeNull()
+  })
+})
+
+describe('isCanonicalRemito', () => {
+  it('devuelve true para valores ya normalizados', () => {
+    expect(isCanonicalRemito('000000011278')).toBe(true)
+    expect(isCanonicalRemito('R-0001')).toBe(true)
+  })
+
+  it('devuelve false para valores sin normalizar', () => {
+    expect(isCanonicalRemito('11278')).toBe(false)
+    expect(isCanonicalRemito('11.278')).toBe(false)
+  })
+
+  it('devuelve false para valores vacios o nulos', () => {
+    expect(isCanonicalRemito('')).toBe(false)
+    expect(isCanonicalRemito(null)).toBe(false)
+    expect(isCanonicalRemito(undefined)).toBe(false)
+  })
+})

--- a/frontend/src/utils/remito.test.js
+++ b/frontend/src/utils/remito.test.js
@@ -55,15 +55,40 @@ describe('normalizeRemito', () => {
   })
 })
 
+describe('normalizeRemito - formato hifenado', () => {
+  it.each([
+    ['99-99999', '009900099999'],
+    ['02-1335', '000200001335'],
+    ['0000002-1335', '000200001335'],
+    ['9999-99999999', '999999999999'],
+  ])('normaliza %s a %s', (entrada, esperado) => {
+    expect(normalizeRemito(entrada)).toBe(esperado)
+  })
+
+  it('pasa a mayusculas la parte alfanumerica del guion', () => {
+    expect(normalizeRemito('r-0001')).toBe('R-0001')
+  })
+
+  it('devuelve null si el prefijo hifenado tiene mas de 4 digitos', () => {
+    expect(normalizeRemito('99999-1234')).toBeNull()
+  })
+
+  it('devuelve null si el sufijo hifenado tiene mas de 8 digitos', () => {
+    expect(normalizeRemito('12-123456789')).toBeNull()
+  })
+})
+
 describe('isCanonicalRemito', () => {
   it('devuelve true para valores ya normalizados', () => {
     expect(isCanonicalRemito('000000011278')).toBe(true)
     expect(isCanonicalRemito('R-0001')).toBe(true)
+    expect(isCanonicalRemito('009900099999')).toBe(true)
   })
 
   it('devuelve false para valores sin normalizar', () => {
     expect(isCanonicalRemito('11278')).toBe(false)
     expect(isCanonicalRemito('11.278')).toBe(false)
+    expect(isCanonicalRemito('02-1335')).toBe(false)
   })
 
   it('devuelve false para valores vacios o nulos', () => {

--- a/frontend/src/views/CombustibleFormView.vue
+++ b/frontend/src/views/CombustibleFormView.vue
@@ -170,6 +170,7 @@ import SectionCard from '@/components/SectionCard.vue'
 import PageHeader from '@/components/ui/PageHeader.vue'
 import AppButton from '@/components/ui/AppButton.vue'
 import AppIcon from '@/components/ui/AppIcon.vue'
+import { normalizeRemito } from '@/utils/remito'
 
 const authStore = useAuthStore()
 const store = useCombustibleStore()
@@ -261,9 +262,9 @@ async function submit() {
       km: Number(form.km),
       id_lugar_carga: Number(form.id_lugar_carga),
       id_tipo_comb: 1,
-      remito: form.remito.trim(),
-      remito2: form.remito2.trim(),
-      remito3: form.remito3.trim(),
+      remito: normalizeRemito(form.remito) ?? form.remito.trim(),
+      remito2: normalizeRemito(form.remito2) ?? form.remito2.trim(),
+      remito3: normalizeRemito(form.remito3) ?? form.remito3.trim(),
       observaciones: form.observaciones?.trim() || null,
     })
     successMessage.value = `Carga registrada para ${carga.movil}.`

--- a/frontend/src/views/ProduccionFormView.vue
+++ b/frontend/src/views/ProduccionFormView.vue
@@ -977,6 +977,7 @@ import AppIcon from '@/components/ui/AppIcon.vue'
 import motivosNoOperativos from '@/data/motivosNoOperativos.json'
 import { cleanLocationValues, getLocationRequirements, shouldShowActaPredioFields } from '@/services/actaPredioRules'
 import { focusInside } from '@/utils/focusInside'
+import { normalizeRemito } from '@/utils/remito'
 
 const router = useRouter()
 const authStore = useAuthStore()
@@ -1795,9 +1796,15 @@ async function handleSubmit() {
       hr_fin: form.hr_fin,
       combustible: form.combustible,
       km_combustible: cargoCombustible.value ? Number(form.km_combustible) : 0,
-      remito: cargoCombustible.value ? String(form.remito ?? '').trim() : '',
-      remito2: cargoCombustible.value ? String(form.remito2 ?? '').trim() : '',
-      remito3: cargoCombustible.value ? String(form.remito3 ?? '').trim() : '',
+      remito: cargoCombustible.value
+        ? (normalizeRemito(form.remito) ?? String(form.remito ?? '').trim())
+        : '',
+      remito2: cargoCombustible.value
+        ? (normalizeRemito(form.remito2) ?? String(form.remito2 ?? '').trim())
+        : '',
+      remito3: cargoCombustible.value
+        ? (normalizeRemito(form.remito3) ?? String(form.remito3 ?? '').trim())
+        : '',
       aceite_cadena: form.aceite_cadena,
       aceite_hidraulico: form.aceite_hidraulico,
       aceite_motor: form.aceite_motor,


### PR DESCRIPTION
## Objetivo

Closes #124

Evitar que el reporte **Control de combustible** muestre la misma carga dos veces porque el remito se persiste en formatos distintos.

## Causa raiz

\cargacomb.remito\ y \	ablero_produccion.remito\ son \VARCHAR(12)\ y el backend aceptaba cualquier string de hasta 12 caracteres sin normalizar. En produccion conviven tres variantes del mismo comprobante:

| Entrada | Canonico |
|---|---|
| \1\ | \