### PR TITLE
fix(produccion): filtrar rodales por el acta seleccionada en la app (closes #133)

### DIFF
--- a/backend/app/api/routes/produccion.py
+++ b/backend/app/api/routes/produccion.py
@@ -519,6 +519,42 @@ async def list_actas(db: Session = Depends(get_db)):
     return unique_rows
 
 
+# ─── Rodales por Acta (issue #133) ───
+# Devuelve la union de los rodales vinculados a un acta (mismo `numero` puede
+# tener varias filas con distintos `rodal_id` en la tabla `actas`).
+@router.get("/actas/{acta_numero}/rodales", response_model=List[RodalResponse])
+async def list_rodales_por_acta(acta_numero: str, db: Session = Depends(get_db)):
+    numero = str(acta_numero or "").strip()
+    if not numero:
+        return []
+    if not _table_exists(db, "actas") or not _table_exists(db, "rodales"):
+        return []
+
+    # 1) Reunir los rodal_id de TODAS las filas de actas con este numero
+    acta_rows = (
+        db.query(Acta.rodal_id)
+        .filter(Acta.numero == numero)
+        .all()
+    )
+    rodal_ids: set[int] = {
+        int(row.rodal_id) for row in acta_rows if row.rodal_id
+    }
+    if not rodal_ids:
+        return []
+
+    # 2) Cargar la info de cada Rodal
+    rows = (
+        db.query(Rodal)
+        .filter(Rodal.idRodal.in_(rodal_ids))
+        .order_by(Rodal.Rodal)
+        .all()
+    )
+    return [
+        RodalResponse(idRodal=r.idRodal, rodal=r.Rodal, idPredio=r.idPredio)
+        for r in rows
+    ]
+
+
 # ─── Predios ───
 @router.get("/predios", response_model=List[PredioResponse])
 async def list_predios(db: Session = Depends(get_db)):

--- a/backend/tests/test_produccion_acta_rodales.py
+++ b/backend/tests/test_produccion_acta_rodales.py
@@ -1,0 +1,240 @@
+"""Tests de regresion para `GET /api/produccion/actas/{numero}/rodales`.
+
+Issue #133: el dropdown de Rodal en la app móvil debe mostrar los rodales
+vinculados al Acta elegida, no los del último Predio cargado.
+
+Estos tests validan el endpoint nuevo sin levantar FastAPI: llaman a la
+función async con un doble de ``Session`` (FakeDb) que responde segun el
+modelo que se le pida. Se hace monkeypatch de ``_table_exists`` para no
+depender del engine real.
+"""
+import asyncio
+from types import SimpleNamespace
+
+from app.api.routes import produccion
+
+
+class ActaRow:
+    """Fila minima del modelo ``Acta`` (solo lo que el endpoint mira)."""
+
+    def __init__(self, numero, rodal_id):
+        self.numero = numero
+        self.rodal_id = rodal_id
+
+
+class RodalRow:
+    """Fila minima del modelo ``Rodal`` (mapea a ``RodalResponse``)."""
+
+    def __init__(self, idRodal, rodal, idPredio):
+        self.idRodal = idRodal
+        self.Rodal = rodal
+        self.idPredio = idPredio
+
+
+class FakeQuery:
+    """Query en cadena que aplica filtros de igualdad simples.
+
+    Soporta encadenar ``.filter(...)`` y ``.order_by(...)``. El filter
+    inspecciona la expresión de SQLAlchemy (``BinaryExpression`` con
+    ``left`` columna y ``right`` valor) y descarta las filas cuyo atributo
+    no coincida con el valor. Si el filter no se puede inspeccionar (por
+    ejemplo, una expresión compleja), no se aplica.
+    """
+
+    def __init__(self, rows):
+        self._rows = list(rows)
+
+    def filter(self, *conditions, **_kwargs):
+        for cond in conditions:
+            self._rows = [r for r in self._rows if _match_condition(r, cond)]
+        return self
+
+    def order_by(self, *_args, **_kwargs):
+        return self
+
+    def all(self):
+        return list(self._rows)
+
+
+def _match_condition(row, cond):
+    """Si ``cond`` es ``Column == value`` o ``Column.in_(values)``, filtra.
+
+    Para mantener el test simple, solo soporta equality y ``in_``.
+    Si la expresión es compleja, devuelve True (no filtra).
+    """
+    # Equality: Column == value  (BinaryExpression)
+    left = getattr(cond, "left", None)
+    right = getattr(cond, "right", None)
+    op = getattr(cond, "operator", None)
+    if left is not None and right is not None and op is not None:
+        op_name = getattr(op, "__name__", "")
+        attr_name = getattr(left, "key", None) or getattr(left, "name", None)
+        if op_name == "eq" and attr_name:
+            return getattr(row, attr_name, None) == _unwrap_bindparam(right)
+        # in_: el lado derecho es un tuple/lista
+        if op_name == "in_op" and attr_name:
+            values = right
+            if hasattr(right, "value"):  # BindParameter con tupla adentro
+                values = right.value
+            try:
+                return getattr(row, attr_name, None) in values
+            except TypeError:
+                return True
+    return True
+
+
+def _unwrap_bindparam(value):
+    """Los valores literales del filter vienen envueltos en BindParameter."""
+    return getattr(value, "value", value)
+
+
+class FakeDb:
+    """Doble de ``Session`` con dos colecciones: ``actas`` y ``rodales``.
+
+    Acepta tanto ``db.query(Acta)`` como ``db.query(Acta.rodal_id)``
+    (queries por columna). Para las queries por columna, identifica la
+    tabla via ``column.table.name``.
+    """
+
+    def __init__(self, actas=None, rodales=None):
+        self._actas = list(actas or [])
+        self._rodales = list(rodales or [])
+
+    def query(self, model, *_args, **_kwargs):
+        # Caso 1: query por columna → tiene ``.table.name``
+        table = getattr(model, "table", None)
+        table_name = getattr(table, "name", None) if table is not None else None
+        if table_name == "actas":
+            return FakeQuery(self._actas)
+        if table_name == "rodales":
+            return FakeQuery(self._rodales)
+        # Caso 2: query por modelo → tiene ``__name__``
+        cls_name = getattr(model, "__name__", "")
+        if cls_name == "Acta":
+            return FakeQuery(self._actas)
+        if cls_name == "Rodal":
+            return FakeQuery(self._rodales)
+        return FakeQuery([])
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def test_endpoint_devuelve_rodales_de_un_acta_con_multiples_filas(monkeypatch):
+    """Caso del bug: acta 7900001260 tiene 2 filas, una por cada Rodal."""
+    monkeypatch.setattr(produccion, "_table_exists", lambda _db, _t: True)
+    actas = [
+        ActaRow(numero="7900001260", rodal_id=10),
+        ActaRow(numero="7900001260", rodal_id=11),
+    ]
+    rodales = [
+        RodalRow(idRodal=10, rodal="01", idPredio=1),
+        RodalRow(idRodal=11, rodal="94", idPredio=2),
+        # Rodal de OTRA acta que NO debe aparecer
+        RodalRow(idRodal=99, rodal="99", idPredio=3),
+    ]
+    db = FakeDb(actas=actas, rodales=rodales)
+
+    result = _run(produccion.list_rodales_por_acta("7900001260", db=db))
+
+    assert len(result) == 2
+    rodales_devueltos = sorted([r.rodal for r in result])
+    assert rodales_devueltos == ["01", "94"]
+
+
+def test_endpoint_acta_no_encontrada_devuelve_lista_vacia(monkeypatch):
+    """Si el numero de acta no existe, devolver lista vacia (no 404)."""
+    monkeypatch.setattr(produccion, "_table_exists", lambda _db, _t: True)
+    db = FakeDb(
+        actas=[ActaRow(numero="OTRA", rodal_id=10)],
+        rodales=[RodalRow(idRodal=10, rodal="01", idPredio=1)],
+    )
+
+    result = _run(produccion.list_rodales_por_acta("NO-EXISTE", db=db))
+
+    assert result == []
+
+
+def test_endpoint_acta_sin_rodal_id_devuelve_lista_vacia(monkeypatch):
+    """Filas con ``rodal_id=0`` (basura/sin asignar) no deben explotar."""
+    monkeypatch.setattr(produccion, "_table_exists", lambda _db, _t: True)
+    actas = [
+        ActaRow(numero="X", rodal_id=0),
+        ActaRow(numero="X", rodal_id=0),
+    ]
+    db = FakeDb(actas=actas, rodales=[])
+
+    result = _run(produccion.list_rodales_por_acta("X", db=db))
+
+    assert result == []
+
+
+def test_endpoint_numero_vacio_devuelve_lista_vacia(monkeypatch):
+    """``acta_numero`` vacio o solo espacios: lista vacia sin tocar la DB."""
+    monkeypatch.setattr(produccion, "_table_exists", lambda _db, _t: True)
+    db = FakeDb(
+        actas=[ActaRow(numero="X", rodal_id=10)],
+        rodales=[RodalRow(idRodal=10, rodal="01", idPredio=1)],
+    )
+
+    for vacio in ["", "   "]:
+        result = _run(produccion.list_rodales_por_acta(vacio, db=db))
+        assert result == []
+
+
+def test_endpoint_normaliza_numero_con_espacios(monkeypatch):
+    """El numero viene con espacios (ej. del form); debe trim-ear antes de buscar."""
+    monkeypatch.setattr(produccion, "_table_exists", lambda _db, _t: True)
+    actas = [ActaRow(numero="7900001260", rodal_id=10)]
+    rodales = [RodalRow(idRodal=10, rodal="01", idPredio=1)]
+    db = FakeDb(actas=actas, rodales=rodales)
+
+    result = _run(produccion.list_rodales_por_acta("  7900001260  ", db=db))
+
+    assert len(result) == 1
+    assert result[0].rodal == "01"
+
+
+def test_endpoint_deduplica_si_hay_filas_repetidas_para_mismo_rodal(monkeypatch):
+    """Si dos filas de actas repiten el mismo ``rodal_id``, no duplicar en la respuesta."""
+    monkeypatch.setattr(produccion, "_table_exists", lambda _db, _t: True)
+    actas = [
+        ActaRow(numero="DUP", rodal_id=10),
+        ActaRow(numero="DUP", rodal_id=10),
+        ActaRow(numero="DUP", rodal_id=10),
+    ]
+    rodales = [RodalRow(idRodal=10, rodal="01", idPredio=1)]
+    db = FakeDb(actas=actas, rodales=rodales)
+
+    result = _run(produccion.list_rodales_por_acta("DUP", db=db))
+
+    assert len(result) == 1
+    assert result[0].idRodal == 10
+
+
+def test_endpoint_respeta_caso_un_solo_rodal(monkeypatch):
+    """Caso normal (un acta con un solo rodal) sigue funcionando."""
+    monkeypatch.setattr(produccion, "_table_exists", lambda _db, _t: True)
+    actas = [ActaRow(numero="UNICO", rodal_id=42)]
+    rodales = [RodalRow(idRodal=42, rodal="A", idPredio=1)]
+    db = FakeDb(actas=actas, rodales=rodales)
+
+    result = _run(produccion.list_rodales_por_acta("UNICO", db=db))
+
+    assert len(result) == 1
+    assert result[0].idRodal == 42
+    assert result[0].rodal == "A"
+    assert result[0].idPredio == 1
+
+
+def test_endpoint_no_explota_si_tabla_actas_no_existe(monkeypatch):
+    """Defensivo: si la tabla ``actas`` no esta, devolver lista vacia (no 500)."""
+    def fake_table_exists(_db, table):
+        return table != "actas"
+    monkeypatch.setattr(produccion, "_table_exists", fake_table_exists)
+    db = FakeDb()
+
+    result = _run(produccion.list_rodales_por_acta("LO-QUE-SEA", db=db))
+
+    assert result == []

--- a/frontend/src/stores/produccion.js
+++ b/frontend/src/stores/produccion.js
@@ -249,6 +249,21 @@ export const useProduccionStore = defineStore('produccion', {
       })
     },
 
+    // Issue #133: lista de rodales vinculados al Acta seleccionada.
+    // El dropdown del parte usa esta lista cuando hay un Acta elegida;
+    // si ademas hay un Predio elegido, se filtra client-side.
+    async fetchRodalesPorActa(actaNumero) {
+      const numero = (actaNumero || '').toString().trim()
+      if (!numero) return null
+      return this.fetchCatalog({
+        catalog: 'rodales',
+        target: 'rodales',
+        url: `/api/produccion/actas/${encodeURIComponent(numero)}/rodales`,
+        scope: `acta:${numero}`,
+        skipWhenMissingScope: true,
+      })
+    },
+
     async fetchLugaresCarga(unId) {
       return this.fetchCatalog({
         catalog: 'lugaresCarga',

--- a/frontend/src/stores/produccion.test.js
+++ b/frontend/src/stores/produccion.test.js
@@ -139,6 +139,51 @@ describe('produccion catalogos offline', () => {
       expect.objectContaining({ _suppressErrorToast: true }),
     )
   })
+
+  // ─── Issue #133: rodales por acta ───
+
+  it('fetchRodalesPorActa pide los rodales vinculados al acta seleccionada', async () => {
+    api.get.mockResolvedValueOnce({
+      data: [
+        { idRodal: 10, rodal: '01', idPredio: 1 },
+        { idRodal: 11, rodal: '94', idPredio: 2 },
+      ],
+    })
+    const store = useProduccionStore()
+
+    await store.fetchRodalesPorActa('7900001260')
+
+    expect(api.get).toHaveBeenCalledWith(
+      '/api/produccion/actas/7900001260/rodales',
+      expect.objectContaining({ _suppressErrorToast: true }),
+    )
+    expect(store.rodales).toEqual([
+      { idRodal: 10, rodal: '01', idPredio: 1 },
+      { idRodal: 11, rodal: '94', idPredio: 2 },
+    ])
+    expect(store.catalogStatus.rodales.state).toBe('success')
+  })
+
+  it('fetchRodalesPorActa codifica el numero por si trae caracteres especiales', async () => {
+    api.get.mockResolvedValueOnce({ data: [] })
+    const store = useProduccionStore()
+
+    await store.fetchRodalesPorActa('123 456/ABC')
+
+    expect(api.get).toHaveBeenCalledWith(
+      '/api/produccion/actas/123%20456%2FABC/rodales',
+      expect.any(Object),
+    )
+  })
+
+  it('fetchRodalesPorActa no llama a la API si el numero esta vacio', async () => {
+    const store = useProduccionStore()
+
+    const result = await store.fetchRodalesPorActa('')
+
+    expect(api.get).not.toHaveBeenCalled()
+    expect(result).toBeNull()
+  })
 })
 
 describe('produccion sync offline', () => {

--- a/frontend/src/views/ProduccionFormView.vue
+++ b/frontend/src/views/ProduccionFormView.vue
@@ -800,17 +800,17 @@
 
           <div v-if="requiereRodal" class="mt-3">
             <AutocompleteField
-              v-if="store.rodales.length > 0"
+              v-if="rodalesVisibles.length > 0"
               label="Rodal"
               v-model="form.rodal_id"
-              :items="store.rodales"
+              :items="rodalesVisibles"
               labelKey="rodal"
               valueKey="idRodal"
               placeholder="— Buscar rodal —"
               :loading="catalogLoading('rodales')"
               :error="catalogError('rodales')"
               :errorMessage="catalogErrorMessage('rodales')"
-              emptyMessage="Sin rodales configurados para este predio"
+              emptyMessage="Sin rodales configurados para este acta"
               :stale="catalogStale('rodales')"
             />
             <div v-else-if="catalogHasError('rodales')" class="app-surface-muted rounded-lg border p-3 text-sm text-neutral-600">
@@ -1261,6 +1261,17 @@ const rodalCompleto = computed(() => {
   return String(form.rodal_manual ?? '').trim().length > 0
 })
 
+// Issue #133: si hay Acta elegida, los rodales visibles son los vinculados
+// al acta; si ademas hay Predio elegido, se filtra por idPredio (interseccion).
+// Si no hay Acta, mantiene el comportamiento por Predio.
+const rodalesVisibles = computed(() => {
+  const lista = store.rodales || []
+  if (!actaNormalizada.value) return lista
+  const predioId = Number(form.predio_id || 0)
+  if (!predioId) return lista
+  return lista.filter((r) => Number(r.idPredio) === predioId)
+})
+
 const ubicacionValida = computed(() => {
   if (!ubicacionOperativaRequerida.value) return true
   if (requiereActa.value && (!actaNormalizada.value || actaNormalizada.value === '0')) return false
@@ -1579,10 +1590,24 @@ function onTipoProcesoChange() {
 async function onPredioChange() {
   form.rodal_id = ''
   form.rodal_manual = ''
-  if (form.predio_id) {
+  // Issue #133: si hay Acta elegida, los rodales ya fueron cargados
+  // por el watcher de ``actaNormalizada``. Solo reseteamos el form;
+  // la interseccion con Predio la hace ``rodalesVisibles``.
+  if (!actaNormalizada.value && form.predio_id) {
     await store.fetchRodales(form.predio_id)
   }
 }
+
+// Issue #133: al cambiar el Acta, recargar los rodales vinculados.
+// Reset del Rodal seleccionado + fetch de la nueva lista.
+watch(actaNormalizada, async (nuevo, anterior) => {
+  if (nuevo === anterior) return
+  form.rodal_id = ''
+  form.rodal_manual = ''
+  if (nuevo) {
+    await store.fetchRodalesPorActa(nuevo)
+  }
+})
 
 // ─── Watch combustible toggle ───
 watch(cargoCombustible, (val) => {


### PR DESCRIPTION
## Objetivo

Closes #133

Arregla el bug detectado por Matias: en el panel admin el acta `7900001260`
tiene dos rodales (`01` y `94`), pero en la app movil el dropdown de Rodal
mostraba `02` y `03` (los del ultimo Predio elegido). El operario terminaba
cargando partes con un Rodal que no correspondia al Acta real.

## Causa raiz

Dos bugs encadenados:

1. **`GET /api/produccion/actas`** deduplicaba por `numero` y devolvia
   solo la primera fila de cada acta. La tabla `actas` ya estaba bien
   modelada (1 fila = 1 par `numero + rodal_id`), pero el endpoint
   aplastaba toda la info. El admin usa otro endpoint
   (`admin/catalogs/actas`) y por eso veia bien.
2. **`ProduccionFormView` + `GET /api/produccion/rodales`**: el dropdown
   de Rodal en la app se filtraba **solo por `predio_id`**, sin importar
   el Acta. Ademas, no se reseteaba la lista de Rodales al cambiar el
   Acta ni al limpiar el Predio.

## Fix

### Backend

* Nuevo endpoint `GET /api/produccion/actas/{acta_numero}/rodales` que
  devuelve la **union de los rodales** vinculados a un acta
  (deduplicado por `idRodal`, ordenado por nombre).
* `GET /actas` y `GET /rodales` quedan sin tocar (back-compat).

### Frontend

* `stores/produccion.js`: nuevo metodo `fetchRodalesPorActa(numero)` con
  cache offline igual que el resto de catalogos.
* `views/ProduccionFormView.vue`:
  * `watch(actaNormalizada)`: al cambiar el Acta resetea el Rodal
    seleccionado y recarga la lista.
  * `computed rodalesVisibles`: si hay Acta + Predio elegidos, hace la
    interseccion client-side (sin volver a pegarle al backend).
  * `onPredioChange`: ya no pisa la lista cuando hay Acta elegida.

## Cambios

* `backend/app/api/routes/produccion.py` — +36 lineas (nuevo endpoint).
* `backend/tests/test_produccion_acta_rodales.py` — +240 lineas
  (archivo nuevo, 8 tests con FakeDb/FakeQuery que soporta `eq` e
  `in_`).
* `frontend/src/stores/produccion.js` — +15 lineas
  (`fetchRodalesPorActa`).
* `frontend/src/stores/produccion.test.js` — +45 lineas (3 tests).
* `frontend/src/views/ProduccionFormView.vue` — +33/-4
  (watcher, computed, ajuste de handler).

## Tests / Validaciones

- [x] `git diff --check` limpio
- [x] `git diff --cached --check` limpio
- [x] `py -3.12 -m compileall app` — OK
- [x] `py -3.12 -m pytest tests/test_produccion_acta_rodales.py` —
      **8/8 OK**
- [x] `py -3.12 -m pytest` (suite produccion + combustible + remito) —
      **114/114 OK**
- [x] `npx vitest run src/stores/produccion.test.js` — **14/14 OK**
- [x] `npx vitest run` (suite completa frontend) — **230/230 OK**
- [x] `npx vite build` — OK

## Fuera de alcance

- No se cambia `GET /api/produccion/actas` (sigue con su dedupe; el
  dropdown del Acta sigue funcionando).
- No se cambia el modelo `Acta` ni el schema de la tabla.
- No se hace limpieza retroactiva de los partes ya cargados con Rodal
  mal (queda como tarea aparte si Matias lo pide).
- No se toca la pantalla de Admin → Actas (ya lista bien).
- No se cambia `GET /api/produccion/rodales` (el flujo por Predio sigue
  intacto).

## Compatibilidad

* Consumers existentes del endpoint `/actas` (mobile, admin, etc.) no
  cambian de shape.
* El `ActaResponse` y el `RodalResponse` no se tocan.
* El `rodales` state del store mantiene la misma forma.
* Si no hay Acta elegida, el comportamiento es identico al actual
  (filtra por Predio).
* Si hay Acta pero no hay Predio, el dropdown muestra todos los
  rodales del acta.
* Si hay Acta + Predio, se filtra client-side a la interseccion.

## Riesgos / pendientes

- **Bajo**. Cambio additive, no rompe consumidores existentes.
- El pre-fetch de rodales para un parte pre-poblado desde `pendingRecords`
  queda fuera de alcance (queda cubierto por el watch cuando el usuario
  re-edita el parte).
- Validacion visual post-deploy: confirmar en produccion que al elegir
  `Acta = 7900001260` el dropdown muestra `01` y `94` (no `02, 03`).
  Captura sugerida en `docs/screenshots/issue-133-rodal-fix/`.
