### PR TITLE
fix(ci): pinear httpx<0.28 y skip test_deploy_* en Linux

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -8,3 +8,7 @@ pymysql==1.1.0
 python-jose[cryptography]==3.3.0
 passlib[bcrypt]==1.7.4
 bcrypt>=4.0,<4.2
+# Pin transitivo: starlette 0.35.x pasa `app=...` a httpx.Client.
+# httpx>=0.28 removio ese kwarg y rompe los TestClient del repo.
+# El CI corre `pip install httpx` sin pin, por eso dejamos la restriccion aca.
+httpx<0.28

--- a/backend/tests/test_deploy_main_fasa195.py
+++ b/backend/tests/test_deploy_main_fasa195.py
@@ -1,9 +1,16 @@
 import os
 import subprocess
+import sys
 from dataclasses import dataclass
 from pathlib import Path
 
 import pytest
+
+
+pytestmark = pytest.mark.skipif(
+    sys.platform != "win32",
+    reason="Test designed for Windows Git Bash (bash.exe + drive-letter paths).",
+)
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]

--- a/backend/tests/test_deploy_produccion_fg_main_fasa195.py
+++ b/backend/tests/test_deploy_produccion_fg_main_fasa195.py
@@ -2,11 +2,18 @@ import io
 import os
 import re
 import subprocess
+import sys
 import tarfile
 from dataclasses import dataclass
 from pathlib import Path
 
 import pytest
+
+
+pytestmark = pytest.mark.skipif(
+    sys.platform != "win32",
+    reason="Test designed for Windows Git Bash (bash.exe + drive-letter paths).",
+)
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]


### PR DESCRIPTION
## Resumen

Closes #0

El CI verde del repo se rompió por dos motivos preexistentes no relacionados con ningún PR reciente:

1. pip install httpx (sin pin) en el workflow de CI termina agarrando httpx 0.28+, que removió el kwarg pp de httpx.Client. starlette 0.35.x (la que requiere fastapi 0.109.0) sigue pasando pp=app y revienta con TypeError: Client.__init__() got an unexpected keyword argument 'app'. Pinear httpx<0.28 en equirements.txt mantiene la compatibilidad sin tocar el workflow (que no vive en este repo).

2. 	est_deploy_main_fasa195.py y 	est_deploy_produccion_fg_main_fasa195.py asumen Windows: usan C:\Program Files\Git\bin\bash.exe y ash_path() que accede a esolved.drive[0]. En Linux el drive es vacío y revienta con IndexError: string index out of range. Se skipean con pytest.mark.skipif(sys.platform != 'win32') y mantienen su valor en Windows.

Sin este fix el PR #138 (issue #137) y cualquier PR futuro falla Backend tests en CI por motivos no relacionados con su diff.

## Cambios

- ackend/requirements.txt: pin httpx<0.28 con comentario explicando el motivo
- ackend/tests/test_deploy_main_fasa195.py: pytestmark = pytest.mark.skipif(sys.platform != 'win32', ...)
- ackend/tests/test_deploy_produccion_fg_main_fasa195.py: mismo skip

## Validación local

- cd backend && py -3.12 -m pytest → 202 passed
- En Windows los 	est_deploy_* siguen corriendo (skip no aplica)
- En Linux se skipean correctamente

## CI esperado

- Backend tests: verde
- Frontend tests and build: verde (no tocamos nada del frontend)

## Fuera de alcance

- Mover el workflow de CI al repo para poder usar -r requirements-dev.txt (que ya tiene httpx==0.27.2 pineado)
- Hacer los 	est_deploy_* realmente cross-platform (hoy son Windows-only por diseño, no es scope de un fix de CI)
- Actualizar starlette/fastapi/httpx a versiones modernas