### PR TITLE
Fix #146: calcular producción automática en HORAS MAQUINAS

### DIFF
--- a/backend/app/schemas/produccion.py
+++ b/backend/app/schemas/produccion.py
@@ -239,6 +239,26 @@ class TableroProduccionCreate(BaseModel):
         return _coerce_empty_numeric(data)
 
     @model_validator(mode="after")
+    def apply_horas_maquinas_production(self):
+        """Issue #146: HORAS MAQUINAS usa el horómetro como fuente de verdad.
+
+        El operador no carga producción manual: se calcula como hr_fin - hr_inicio
+        y se persiste en horas. El cálculo vive en backend para que también aplique
+        a reintentos offline u otros clientes de la API.
+        """
+        if self.operacion.strip().upper() != "HORAS MAQUINAS":
+            return self
+
+        if self.hr_inicio <= 0 or self.hr_fin <= 0:
+            raise ValueError("HORAS MAQUINAS requiere hora de inicio y hora de fin mayores a cero")
+        if self.hr_fin <= self.hr_inicio:
+            raise ValueError("En HORAS MAQUINAS la hora final debe ser mayor a la hora inicial")
+
+        self.produccion = round(self.hr_fin - self.hr_inicio, 2)
+        self.unidad_produccion = "HS"
+        return self
+
+    @model_validator(mode="after")
     def validate_combustible_movement(self):
         if self.combustible <= 0:
             return self

--- a/backend/tests/test_horas_maquinas_produccion.py
+++ b/backend/tests/test_horas_maquinas_produccion.py
@@ -1,0 +1,53 @@
+from datetime import date
+
+import pytest
+from pydantic import ValidationError
+
+from app.schemas.produccion import TableroProduccionCreate
+
+
+def build_payload(**overrides):
+    data = {
+        "fecha": date(2026, 8, 18),
+        "operacion": "HORAS MAQUINAS",
+        "hr_inicio": 2192.70,
+        "hr_fin": 2197.40,
+        "produccion": 999,
+        "unidad_produccion": "OTRA",
+    }
+    data.update(overrides)
+    return TableroProduccionCreate(**data)
+
+
+def test_horas_maquinas_calcula_produccion_desde_horometro():
+    payload = build_payload()
+
+    assert payload.produccion == 4.70
+    assert payload.unidad_produccion == "HS"
+
+
+def test_horas_maquinas_ignora_produccion_enviada_por_cliente():
+    payload = build_payload(produccion=123.45)
+
+    assert payload.produccion == 4.70
+
+
+def test_horas_maquinas_requiere_fin_mayor_a_inicio():
+    with pytest.raises(ValidationError, match="hora final debe ser mayor"):
+        build_payload(hr_inicio=2200, hr_fin=2199)
+
+
+def test_horas_maquinas_no_permite_horometros_en_cero():
+    with pytest.raises(ValidationError, match="hora de inicio y hora de fin mayores a cero"):
+        build_payload(hr_inicio=0, hr_fin=2199)
+
+
+def test_otro_proceso_no_reescribe_produccion():
+    payload = build_payload(
+        operacion="CARGA",
+        produccion=15.25,
+        unidad_produccion="TN",
+    )
+
+    assert payload.produccion == 15.25
+    assert payload.unidad_produccion == "TN"

--- a/scripts/backfill_horas_maquinas_produccion.sql
+++ b/scripts/backfill_horas_maquinas_produccion.sql
@@ -1,0 +1,38 @@
+-- Issue #146
+-- Completa produccion historica SOLO para registros HORAS MAQUINAS
+-- que quedaron en 0/NULL y poseen horometros validos.
+--
+-- Recomendado: ejecutar primero el SELECT de control y revisar la cantidad.
+
+SELECT
+    id,
+    fecha,
+    UN,
+    equipo,
+    operador,
+    hr_inicio,
+    hr_fin,
+    produccion AS produccion_actual,
+    ROUND(hr_fin - hr_inicio, 2) AS produccion_calculada
+FROM tablero_produccion
+WHERE UPPER(TRIM(operacion)) = 'HORAS MAQUINAS'
+  AND (produccion IS NULL OR produccion = 0)
+  AND hr_inicio > 0
+  AND hr_fin > hr_inicio
+ORDER BY fecha, id;
+
+START TRANSACTION;
+
+UPDATE tablero_produccion
+SET produccion = ROUND(hr_fin - hr_inicio, 2),
+    unidad_produccion = 'HS'
+WHERE UPPER(TRIM(operacion)) = 'HORAS MAQUINAS'
+  AND (produccion IS NULL OR produccion = 0)
+  AND hr_inicio > 0
+  AND hr_fin > hr_inicio;
+
+-- Revisar ROW_COUNT() antes de confirmar.
+SELECT ROW_COUNT() AS registros_actualizados;
+
+-- Cambiar por ROLLBACK si la cantidad no coincide con lo esperado.
+COMMIT;


### PR DESCRIPTION
## Resumen

Implementa el issue #146 para que los registros de **HORAS MAQUINAS** tomen como producción la diferencia de horómetro.

### Cambios
- Backend calcula `produccion = round(hr_fin - hr_inicio, 2)`.
- Fuerza `unidad_produccion = "HS"`.
- Ignora cualquier producción manual enviada por el cliente para HORAS MAQUINAS.
- Valida horómetros mayores a cero y `hr_fin > hr_inicio`.
- Agrega tests específicos para cálculo, validaciones y no afectar otros procesos.
- Agrega `scripts/backfill_horas_maquinas_produccion.sql` para completar registros históricos en 0/NULL de forma acotada.

### Frontend
La pantalla actual ya muestra antes de guardar `Horas trabajadas: hr_fin - hr_inicio`, por lo que se reutiliza esa previsualización sin agregar un campo manual de producción.

Closes #146