### PR TITLE
fix(docs): advertir que este runbook no aplica al deploy normal de produccion_fg (closes #135)

### DIFF
--- a/docs/DEPLOY_GITHUB_MAIN_RUNBOOK.md
+++ b/docs/DEPLOY_GITHUB_MAIN_RUNBOOK.md
@@ -4,6 +4,11 @@
 > Cubre **backend** (containers `indufor` + `produccion_fg`) y **frontend**
 > (estáticos de `produccion_fg` servidos por Nginx).
 > El commit debe estar mergeado en `origin/main` antes de empezar.
+> ⚠️ **NO usar para el deploy normal de `produccion_fg`**. Este runbook cubre
+> el flujo **multi-instance** (backend `indufor` + `produccion_fg` + frontend
+> estático) desde `origin/main`. Para el deploy acotado y periódico de
+> `produccion_fg` (solo backend + frontend), usar
+> [`DEPLOY.md`](../DEPLOY.md) y `scripts/deploy_produccion_fg_main_fasa195.sh`.
 
 ## Resumen
 


### PR DESCRIPTION
## Objetivo

Closes #135

Arregla el test pre-existente roto `test_multiinstance_runbook_warns_against_normal_produccion_fg_deploy`, que buscaba el string literal `"NO usar para el deploy normal de \`produccion_fg\`"` en `docs/DEPLOY_GITHUB_MAIN_RUNBOOK.md` pero nunca se escribio. Eso bloqueaba `scripts/build_deploy_package.ps1` (corre pytest como parte del packaging) y obligaba a usar `-SkipTests` en cada deploy, como se hizo en el PR #134 (issue #133).

## Causa

El test fue agregado en `a74afca` (1 de agosto) con la intencion de que el runbook multi-instance tuviera una advertencia explicita de que NO aplica al deploy normal (acotado) de `produccion_fg`. El parrafo nunca se escribio en el `.md`.

## Fix

Agrega un callout justo despues del bloque introductorio del runbook, con el string literal que el test busca. El callout aclara que este runbook es el flujo multi-instance (backend `indufor` + `produccion_fg` + frontend) desde `origin/main`, y deriva al `DEPLOY.md` canonico + `scripts/deploy_produccion_fg_main_fasa195.sh` para el deploy acotado de `produccion_fg`.

## Cambios

- `docs/DEPLOY_GITHUB_MAIN_RUNBOOK.md` - +5 lineas (callout nuevo).

## Tests / Validaciones

- [x] `git diff --check` limpio
- [x] `git diff --cached --check` limpio
- [x] `py -3.12 -m pytest tests/test_deploy_scripts_contract.py -v` - **10/10 OK**
- [x] `py -3.12 -m pytest` (suite completa backend) - 0 fallos (la suite
      completa, incluido el test que estaba roto, ahora pasa)

## Fuera de alcance

- No se modifica el test (la regla que codifica es razonable).
- No se cambian otros runbooks.
- No se toca el script `deploy_produccion_fg_main_fasa195.sh`.
- No se cambia el flujo de deploy.

## Verificacion post-merge

Para confirmar que destraba el packaging, correr en cualquier momento:

```bash
pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/build_deploy_package.ps1
```

(sin `-SkipTests`) - deberia terminar con `==> Paquete listo` en vez de abortar
por el test roto.
