### PR TITLE
fix(caminos): completar validación 422 del issue #141

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -25,6 +25,33 @@ SAFE_VALIDATION_ERROR_DETAIL = "Los datos enviados no son validos. Revisa los ca
 # clean sentence instead of a cryptic Pydantic tag.
 _VALUE_ERROR_PREFIX = "Value error, "
 
+# Keep validation field names operator-facing and explicit. We intentionally
+# do not echo Pydantic's full `loc`, input value or payload because those are
+# implementation details and can contain sensitive data.
+_VALIDATION_FIELD_LABELS = {
+    "form_uuid": "identificador del formulario",
+    "equipo": "equipo",
+    "operador": "operador",
+    "UN": "unidad de negocio",
+    "motivo_no_op": "motivo no operativo",
+    "observaciones": "observaciones",
+    "predio": "predio",
+    "acta": "acta",
+    "rodal": "rodal",
+    "remito": "remito 1",
+    "remito2": "remito 2",
+    "remito3": "remito 3",
+}
+
+
+def _validation_field_label(err: dict) -> str | None:
+    """Return a safe user-facing label for a validation error location."""
+    location = err.get("loc") or ()
+    for part in reversed(location):
+        if isinstance(part, str) and part not in {"body", "query", "path"}:
+            return _VALIDATION_FIELD_LABELS.get(part)
+    return None
+
 
 def _humanize_validation_error(exc: RequestValidationError) -> str:
     """Build a single, user-friendly sentence for a Pydantic validation error.
@@ -56,7 +83,13 @@ def _humanize_validation_error(exc: RequestValidationError) -> str:
         "json_invalid": "el cuerpo de la solicitud no tiene un formato valido",
     }
     for err in errors:
-        translated = type_messages.get(err.get("type", ""))
+        error_type = err.get("type", "")
+        if error_type == "string_too_long":
+            field_label = _validation_field_label(err)
+            if field_label:
+                return f"El campo {field_label} excede el tamano maximo permitido"
+
+        translated = type_messages.get(error_type)
         if translated:
             return translated
 
@@ -191,4 +224,3 @@ async def health():
         payload["database"] = "ok" if database_ok else "error"
         payload["database_name"] = database_name_check
     return JSONResponse(status_code=200 if healthy else 503, content=payload)
- 

--- a/backend/tests/test_issue_141_validation_field.py
+++ b/backend/tests/test_issue_141_validation_field.py
@@ -1,0 +1,53 @@
+from fastapi.exceptions import RequestValidationError
+
+from app.main import _humanize_validation_error
+
+
+class _ValidationError(RequestValidationError):
+    def __init__(self, payload):
+        super().__init__(payload)
+        self._payload = payload
+
+    def errors(self):
+        return self._payload
+
+
+def _string_too_long_error(loc, max_length=100):
+    return _ValidationError([
+        {
+            "type": "string_too_long",
+            "loc": loc,
+            "msg": f"String should have at most {max_length} characters",
+            "input": "x" * (max_length + 1),
+            "ctx": {"max_length": max_length},
+        }
+    ])
+
+
+def test_string_too_long_identifies_top_level_caminos_field():
+    message = _humanize_validation_error(
+        _string_too_long_error(("body", "equipo"), max_length=100)
+    )
+
+    assert message == "El campo equipo excede el tamano maximo permitido"
+    assert "body" not in message
+    assert "x" * 20 not in message
+
+
+def test_string_too_long_identifies_nested_process_field_without_internal_path():
+    message = _humanize_validation_error(
+        _string_too_long_error(("body", "procesos", 1, "predio"), max_length=50)
+    )
+
+    assert message == "El campo predio excede el tamano maximo permitido"
+    assert "procesos" not in message
+    assert "[1]" not in message
+
+
+def test_string_too_long_unknown_field_keeps_safe_generic_message():
+    message = _humanize_validation_error(
+        _string_too_long_error(("body", "campo_interno"), max_length=10)
+    )
+
+    assert message == "uno de los textos excede el tamano maximo permitido"
+    assert "campo_interno" not in message


### PR DESCRIPTION
## Resumen

Completa el criterio que quedaba pendiente del issue #141.

Al revisar `main` después de los PR de Caminos ya estaban implementados y cubiertos por tests:

- trim de textos en frontend antes del POST;
- trim equivalente en `ParteCaminosCreate` / `ProcesoCaminosCreate` antes de validar `max_length`;
- payload multi-proceso como `procesos: [...]`, sin concatenar operaciones;
- persistencia de una fila por proceso con el mismo `form_uuid`;
- `DISPOSICION` y `REMOLQUE` conservados como operaciones separadas y métricas propias;
- un único movimiento de combustible por parte.

### Cambio de este PR

El handler global de 422 ahora identifica de forma segura el campo cuando Pydantic devuelve `string_too_long`.

Ejemplos:

- `El campo equipo excede el tamano maximo permitido`
- `El campo predio excede el tamano maximo permitido`

Se usa una whitelist de etiquetas visibles al operador. No se devuelve el `loc` completo de Pydantic, el valor ingresado ni el payload de la solicitud.

### Tests agregados

`backend/tests/test_issue_141_validation_field.py` cubre:

- campo de cabecera (`equipo`);
- campo anidado de proceso (`predio`);
- fallback genérico para campos internos/no conocidos, sin filtrarlos al usuario.

El test de integración existente `test_parte_caminos_integration.py` ya cubre el caso real DISPOSICION + REMOLQUE = 2 filas + 1 movimiento de combustible.

Closes #141