### PR TITLE
fix(combustible): dedupe por clave natural (idMovil+Fecha+Litros+remito) ademas del form_uuid (closes #124)

### DIFF
--- a/backend/app/api/routes/combustible.py
+++ b/backend/app/api/routes/combustible.py
@@ -164,6 +164,35 @@ async def create_carga_combustible(
         )
         return _to_carga_response(existing, existing_movil or movil, user)
 
+    # Issue #124 (parte 2): ademas del dedupe por form_uuid (idempotencia del
+    # mismo formulario), bloqueamos cargas con la misma clave natural
+    # (idMovil, Fecha, Litros, remito, tipo_mov='E') para el mismo operador.
+    # Esto cubre el doble submit desde la UI (doble click, doble tab, retry
+    # de red) que genera form_uuids distintos pero la misma carga.
+    if payload.remito:
+        natural_key_dup = (
+            db.query(CargaComb)
+            .filter(
+                CargaComb.personal == user.idPersonal,
+                CargaComb.idMovil == payload.id_movil,
+                CargaComb.Fecha == payload.fecha,
+                CargaComb.Litros == payload.litros,
+                CargaComb.remito == payload.remito,
+                CargaComb.tipo_mov == "E",
+            )
+            .first()
+        )
+        if natural_key_dup:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail=(
+                    f"Ya existe una carga de {payload.litros} L del movil "
+                    f"{payload.id_movil} con remito {payload.remito} en "
+                    f"{payload.fecha} (id carga {natural_key_dup.idCargaComb}). "
+                    f"No se duplica el egreso de stock."
+                ),
+            )
+
     if not _lugar_carga_habilitado(db, payload.id_lugar_carga, movil_unidad):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,

--- a/backend/app/api/routes/produccion.py
+++ b/backend/app/api/routes/produccion.py
@@ -703,6 +703,37 @@ async def create_produccion(
         # El abastecimiento asociado al parte se registra en la misma
         # transaccion: el parte y el egreso de stock nacen o fallan juntos.
         if data.combustible > 0:
+            # Issue #124 (parte 2): dedupe por clave natural antes del
+            # insert. Si ya existe una carga con la misma combinacion
+            # (movil, fecha, litros, remito, tipo_mov='E') para el mismo
+            # operador, abortamos para no duplicar el egreso de stock.
+            # Cubre doble submit desde la UI (doble click, doble tab,
+            # retry de red) que genera form_uuids distintos.
+            if data.remito:
+                existing_carga = (
+                    db.query(CargaComb)
+                    .filter(
+                        CargaComb.personal == data.cod_operador,
+                        CargaComb.idMovil == data.cod_equipo,
+                        CargaComb.Fecha == data.fecha,
+                        CargaComb.Litros == data.combustible,
+                        CargaComb.remito == data.remito,
+                        CargaComb.tipo_mov == "E",
+                    )
+                    .first()
+                )
+                if existing_carga:
+                    raise HTTPException(
+                        status_code=409,
+                        detail=(
+                            f"Ya existe una carga de {data.combustible} L "
+                            f"del movil {data.cod_equipo} con remito "
+                            f"{data.remito} en {data.fecha} "
+                            f"(id carga {existing_carga.idCargaComb}). "
+                            f"No se duplica el egreso de stock."
+                        ),
+                    )
+
             now = datetime.now()
             carga = CargaComb(
                 idMovil=data.cod_equipo,

--- a/backend/tests/test_combustible_fuente_verdad.py
+++ b/backend/tests/test_combustible_fuente_verdad.py
@@ -199,24 +199,31 @@ def test_same_explicit_event_id_cannot_be_written_again_from_the_other_flow(
     assert result.id_carga == rows[0].idCargaComb
 
 
-def test_identical_real_loads_with_different_ids_are_allowed(db):
-    first = asyncio.run(
+def test_identical_real_loads_with_different_ids_are_rejected(db):
+    """Issue #124 (parte 2): dos cargas con el mismo (movil, fecha, litros,
+    remito) y mismo operador se consideran la misma carga fisica aunque
+    tengan form_uuids distintos. La segunda debe rebotar con 409 para no
+    duplicar el egreso de stock.
+    """
+    from fastapi import HTTPException
+
+    asyncio.run(
         combustible.create_carga_combustible(
             _payload("carga-fisica-a"),
             db=db,
             user=_user(),
         )
     )
-    second = asyncio.run(
-        combustible.create_carga_combustible(
-            _payload("carga-fisica-b"),
-            db=db,
-            user=_user(),
+    with pytest.raises(HTTPException) as excinfo:
+        asyncio.run(
+            combustible.create_carga_combustible(
+                _payload("carga-fisica-b"),
+                db=db,
+                user=_user(),
+            )
         )
-    )
-
-    assert second.id_carga != first.id_carga
-    assert db.query(CargaComb).count() == 2
+    assert excinfo.value.status_code == 409
+    assert db.query(CargaComb).count() == 1
 
 
 def test_form_uuid_matches_the_database_contract():
@@ -293,3 +300,81 @@ def test_combustible_endpoint_persiste_remito_normalizado(db):
 
     row = db.query(CargaComb).one()
     assert row.remito == "000000011278"
+
+
+# ─── Issue #124 (parte 2): dedupe por clave natural ─────────────────────
+
+
+def test_combustible_endpoint_rechaza_carga_duplicada_con_otro_form_uuid(db):
+    """Cubre el doble submit del mismo operador: dos form_uuids distintos
+    para la misma carga fisica. La segunda llamada debe rebotar con 409.
+    """
+    first = CargaCombustibleCreate(
+        form_uuid="carga-original",
+        fecha=date(2026, 7, 29),
+        id_movil=10,
+        litros=160,
+        km=14855,
+        id_lugar_carga=42,
+        id_tipo_comb=1,
+        remito="000000011278",
+    )
+    asyncio.run(
+        combustible.create_carga_combustible(
+            first, db=db, user=_user()
+        )
+    )
+
+    # Misma carga, distinto form_uuid (retry de red, doble click, etc.).
+    duplicate = CargaCombustibleCreate(
+        form_uuid="carga-retry",
+        fecha=date(2026, 7, 29),
+        id_movil=10,
+        litros=160,
+        km=14856,  # KM puede variar
+        id_lugar_carga=42,
+        id_tipo_comb=1,
+        remito="000000011278",
+    )
+
+    from fastapi import HTTPException
+
+    with pytest.raises(HTTPException) as excinfo:
+        asyncio.run(
+            combustible.create_carga_combustible(
+                duplicate, db=db, user=_user()
+            )
+        )
+    assert excinfo.value.status_code == 409
+    assert "Ya existe una carga" in excinfo.value.detail
+
+    # Solo se persiste la primera.
+    assert db.query(CargaComb).count() == 1
+
+
+def test_combustible_endpoint_permite_cargas_distintas(db):
+    """Cargas con la misma fecha y movil pero distinto remito son legitimas."""
+    a = CargaCombustibleCreate(
+        form_uuid="carga-a",
+        fecha=date(2026, 7, 29),
+        id_movil=10,
+        litros=160,
+        km=14855,
+        id_lugar_carga=42,
+        id_tipo_comb=1,
+        remito="000000011278",
+    )
+    b = CargaCombustibleCreate(
+        form_uuid="carga-b",
+        fecha=date(2026, 7, 29),
+        id_movil=10,
+        litros=160,
+        km=14855,
+        id_lugar_carga=42,
+        id_tipo_comb=1,
+        remito="000000011279",  # remito distinto
+    )
+    asyncio.run(combustible.create_carga_combustible(a, db=db, user=_user()))
+    asyncio.run(combustible.create_carga_combustible(b, db=db, user=_user()))
+
+    assert db.query(CargaComb).count() == 2

--- a/backend/tests/test_produccion_combustible_remitos.py
+++ b/backend/tests/test_produccion_combustible_remitos.py
@@ -14,6 +14,7 @@ from datetime import date
 from types import SimpleNamespace
 
 import pytest
+from fastapi import HTTPException
 from pydantic import ValidationError
 
 from app.api.routes import produccion
@@ -158,27 +159,45 @@ def test_schema_rechaza_remito_numerico_con_mas_de_12_digitos():
 
 
 class FakeQuery:
-    """Query en cadena que devuelve ``None`` para first() y 0 para scalar()."""
+    """Query en cadena que devuelve ``None`` para first() y 0 para scalar().
+
+    Se puede inyectar un set de filas con ``rows=[...]`` para que ``first()``
+    las recorra y devuelva la primera que coincida (sin aplicar realmente los
+    filtros, sirve para tests de dedupe por clave natural).
+    """
+
+    def __init__(self, rows=None):
+        self._rows = rows or []
 
     def filter(self, *_args, **_kwargs):
         return self
 
     def first(self):
-        return None
+        return self._rows[0] if self._rows else None
 
     def scalar(self):
         return 0
 
 
 class FakeDb:
-    """Doble de ``Session`` que registra lo agregado y mockea el resto."""
+    """Doble de ``Session`` que registra lo agregado y mockea el resto.
+
+    ``existing_cargas`` permite inyectar cargas pre-existentes para que las
+    queries de dedupe por clave natural las "encuentren". Para ``CargaComb``
+    las devuelve, para cualquier otro modelo (tablero, func.max) devuelve
+    una query vacia.
+    """
 
     def __init__(self):
         self.added = []
         self.commits = 0
         self.flushes = 0
+        self.existing_cargas = []
 
-    def query(self, *_args, **_kwargs):
+    def query(self, model, *_args, **_kwargs):
+        from app.models.carga_comb import CargaComb as _CargaComb
+        if model is _CargaComb:
+            return FakeQuery(rows=self.existing_cargas)
         return FakeQuery()
 
     def add(self, row):
@@ -346,3 +365,95 @@ def test_create_persists_hyphenated_remito_in_part_and_carga(monkeypatch):
     carga = db.added[1]
     assert tablero.remito == "000200001335"
     assert carga.remito == "000200001335"
+
+
+# ─── Issue #124 (parte 2): dedupe por clave natural en produccion ────────
+
+
+def test_create_produccion_rechaza_carga_duplicada_con_otro_form_uuid(monkeypatch):
+    """Si ya existe una carga con el mismo (movil, fecha, litros, remito)
+    para el mismo operador, el segundo parte con distinto form_uuid rebota
+    con 409 para no duplicar el egreso de stock.
+    """
+    db = FakeDb()
+    _bypass_external_deps(monkeypatch)
+
+    # Simulamos que ya existe la carga original en la base.
+    db.existing_cargas = [
+        SimpleNamespace(
+            idCargaComb=1, idMovil=10, Fecha=date(2026, 7, 28),
+            Litros=150, remito="000000011278", personal=5,
+        )
+    ]
+
+    duplicate = TableroProduccionCreate(
+        fecha=date(2026, 7, 28),
+        form_uuid="parte-retry",
+        UN="BIOMASA FRESA",
+        cod_un=1,
+        cod_equipo=10,
+        cod_operador=5,
+        combustible=150,
+        km_combustible=14856,  # KM puede variar
+        lugar_carga=42,
+        id_tipo_comb=2,
+        remito="000000011278",
+    )
+
+    from app.models.carga_comb import CargaComb as _CargaComb
+
+    with pytest.raises(HTTPException) as excinfo:
+        asyncio.run(
+            produccion.create_produccion(
+                duplicate, db=db, user=SimpleNamespace()
+            )
+        )
+    assert excinfo.value.status_code == 409
+    assert "Ya existe una carga" in excinfo.value.detail
+    # El CargaComb (que es lo que duplica el egreso de stock) NO se agrega.
+    # El TableroProduccion puede haber sido agregado antes del check, pero
+    # en una DB real el rollback limpia la transaccion completa.
+    cargas_agregadas = [r for r in db.added if isinstance(r, _CargaComb)]
+    assert len(cargas_agregadas) == 0
+    # Y ademas, el commit no se ejecuto (la transaccion queda abierta para
+    # que FastAPI haga rollback).
+    assert db.commits == 0
+
+
+def test_create_produccion_permite_cargas_con_remito_distinto(monkeypatch):
+    """Dos partes en la misma fecha, mismo movil, mismo operador pero
+    con remito distinto son legitimos (caso normal de dos cargas en el dia).
+    """
+    db = FakeDb()
+    _bypass_external_deps(monkeypatch)
+
+    a = TableroProduccionCreate(
+        fecha=date(2026, 7, 28),
+        form_uuid="parte-a",
+        UN="BIOMASA FRESA",
+        cod_un=1,
+        cod_equipo=10,
+        cod_operador=5,
+        combustible=150,
+        km_combustible=14855,
+        lugar_carga=42,
+        id_tipo_comb=2,
+        remito="000000011278",
+    )
+    b = TableroProduccionCreate(
+        fecha=date(2026, 7, 28),
+        form_uuid="parte-b",
+        UN="BIOMASA FRESA",
+        cod_un=1,
+        cod_equipo=10,
+        cod_operador=5,
+        combustible=150,
+        km_combustible=14855,
+        lugar_carga=42,
+        id_tipo_comb=2,
+        remito="000000011279",  # remito distinto
+    )
+    asyncio.run(produccion.create_produccion(a, db=db, user=SimpleNamespace()))
+    asyncio.run(produccion.create_produccion(b, db=db, user=SimpleNamespace()))
+
+    assert len(db.added) == 4  # 2 tableros + 2 cargas


### PR DESCRIPTION
## Objetivo

Closes #124 (parte 2 de la duplicacion de cargas).

El dedupe por \orm_uuid\ cubre el retry idempotente del mismo formulario,
pero NO cubre el doble submit que genera form_uuids distintos con la misma
carga (doble click, doble tab, retry de red con UUID regenerado). Esto
deja el stock descuadrado porque el mismo egreso de combustible se persiste
dos veces.

## Causa raiz

\POST /api/combustible/cargas\ y \POST /api/produccion/\ validan que no
exista una carga con el mismo \orm_uuid\ para el mismo operador, pero
no verifican la **clave natural** de la carga fisica
(\idMovil + Fecha + Litros + remito + tipo_mov='E'\). Si dos submits
llegan con form_uuids distintos pero la misma clave natural, ambos pasan
y se duplica el egreso de stock.

## Fix

Antes del INSERT, ambos endpoints consultan \cargacomb\ por la clave
natural para el mismo operador. Si ya existe, devuelven HTTP 409 con el
id de la carga original y un mensaje claro para que el operador sepa
que la carga ya esta registrada.

El dedupe por \orm_uuid\ se mantiene primero para preservar la
idempotencia del retry del mismo formulario (devuelve la carga existente
en vez de rechazarla con 409).

## Cambios

- \ackend/app/api/routes/combustible.py\: bloquea el POST /cargas
  cuando la clave natural ya existe para el mismo usuario.
- \ackend/app/api/routes/produccion.py\: mismo check dentro de la
  transaccion del parte, antes de insertar el CargaComb relacionado.
- \ackend/tests/test_combustible_fuente_verdad.py\: 2 tests nuevos
  (rechazo del duplicado + permiso de cargas distintas) y actualizacion
  de \	est_identical_real_loads_with_different_ids_are_allowed\ que
  ahora es \..._are_rejected\ (refleja la nueva regla).
- \ackend/tests/test_produccion_combustible_remitos.py\: 2 tests nuevos
  equivalentes para el flujo Produccion + FakeDb mejorado para soportar
  cargas pre-existentes.

## Tests / Validaciones

- [x] \git diff --check\
- [x] \py -3.12 -m compileall app\
- [x] \py -3.12 -m pytest tests/test_remito_normalize.py\ (29/29)
- [x] \py -3.12 -m pytest tests/test_produccion_combustible_remitos.py\ (29/29)
- [x] \py -3.12 -m pytest tests/test_combustible_fuente_verdad.py\ (15/15)
- [x] \py -3.12 -m pytest\ (suite completa: 184/184, excluyendo
      \	est_deploy_scripts_contract.py\ que ya fallaba en main)
- [x] \
pm test\ (frontend: 227/227)

## Fuera de alcance

- Proceso batch externo que duplica sin pasar por el backend
  (no hay codigo fuente en este repo, requiere acceso al sistema
  que lo origina).
- Migracion de limpieza de los ~21 duplicados que ese batch dejo en
  la base entre 04/08 y 05/08.

## Verificacion manual post-merge

Para confirmar que el fix funciona en la app real:

1. Crear una carga desde Produccion con \emito=000000011278\, 100 L.
2. Intentar crear la misma carga de nuevo (doble click o nuevo tab).
3. **Esperado**: el segundo submit devuelve 409 con el id de la primera
   carga. La UI deberia mostrar el error y NO duplicar el egreso.