### PR TITLE
fix(caminos): validar solo horas de remolque contra horómetro

### DIFF
--- a/backend/app/schemas/parte_caminos.py
+++ b/backend/app/schemas/parte_caminos.py
@@ -112,19 +112,18 @@ class ParteCaminosCreate(BaseModel):
             raise ValueError("Las horas no operativas requieren un motivo")
 
         horas_jornada = self.hr_fin - self.hr_inicio
-        horas_disponibles = horas_jornada - self.hrs_no_op
-        if horas_disponibles < 0:
+        if self.hrs_no_op > horas_jornada:
             raise ValueError("Las horas no operativas no pueden superar la duracion de la jornada")
 
-        horas_procesos = sum(
-            float(proceso.hr_disposicion or 0) + float(proceso.hr_remolque or 0)
+        horas_remolque = sum(
+            float(proceso.hr_remolque or 0)
             for proceso in self.procesos
         )
-        if horas_procesos > horas_disponibles + 1e-9:
+        if horas_remolque > horas_jornada + 1e-9:
             raise ValueError(
-                "La suma de horas de disposicion y remolque "
-                f"({horas_procesos:g} h) no puede superar las horas operativas "
-                f"disponibles de la jornada ({horas_disponibles:g} h)"
+                "Las horas de remolque "
+                f"({horas_remolque:g} h) no pueden superar la diferencia entre "
+                f"el horometro final y el inicial ({horas_jornada:g} h)"
             )
 
         if self.combustible > 0:

--- a/backend/tests/test_parte_caminos_schema.py
+++ b/backend/tests/test_parte_caminos_schema.py
@@ -121,36 +121,36 @@ def test_requires_reason_when_non_operational_hours_are_positive():
         )
 
 
-def test_rejects_process_hours_over_available_shift_hours():
-    with pytest.raises(ValidationError, match="no puede superar las horas operativas"):
-        ParteCaminosCreate.model_validate(
-            _base_payload(
-                hr_inicio=1,
-                hr_fin=15,
-                procesos=[
-                    {
-                        "tipo_proceso_id": 20,
-                        "predio": "PREDIO 1",
-                        "hr_disposicion": 12,
-                    },
-                    {
-                        "tipo_proceso_id": 21,
-                        "predio": "PREDIO 1",
-                        "hr_remolque": 5,
-                    },
-                ],
-            )
+def test_allows_disposition_hours_over_meter_difference():
+    data = ParteCaminosCreate.model_validate(
+        _base_payload(
+            hr_inicio=1,
+            hr_fin=4,
+            procesos=[
+                {
+                    "tipo_proceso_id": 20,
+                    "predio": "PREDIO 1",
+                    "hr_disposicion": 8,
+                },
+                {
+                    "tipo_proceso_id": 21,
+                    "predio": "PREDIO 1",
+                    "hr_remolque": 3,
+                },
+            ],
         )
+    )
+
+    assert data.procesos[0].hr_disposicion == 8
+    assert data.procesos[1].hr_remolque == 3
 
 
-def test_non_operational_hours_reduce_available_process_hours():
-    with pytest.raises(ValidationError, match="10 h"):
+def test_rejects_towing_hours_over_meter_difference():
+    with pytest.raises(ValidationError, match="horas de remolque"):
         ParteCaminosCreate.model_validate(
             _base_payload(
                 hr_inicio=1,
-                hr_fin=15,
-                hrs_no_op=4,
-                motivo_no_op="Reparacion",
+                hr_fin=4,
                 procesos=[
                     {
                         "tipo_proceso_id": 20,
@@ -160,11 +160,36 @@ def test_non_operational_hours_reduce_available_process_hours():
                     {
                         "tipo_proceso_id": 21,
                         "predio": "PREDIO 1",
-                        "hr_remolque": 3,
+                        "hr_remolque": 4,
                     },
                 ],
             )
         )
+
+
+def test_non_operational_hours_do_not_reduce_meter_difference_for_towing():
+    data = ParteCaminosCreate.model_validate(
+        _base_payload(
+            hr_inicio=1,
+            hr_fin=15,
+            hrs_no_op=4,
+            motivo_no_op="Reparacion",
+            procesos=[
+                {
+                    "tipo_proceso_id": 20,
+                    "predio": "PREDIO 1",
+                    "hr_disposicion": 20,
+                },
+                {
+                    "tipo_proceso_id": 21,
+                    "predio": "PREDIO 1",
+                    "hr_remolque": 14,
+                },
+            ],
+        )
+    )
+
+    assert data.procesos[1].hr_remolque == 14
 
 
 def test_fuel_requires_meter_load_place_and_remito():

--- a/frontend/src/views/CaminosFormView.test.js
+++ b/frontend/src/views/CaminosFormView.test.js
@@ -116,28 +116,52 @@ describe('CaminosFormView', () => {
     expect(wrapper.vm.form.motivo_no_op).toBe('')
   })
 
-  it('blocks production when disposition plus towing exceeds available shift hours', async () => {
+  it('allows disposition hours over meter difference when towing remains valid', async () => {
     const wrapper = mountView()
 
     wrapper.vm.form.hr_inicio = 1
     wrapper.vm.form.hr_fin = 15
-    wrapper.vm.form.hrs_no_op = 0
+    wrapper.vm.form.hrs_no_op = 4
+    wrapper.vm.form.motivo_no_op = 'Reparacion'
     wrapper.vm.procesos[0].tipo_proceso_id = 20
     wrapper.vm.procesos[0].predio_id = 1
-    wrapper.vm.procesos[0].hr_disposicion = 12
+    wrapper.vm.procesos[0].hr_disposicion = 20
     wrapper.vm.agregarProceso()
     wrapper.vm.procesos[1].tipo_proceso_id = 21
     wrapper.vm.procesos[1].predio_id = 1
-    wrapper.vm.procesos[1].hr_remolque = 5
+    wrapper.vm.procesos[1].hr_remolque = 14
     wrapper.vm.pasoActual = 5
     await nextTick()
 
-    expect(wrapper.vm.horasOperativasDisponibles).toBe(14)
-    expect(wrapper.vm.totalHorasProcesos).toBe(17)
-    expect(wrapper.vm.horasProcesosValidas).toBe(false)
+    expect(wrapper.vm.horasJornada).toBe(14)
+    expect(wrapper.vm.totalHorasRemolque).toBe(14)
+    expect(wrapper.vm.horasRemolqueValidas).toBe(true)
+    expect(wrapper.vm.puedeAvanzar).toBe(true)
+    expect(wrapper.text()).toContain('Horas de remolque: 14 h de 14 h')
+    expect(wrapper.text()).not.toContain('disposición/remolque')
+  })
+
+  it('blocks production only when towing exceeds meter difference', async () => {
+    const wrapper = mountView()
+
+    wrapper.vm.form.hr_inicio = 1
+    wrapper.vm.form.hr_fin = 4
+    wrapper.vm.procesos[0].tipo_proceso_id = 20
+    wrapper.vm.procesos[0].predio_id = 1
+    wrapper.vm.procesos[0].hr_disposicion = 20
+    wrapper.vm.agregarProceso()
+    wrapper.vm.procesos[1].tipo_proceso_id = 21
+    wrapper.vm.procesos[1].predio_id = 1
+    wrapper.vm.procesos[1].hr_remolque = 4
+    wrapper.vm.pasoActual = 5
+    await nextTick()
+
+    expect(wrapper.vm.horasJornada).toBe(3)
+    expect(wrapper.vm.totalHorasRemolque).toBe(4)
+    expect(wrapper.vm.horasRemolqueValidas).toBe(false)
     expect(wrapper.vm.puedeAvanzar).toBe(false)
-    expect(wrapper.text()).toContain('17 h de 14 h disponibles')
-    expect(wrapper.text()).toContain('Reducí las horas de disposición/remolque')
+    expect(wrapper.text()).toContain('Horas de remolque: 4 h de 3 h')
+    expect(wrapper.text()).toContain('Reducí las horas de remolque')
   })
 
   it('sends a trimmed two-process payload without concatenating operations', async () => {

--- a/frontend/src/views/CaminosFormView.vue
+++ b/frontend/src/views/CaminosFormView.vue
@@ -180,16 +180,16 @@
               </div>
             </div>
             <div
-              v-if="totalHorasProcesos > 0"
+              v-if="totalHorasRemolque > 0"
               :class="[
                 'rounded-xl border px-3 py-2.5 text-sm font-semibold',
-                horasProcesosValidas
+                horasRemolqueValidas
                   ? 'border-success/30 bg-success-light/30 text-success-dark'
                   : 'border-error/30 bg-error-light/40 text-error-dark',
               ]"
             >
-              Horas asignadas a procesos: {{ formatHoras(totalHorasProcesos) }} h de {{ formatHoras(horasOperativasDisponibles) }} h disponibles.
-              <span v-if="!horasProcesosValidas"> Reducí las horas de disposición/remolque para continuar.</span>
+              Horas de remolque: {{ formatHoras(totalHorasRemolque) }} h de {{ formatHoras(horasJornada) }} h de diferencia de horómetro.
+              <span v-if="!horasRemolqueValidas"> Reducí las horas de remolque para continuar.</span>
             </div>
           </div>
         </SectionCard>
@@ -360,8 +360,6 @@ async function onPredioProcesoChange(proceso, item) {
   proceso.predio_id = Number(item?.idPredio || 0)
   proceso.rodal_id = 0
 
-  // Cuando hay Acta, la fuente de verdad son los rodales vinculados al Acta;
-  // el Predio sólo restringe esa lista, igual que en el formulario habitual.
   if (proceso.acta) return
 
   rodalesPorProceso[proceso.key] = []
@@ -372,16 +370,13 @@ async function onPredioProcesoChange(proceso, item) {
 
 const procesosTiposValidos = computed(() => procesos.length > 0 && procesos.every(p => p.tipo_proceso_id > 0))
 const horasValidas = computed(() => Number(form.hr_inicio) > 0 && Number(form.hr_fin) > Number(form.hr_inicio))
-const horasOperativasDisponibles = computed(() => Math.max(
-  0,
-  Number(form.hr_fin || 0) - Number(form.hr_inicio || 0) - Number(form.hrs_no_op || 0),
-))
-const totalHorasProcesos = computed(() => procesos.reduce(
-  (total, proceso) => total + Number(proceso.hr_disposicion || 0) + Number(proceso.hr_remolque || 0),
+const horasJornada = computed(() => Math.max(0, Number(form.hr_fin || 0) - Number(form.hr_inicio || 0)))
+const totalHorasRemolque = computed(() => procesos.reduce(
+  (total, proceso) => total + Number(proceso.hr_remolque || 0),
   0,
 ))
-const horasProcesosValidas = computed(() => totalHorasProcesos.value <= horasOperativasDisponibles.value + 0.000001)
-const produccionValida = computed(() => horasProcesosValidas.value && procesos.every(p => {
+const horasRemolqueValidas = computed(() => totalHorasRemolque.value <= horasJornada.value + 0.000001)
+const produccionValida = computed(() => horasRemolqueValidas.value && procesos.every(p => {
   if (requierePredio(p) && !p.predio_id) return false
   if (requiereActa(p) && !String(p.acta || '').trim()) return false
   if (requiereRodal(p) && !Number(p.rodal_id || 0)) return false
@@ -399,7 +394,7 @@ function validar() {
   if (!procesosTiposValidos.value) return 'Completá los procesos del parte.'
   if (!horasValidas.value) return 'La hora fin debe ser mayor que la hora inicio.'
   if (Number(form.hrs_no_op) > 0 && !String(form.motivo_no_op || '').trim()) return 'Indicá el motivo de las horas no operativas.'
-  if (!horasProcesosValidas.value) return `Las horas de disposición y remolque suman ${formatHoras(totalHorasProcesos.value)} h, pero sólo hay ${formatHoras(horasOperativasDisponibles.value)} h operativas disponibles.`
+  if (!horasRemolqueValidas.value) return `Las horas de remolque suman ${formatHoras(totalHorasRemolque.value)} h, pero la diferencia entre horómetro final e inicial es ${formatHoras(horasJornada.value)} h.`
   if (!produccionValida.value) return 'Completá ubicación y métricas de todos los procesos.'
   if (!consumosValidos.value) return 'Completá los datos de combustible.'
   return ''


### PR DESCRIPTION
## Resumen

Completa el issue #144 para que el control contra horómetro de Caminos aplique exclusivamente a **REMOLQUE**.

### Implementado
- Backend: solo `hr_remolque` se compara contra `hr_fin - hr_inicio`.
- Las horas a disposición no participan del control contra horómetro.
- Los kilómetros de perfilado no participan de ninguna validación horaria.
- Las horas no operativas se validan por separado contra la duración de la jornada y no reducen el límite de remolque.
- Frontend alineado con la misma regla: muestra y valida únicamente horas de remolque contra la diferencia de horómetro.
- Mensajes de validación actualizados para mencionar exclusivamente remolque.
- Tests backend para disposición superior a la diferencia de horómetro, exceso de remolque y horas no operativas.
- Tests frontend para permitir disposición alta, bloquear solo exceso de remolque y mantener el payload multiproceso.

Closes #144