### PR TITLE
fix(produccion): impedir procesos no habilitados por unidad (#137)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,71 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  backend:
+    name: Backend tests
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: pip
+          cache-dependency-path: backend/requirements.txt
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pytest httpx
+
+      - name: Run backend tests
+        env:
+          APP_ENV: test
+          SECRET_KEY: github-actions-test-secret
+          DATABASE_URL: mysql+pymysql://user:password@127.0.0.1:3306/dbname
+        run: pytest -q
+
+  frontend:
+    name: Frontend tests and build
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run frontend tests
+        run: npm test
+
+      - name: Build frontend
+        run: npm run build

--- a/backend/app/api/routes/produccion.py
+++ b/backend/app/api/routes/produccion.py
@@ -224,6 +224,18 @@ def _tipo_proceso_habilitado(db: Session, tipo_proceso_id: int, unidad_id: int) 
 
 
 def _validate_restricted_payload(data: TableroProduccionCreate, user: Personal, db: Session) -> None:
+    # Issue #137: la relacion UN -> tipo de proceso es una restriccion dura
+    # para todos los usuarios, no solo para encargados Full Tree.
+    if (
+        data.cod_un
+        and data.codigo_tabla
+        and not _tipo_proceso_habilitado(db, int(data.codigo_tabla), int(data.cod_un))
+    ):
+        raise HTTPException(
+            status_code=422,
+            detail="El tipo de proceso no esta habilitado para la unidad de negocio seleccionada",
+        )
+
     restricted = _restricted_unidad_ids(user, db)
     if restricted is None:
         return
@@ -237,9 +249,6 @@ def _validate_restricted_payload(data: TableroProduccionCreate, user: Personal, 
     movil = db.query(Movil).filter(Movil.idMovil == data.cod_equipo, Movil.activo == 1).first()
     if not movil or not _movil_belongs_to_any_unidad(db, movil, restricted):
         raise HTTPException(status_code=403, detail="El movil no esta habilitado para Full Tree")
-
-    if data.codigo_tabla and not _tipo_proceso_habilitado(db, data.codigo_tabla, int(data.cod_un)):
-        raise HTTPException(status_code=403, detail="El tipo de proceso no esta habilitado para Full Tree")
 
 
 # ─── Operadores activos (filtrados por unidad de negocio) ───
@@ -269,7 +278,13 @@ async def list_operadores(
             nombre=r.Nombre,
             dni=r.dni,
             encargado=r.encargado,
-            tipo_de_proceso_id=r.tipo_de_proceso_id,
+            tipo_de_proceso_id=(
+                r.tipo_de_proceso_id
+                if not un_id
+                or not r.tipo_de_proceso_id
+                or _tipo_proceso_habilitado(db, int(r.tipo_de_proceso_id), int(un_id))
+                else None
+            ),
             unidad_ids=unit_ids_by_person.get(int(r.idPersonal), []),
         )
         for r in rows
@@ -348,14 +363,15 @@ async def list_all_tipos_proceso(
 @router.get("/asignaciones/{operador_id}", response_model=List[AsignacionOperativaResponse])
 async def list_asignaciones(
     operador_id: int,
+    un_id: int | None = None,
     db: Session = Depends(get_db),
     user: Personal = Depends(get_current_user),
 ):
-    """Devuelve todas las asignaciones (movil + proceso) del operador."""
+    """Devuelve asignaciones compatibles con la unidad seleccionada."""
     if not _table_exists(db, "asignaciones_operativas") or not _table_exists(db, "moviles"):
         return []
 
-    allowed_ids = _allowed_unidad_ids(user, db)
+    allowed_ids = _allowed_unidad_ids(user, db, un_id)
     if allowed_ids and not _personal_belongs_to_any_unidad(db, operador_id, allowed_ids):
         return []
 
@@ -398,11 +414,12 @@ async def list_asignaciones(
 @router.get("/movil-by-operador/{operador_id}", response_model=MovilResponse | None)
 async def get_movil_by_operador(
     operador_id: int,
+    un_id: int | None = None,
     db: Session = Depends(get_db),
     user: Personal = Depends(get_current_user),
 ):
     today = date.today()
-    allowed_ids = _allowed_unidad_ids(user, db)
+    allowed_ids = _allowed_unidad_ids(user, db, un_id)
     if allowed_ids and not _personal_belongs_to_any_unidad(db, operador_id, allowed_ids):
         return None
 

--- a/backend/tests/test_produccion_unidad_tipo_proceso_integrity.py
+++ b/backend/tests/test_produccion_unidad_tipo_proceso_integrity.py
@@ -1,0 +1,61 @@
+from datetime import date
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+
+from app.api.routes import produccion
+from app.schemas.produccion import TableroProduccionCreate
+
+
+def _payload(*, cod_un: int = 10, codigo_tabla: int = 20) -> TableroProduccionCreate:
+    return TableroProduccionCreate(
+        fecha=date(2026, 8, 10),
+        cod_un=cod_un,
+        codigo_tabla=codigo_tabla,
+    )
+
+
+def test_rechaza_proceso_no_habilitado_para_la_un_para_cualquier_usuario(monkeypatch):
+    data = _payload()
+    user = SimpleNamespace(encargado=0)
+
+    monkeypatch.setattr(produccion, "_tipo_proceso_habilitado", lambda db, proceso, un: False)
+    monkeypatch.setattr(produccion, "_restricted_unidad_ids", lambda user, db: None)
+
+    with pytest.raises(HTTPException) as exc:
+        produccion._validate_restricted_payload(data, user, object())
+
+    assert exc.value.status_code == 422
+    assert "no esta habilitado" in exc.value.detail
+    assert "unidad de negocio" in exc.value.detail
+
+
+def test_acepta_proceso_habilitado_para_usuario_no_restringido(monkeypatch):
+    data = _payload()
+    user = SimpleNamespace(encargado=0)
+
+    monkeypatch.setattr(produccion, "_tipo_proceso_habilitado", lambda db, proceso, un: True)
+    monkeypatch.setattr(produccion, "_restricted_unidad_ids", lambda user, db: None)
+
+    produccion._validate_restricted_payload(data, user, object())
+
+
+def test_validacion_global_ocurre_antes_de_las_restricciones_full_tree(monkeypatch):
+    data = _payload(cod_un=3, codigo_tabla=99)
+    user = SimpleNamespace(encargado=1)
+    restricted_called = False
+
+    def _restricted(user, db):
+        nonlocal restricted_called
+        restricted_called = True
+        return [3]
+
+    monkeypatch.setattr(produccion, "_tipo_proceso_habilitado", lambda db, proceso, un: False)
+    monkeypatch.setattr(produccion, "_restricted_unidad_ids", _restricted)
+
+    with pytest.raises(HTTPException) as exc:
+        produccion._validate_restricted_payload(data, user, object())
+
+    assert exc.value.status_code == 422
+    assert restricted_called is False

--- a/frontend/src/stores/produccion.js
+++ b/frontend/src/stores/produccion.js
@@ -59,6 +59,7 @@ export const useProduccionStore = defineStore('produccion', {
     unidadesNegocio: [],
     tiposProceso: [],
     todosLosTipos: [],
+    selectedUnId: null,
     movilAsignado: null,
     actas: [],
     predios: [],
@@ -183,6 +184,7 @@ export const useProduccionStore = defineStore('produccion', {
     },
 
     async fetchTiposProceso(unId) {
+      this.selectedUnId = unId || null
       return this.fetchCatalog({
         catalog: 'tiposProceso',
         target: 'tiposProceso',
@@ -205,7 +207,8 @@ export const useProduccionStore = defineStore('produccion', {
       this.movilAsignado = null
       if (!operadorId) return
       try {
-        const { data } = await api.get(`/api/produccion/movil-by-operador/${operadorId}`)
+        const params = this.selectedUnId ? { un_id: this.selectedUnId } : undefined
+        const { data } = await api.get(`/api/produccion/movil-by-operador/${operadorId}`, { params })
         this.movilAsignado = data
       } catch (err) {
         console.error('Error loading movil:', err)
@@ -213,13 +216,42 @@ export const useProduccionStore = defineStore('produccion', {
     },
 
     async fetchAsignaciones(operadorId) {
-      return this.fetchCatalog({
+      if (!operadorId) {
+        this.asignaciones = []
+        return []
+      }
+
+      const allowedProcessIds = new Set(
+        ensureArray(this.tiposProceso)
+          .map((tipo) => Number(tipo.id))
+          .filter((id) => Number.isInteger(id) && id > 0),
+      )
+      const scope = `${operadorId}:un:${this.selectedUnId || 'all'}`
+      const items = await this.fetchCatalog({
         catalog: 'asignaciones',
         target: 'asignaciones',
         url: `/api/produccion/asignaciones/${operadorId}`,
-        scope: operadorId,
-        skipWhenMissingScope: true,
+        params: this.selectedUnId ? { un_id: this.selectedUnId } : undefined,
+        scope,
+        skipWhenMissingScope: false,
       })
+
+      // Defensa adicional del frontend: una asignacion nunca puede inyectar
+      // un proceso que no figure en el catalogo habilitado de la UN actual.
+      // Esto tambien protege contra cache vieja/offline.
+      if (['success', 'empty'].includes(this.catalogStatus.tiposProceso?.state)) {
+        const filtered = ensureArray(items).filter((asig) => {
+          const processId = Number(asig.idProceso)
+          return Number.isInteger(processId) && allowedProcessIds.has(processId)
+        })
+        this.asignaciones = filtered
+        if (filtered.length !== items.length) {
+          await this.saveCatalogCache('asignaciones', scope, filtered)
+        }
+        return filtered
+      }
+
+      return items
     },
 
     async fetchActas() {


### PR DESCRIPTION
## Resumen

Corrige el bug de integridad documentado en #137: una asignación operativa podía inyectar un tipo de proceso que no estaba habilitado para la Unidad de Negocio seleccionada.

## Cambios

- El backend valida **siempre** la combinación `cod_un + codigo_tabla` antes de persistir un parte.
- Una combinación UN/proceso no habilitada devuelve `422` y no llega a `tablero_produccion`.
- `/produccion/asignaciones/{operador_id}` acepta `un_id` y filtra asignaciones por UN, móvil y proceso habilitado.
- `/produccion/movil-by-operador/{operador_id}` acepta `un_id` para no devolver un móvil de otra UN como fallback.
- El catálogo de operadores no expone como proceso por defecto uno que no esté habilitado para la UN solicitada.
- El store de producción conserva la UN seleccionada, la envía al consultar asignaciones/fallback y aplica una segunda defensa en frontend: elimina cualquier asignación cuyo `idProceso` no esté en `store.tiposProceso`.
- La caché de asignaciones queda separada por operador + UN para evitar contaminación entre unidades.
- Se agregan tests unitarios de backend para la validación global UN/tipo de proceso.

## Caso reproducido

- UN: `COSECHA CTL`
- Equipo: `GRUA - N°10`
- Operador: `DORNELLES ARIEL`
- Proceso incorrecto: `ACOPIO BIOMASA`

Si `ACOPIO BIOMASA` no está relacionado con `COSECHA CTL` en `unidadnegocio_tipo_proceso`, ya no debe aparecer por una asignación y el backend tampoco permite guardarlo aunque se manipule la petición.

## Validación esperada

- [ ] `COSECHA CTL` no recibe asignaciones con `ACOPIO BIOMASA` si no está habilitado.
- [ ] Las asignaciones válidas siguen apareciendo.
- [ ] Un POST manipulado con UN/proceso inválido devuelve `422`.
- [ ] Un POST con combinación válida continúa funcionando.
- [ ] Cambiar de UN no reutiliza asignaciones cacheadas de la UN anterior.

## Tests

Se agregaron tests en `backend/tests/test_produccion_unidad_tipo_proceso_integrity.py`.

Closes #137