### PR TITLE
feat(catalogos): gestionar motivos no operativos por UN

### DIFF
--- a/backend/app/api/routes/motivos_no_operativos.py
+++ b/backend/app/api/routes/motivos_no_operativos.py
@@ -1,0 +1,180 @@
+import re
+import unicodedata
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy import or_
+from sqlalchemy.orm import Session
+
+from app.api.deps import get_current_admin, get_current_user, get_db
+from app.models.motivo_no_operativo import MotivoNoOperativo, MotivoNoOperativoUnidadNegocio
+from app.models.personal import Personal
+from app.models.unidad_negocio import UnidadNegocio
+from app.schemas.motivo_no_operativo import (
+    MotivoNoOperativoCatalogoItem,
+    MotivoNoOperativoCreate,
+    MotivoNoOperativoResponse,
+    MotivoNoOperativoUpdate,
+)
+
+router = APIRouter(tags=["motivos-no-operativos"])
+
+
+def _slug(value: str) -> str:
+    normalized = unicodedata.normalize("NFKD", value).encode("ascii", "ignore").decode("ascii")
+    normalized = re.sub(r"[^a-zA-Z0-9]+", "_", normalized).strip("_").lower()
+    return normalized[:40] or "motivo"
+
+
+def _unidad_ids(db: Session, motivo_id: int) -> list[int]:
+    return [
+        int(value)
+        for (value,) in (
+            db.query(MotivoNoOperativoUnidadNegocio.unidad_negocio)
+            .filter(
+                MotivoNoOperativoUnidadNegocio.idMotivo == motivo_id,
+                MotivoNoOperativoUnidadNegocio.activo.is_(True),
+            )
+            .order_by(MotivoNoOperativoUnidadNegocio.unidad_negocio)
+            .all()
+        )
+    ]
+
+
+def _response(db: Session, row: MotivoNoOperativo) -> MotivoNoOperativoResponse:
+    return MotivoNoOperativoResponse(
+        id=row.id,
+        codigo=row.codigo,
+        nombre=row.nombre,
+        activo=bool(row.activo),
+        unidad_ids=_unidad_ids(db, row.id),
+    )
+
+
+def _sync_unidades(db: Session, motivo_id: int, unidad_ids: list[int]) -> None:
+    valid_ids = {
+        int(value)
+        for (value,) in db.query(UnidadNegocio.idUnidadNegocio).filter(
+            UnidadNegocio.idUnidadNegocio.in_(unidad_ids or [-1])
+        ).all()
+    }
+    existing = {
+        int(row.unidad_negocio): row
+        for row in db.query(MotivoNoOperativoUnidadNegocio).filter(
+            MotivoNoOperativoUnidadNegocio.idMotivo == motivo_id
+        ).all()
+    }
+    for unidad_id, row in existing.items():
+        row.activo = unidad_id in valid_ids
+    for unidad_id in valid_ids:
+        if unidad_id not in existing:
+            db.add(MotivoNoOperativoUnidadNegocio(idMotivo=motivo_id, unidad_negocio=unidad_id, activo=True))
+
+
+@router.get("/catalogos/motivos-no-operativos", response_model=list[MotivoNoOperativoCatalogoItem])
+def list_catalogo_motivos(
+    un_id: int | None = Query(default=None, ge=1),
+    db: Session = Depends(get_db),
+    _: Personal = Depends(get_current_user),
+):
+    query = db.query(MotivoNoOperativo).filter(MotivoNoOperativo.activo.is_(True))
+    if un_id is not None:
+        query = query.join(
+            MotivoNoOperativoUnidadNegocio,
+            MotivoNoOperativoUnidadNegocio.idMotivo == MotivoNoOperativo.id,
+        ).filter(
+            MotivoNoOperativoUnidadNegocio.unidad_negocio == un_id,
+            MotivoNoOperativoUnidadNegocio.activo.is_(True),
+        )
+    return query.order_by(MotivoNoOperativo.nombre).all()
+
+
+@router.get("/admin/motivos-no-operativos", response_model=list[MotivoNoOperativoResponse])
+def admin_list_motivos(
+    skip: int = Query(default=0, ge=0),
+    limit: int = Query(default=50, ge=1, le=1000),
+    buscar: str = "",
+    unidad_id: int | None = Query(default=None, ge=1),
+    activo: int | None = Query(default=None, ge=0, le=1),
+    db: Session = Depends(get_db),
+    _: Personal = Depends(get_current_admin),
+):
+    query = db.query(MotivoNoOperativo)
+    if buscar.strip():
+        term = f"%{buscar.strip()}%"
+        query = query.filter(or_(MotivoNoOperativo.nombre.ilike(term), MotivoNoOperativo.codigo.ilike(term)))
+    if activo in (0, 1):
+        query = query.filter(MotivoNoOperativo.activo.is_(bool(activo)))
+    if unidad_id:
+        query = query.join(
+            MotivoNoOperativoUnidadNegocio,
+            MotivoNoOperativoUnidadNegocio.idMotivo == MotivoNoOperativo.id,
+        ).filter(
+            MotivoNoOperativoUnidadNegocio.unidad_negocio == unidad_id,
+            MotivoNoOperativoUnidadNegocio.activo.is_(True),
+        )
+    rows = query.order_by(MotivoNoOperativo.nombre).offset(skip).limit(limit).all()
+    return [_response(db, row) for row in rows]
+
+
+@router.post("/admin/motivos-no-operativos", response_model=MotivoNoOperativoResponse, status_code=status.HTTP_201_CREATED)
+def admin_create_motivo(
+    payload: MotivoNoOperativoCreate,
+    db: Session = Depends(get_db),
+    _: Personal = Depends(get_current_admin),
+):
+    codigo = (payload.codigo or _slug(payload.nombre)).strip().lower()
+    if db.query(MotivoNoOperativo).filter(MotivoNoOperativo.codigo == codigo).first():
+        raise HTTPException(status_code=409, detail="Ya existe un motivo con ese codigo")
+    row = MotivoNoOperativo(codigo=codigo, nombre=payload.nombre.strip().upper(), activo=payload.activo)
+    db.add(row)
+    db.flush()
+    _sync_unidades(db, row.id, payload.unidad_ids)
+    db.commit()
+    db.refresh(row)
+    return _response(db, row)
+
+
+@router.put("/admin/motivos-no-operativos/{motivo_id}", response_model=MotivoNoOperativoResponse)
+def admin_update_motivo(
+    motivo_id: int,
+    payload: MotivoNoOperativoUpdate,
+    db: Session = Depends(get_db),
+    _: Personal = Depends(get_current_admin),
+):
+    row = db.query(MotivoNoOperativo).filter(MotivoNoOperativo.id == motivo_id).first()
+    if not row:
+        raise HTTPException(status_code=404, detail="Motivo no encontrado")
+    values = payload.model_dump(exclude_unset=True)
+    unidad_ids = values.pop("unidad_ids", None)
+    if "nombre" in values and values["nombre"] is not None:
+        row.nombre = values["nombre"].strip().upper()
+    if "codigo" in values and values["codigo"] is not None:
+        codigo = values["codigo"].strip().lower()
+        duplicate = db.query(MotivoNoOperativo).filter(
+            MotivoNoOperativo.codigo == codigo,
+            MotivoNoOperativo.id != motivo_id,
+        ).first()
+        if duplicate:
+            raise HTTPException(status_code=409, detail="Ya existe un motivo con ese codigo")
+        row.codigo = codigo
+    if "activo" in values and values["activo"] is not None:
+        row.activo = bool(values["activo"])
+    if unidad_ids is not None:
+        _sync_unidades(db, motivo_id, unidad_ids)
+    db.commit()
+    db.refresh(row)
+    return _response(db, row)
+
+
+@router.delete("/admin/motivos-no-operativos/{motivo_id}")
+def admin_disable_motivo(
+    motivo_id: int,
+    db: Session = Depends(get_db),
+    _: Personal = Depends(get_current_admin),
+):
+    row = db.query(MotivoNoOperativo).filter(MotivoNoOperativo.id == motivo_id).first()
+    if not row:
+        raise HTTPException(status_code=404, detail="Motivo no encontrado")
+    row.activo = False
+    db.commit()
+    return {"ok": True, "id": motivo_id}

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -9,7 +9,7 @@ from sqlalchemy import text
 from sqlalchemy.exc import SQLAlchemyError
 from app.core.config import settings
 from app.core.database import engine
-from app.api.routes import items, auth, produccion, parte_caminos, dashboard, admin, combustible
+from app.api.routes import items, auth, produccion, parte_caminos, dashboard, admin, combustible, motivos_no_operativos
 
 import pymysql
 
@@ -20,14 +20,7 @@ SAFE_DATABASE_ERROR_DETAIL = "No se pudieron cargar los datos necesarios. Actual
 SAFE_SERVER_ERROR_DETAIL = "No se pudo completar la operacion. Intenta nuevamente en unos minutos."
 SAFE_VALIDATION_ERROR_DETAIL = "Los datos enviados no son validos. Revisa los campos del formulario e intenta nuevamente."
 
-# Pydantic 2.x wraps custom `ValueError(...)` raised inside validators as
-# "Value error, <message>". Strip the prefix so the user-facing toast gets a
-# clean sentence instead of a cryptic Pydantic tag.
 _VALUE_ERROR_PREFIX = "Value error, "
-
-# Keep validation field names operator-facing and explicit. We intentionally
-# do not echo Pydantic's full `loc`, input value or payload because those are
-# implementation details and can contain sensitive data.
 _VALIDATION_FIELD_LABELS = {
     "form_uuid": "identificador del formulario",
     "equipo": "equipo",
@@ -45,7 +38,6 @@ _VALIDATION_FIELD_LABELS = {
 
 
 def _validation_field_label(err: dict) -> str | None:
-    """Return a safe user-facing label for a validation error location."""
     location = err.get("loc") or ()
     for part in reversed(location):
         if isinstance(part, str) and part not in {"body", "query", "path"}:
@@ -54,15 +46,6 @@ def _validation_field_label(err: dict) -> str | None:
 
 
 def _humanize_validation_error(exc: RequestValidationError) -> str:
-    """Build a single, user-friendly sentence for a Pydantic validation error.
-
-    Priority:
-      1. Any custom `ValueError` raised from a model validator (e.g. combustible
-         business rules) — these messages are already written in Spanish.
-      2. The first typed validation error rendered into a short Spanish message
-         via a small map of common Pydantic error types.
-      3. The generic fallback so we never leak a raw Pydantic payload to the UI.
-    """
     errors = exc.errors() or []
     for err in errors:
         if err.get("type") == "value_error":
@@ -88,14 +71,12 @@ def _humanize_validation_error(exc: RequestValidationError) -> str:
             field_label = _validation_field_label(err)
             if field_label:
                 return f"El campo {field_label} excede el tamano maximo permitido"
-
         translated = type_messages.get(error_type)
         if translated:
             return translated
-
     return SAFE_VALIDATION_ERROR_DETAIL
 
-# CORS
+
 app.add_middleware(
     CORSMiddleware,
     allow_origins=settings.ALLOWED_ORIGINS,
@@ -105,7 +86,7 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
-# Global exception handler — ensures CORS headers are always sent even on 500
+
 def _is_allowed_origin(origin: str) -> bool:
     return origin in settings.ALLOWED_ORIGINS or bool(re.match(settings.ALLOWED_ORIGIN_REGEX, origin))
 
@@ -122,44 +103,21 @@ def _cors_headers_for_request(request: Request) -> dict[str, str]:
 @app.exception_handler(SQLAlchemyError)
 async def database_exception_handler(request: Request, exc: SQLAlchemyError):
     logger.exception("Unhandled database error while processing %s %s", request.method, request.url.path)
-    return JSONResponse(
-        status_code=503,
-        content={"detail": SAFE_DATABASE_ERROR_DETAIL},
-        headers=_cors_headers_for_request(request),
-    )
+    return JSONResponse(status_code=503, content={"detail": SAFE_DATABASE_ERROR_DETAIL}, headers=_cors_headers_for_request(request))
 
 
 @app.exception_handler(RequestValidationError)
 async def request_validation_exception_handler(request: Request, exc: RequestValidationError):
-    """Convert Pydantic validation failures into a single, user-friendly string.
-
-    The default FastAPI handler returns the raw error list, which previously
-    leaked Pydantic internals (URLs to docs, internal field names, full input
-    payload) to the operator-facing toast.
-    """
-    logger.warning(
-        "Validation error while processing %s %s: %s",
-        request.method,
-        request.url.path,
-        exc.errors(),
-    )
-    return JSONResponse(
-        status_code=422,
-        content={"detail": _humanize_validation_error(exc)},
-        headers=_cors_headers_for_request(request),
-    )
+    logger.warning("Validation error while processing %s %s: %s", request.method, request.url.path, exc.errors())
+    return JSONResponse(status_code=422, content={"detail": _humanize_validation_error(exc)}, headers=_cors_headers_for_request(request))
 
 
 @app.exception_handler(Exception)
 async def global_exception_handler(request: Request, exc: Exception):
     logger.exception("Unhandled application error while processing %s %s", request.method, request.url.path)
-    return JSONResponse(
-        status_code=500,
-        content={"detail": SAFE_SERVER_ERROR_DETAIL},
-        headers=_cors_headers_for_request(request),
-    )
+    return JSONResponse(status_code=500, content={"detail": SAFE_SERVER_ERROR_DETAIL}, headers=_cors_headers_for_request(request))
 
-# Include routers
+
 app.include_router(auth.router, prefix="/api")
 app.include_router(items.router, prefix="/api")
 app.include_router(produccion.router, prefix="/api")
@@ -167,6 +125,8 @@ app.include_router(parte_caminos.router, prefix="/api")
 app.include_router(combustible.router, prefix="/api")
 app.include_router(dashboard.router, prefix="/api")
 app.include_router(admin.router, prefix="/api")
+app.include_router(motivos_no_operativos.router, prefix="/api")
+
 
 @app.get("/")
 async def root():
@@ -197,21 +157,11 @@ async def health():
     if database_ok and expected_db_name:
         try:
             actual_db_name = get_current_database_name()
-            database_name_check = {
-                "expected": expected_db_name,
-                "actual": actual_db_name,
-                "matches": actual_db_name == expected_db_name,
-            }
+            database_name_check = {"expected": expected_db_name, "actual": actual_db_name, "matches": actual_db_name == expected_db_name}
         except Exception:
-            database_name_check = {
-                "expected": expected_db_name,
-                "actual": None,
-                "matches": False,
-            }
+            database_name_check = {"expected": expected_db_name, "actual": None, "matches": False}
 
-    healthy = bool(database_ok) and (
-        database_name_check is None or bool(database_name_check["matches"])
-    )
+    healthy = bool(database_ok) and (database_name_check is None or bool(database_name_check["matches"]))
     payload = {
         "status": "ok" if healthy else "error",
         "service": settings.APP_NAME,

--- a/backend/app/models/motivo_no_operativo.py
+++ b/backend/app/models/motivo_no_operativo.py
@@ -1,0 +1,27 @@
+from datetime import datetime
+
+from sqlalchemy import Boolean, Column, DateTime, Integer, String, UniqueConstraint
+
+from app.core.database import Base
+
+
+class MotivoNoOperativo(Base):
+    __tablename__ = "motivos_no_operativos"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    codigo = Column(String(40), nullable=False, unique=True)
+    nombre = Column(String(80), nullable=False)
+    activo = Column(Boolean, nullable=False, default=True)
+    created_at = Column(DateTime, nullable=False, default=datetime.utcnow)
+
+
+class MotivoNoOperativoUnidadNegocio(Base):
+    __tablename__ = "motivos_no_operativos_unidad_negocio"
+    __table_args__ = (
+        UniqueConstraint("idMotivo", "unidad_negocio", name="uq_motivo_no_operativo_un"),
+    )
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    idMotivo = Column(Integer, nullable=False)
+    unidad_negocio = Column(Integer, nullable=False)
+    activo = Column(Boolean, nullable=False, default=True)

--- a/backend/app/schemas/motivo_no_operativo.py
+++ b/backend/app/schemas/motivo_no_operativo.py
@@ -1,0 +1,66 @@
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+
+class MotivoNoOperativoBase(BaseModel):
+    nombre: str = Field(min_length=1, max_length=80)
+    codigo: str | None = Field(default=None, max_length=40)
+    activo: bool = True
+    unidad_ids: list[int] = Field(default_factory=list)
+
+    @field_validator("nombre", "codigo", mode="before")
+    @classmethod
+    def strip_text(cls, value):
+        if value is None:
+            return value
+        return str(value).strip()
+
+    @field_validator("unidad_ids", mode="before")
+    @classmethod
+    def normalize_unidades(cls, value):
+        if value is None:
+            return []
+        result: list[int] = []
+        for item in value:
+            try:
+                parsed = int(item)
+            except (TypeError, ValueError):
+                continue
+            if parsed > 0 and parsed not in result:
+                result.append(parsed)
+        return result
+
+
+class MotivoNoOperativoCreate(MotivoNoOperativoBase):
+    pass
+
+
+class MotivoNoOperativoUpdate(BaseModel):
+    nombre: str | None = Field(default=None, min_length=1, max_length=80)
+    codigo: str | None = Field(default=None, max_length=40)
+    activo: bool | None = None
+    unidad_ids: list[int] | None = None
+
+    @field_validator("nombre", "codigo", mode="before")
+    @classmethod
+    def strip_text(cls, value):
+        if value is None:
+            return value
+        return str(value).strip()
+
+
+class MotivoNoOperativoResponse(BaseModel):
+    id: int
+    codigo: str
+    nombre: str
+    activo: bool
+    unidad_ids: list[int] = Field(default_factory=list)
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class MotivoNoOperativoCatalogoItem(BaseModel):
+    id: int
+    codigo: str
+    nombre: str
+
+    model_config = ConfigDict(from_attributes=True)

--- a/backend/tests/test_motivos_no_operativos.py
+++ b/backend/tests/test_motivos_no_operativos.py
@@ -20,8 +20,8 @@ def _db():
 def test_sync_unidades_activa_solo_las_seleccionadas():
     db = _db()
     db.add_all([
-        UnidadNegocio(idUnidadNegocio=1, nombre="UN 1"),
-        UnidadNegocio(idUnidadNegocio=2, nombre="UN 2"),
+        UnidadNegocio(idUnidadNegocio=1, Nombre="UN 1", Prefijo="U1", codigo_kobo="un1"),
+        UnidadNegocio(idUnidadNegocio=2, Nombre="UN 2", Prefijo="U2", codigo_kobo="un2"),
     ])
     motivo = MotivoNoOperativo(codigo="falla", nombre="FALLA", activo=True)
     db.add(motivo)

--- a/backend/tests/test_motivos_no_operativos.py
+++ b/backend/tests/test_motivos_no_operativos.py
@@ -1,0 +1,45 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.core.database import Base
+from app.models.motivo_no_operativo import MotivoNoOperativo, MotivoNoOperativoUnidadNegocio
+from app.models.unidad_negocio import UnidadNegocio
+from app.api.routes.motivos_no_operativos import _sync_unidades
+
+
+def _db():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(bind=engine, tables=[
+        UnidadNegocio.__table__,
+        MotivoNoOperativo.__table__,
+        MotivoNoOperativoUnidadNegocio.__table__,
+    ])
+    return sessionmaker(bind=engine)()
+
+
+def test_sync_unidades_activa_solo_las_seleccionadas():
+    db = _db()
+    db.add_all([
+        UnidadNegocio(idUnidadNegocio=1, nombre="UN 1"),
+        UnidadNegocio(idUnidadNegocio=2, nombre="UN 2"),
+    ])
+    motivo = MotivoNoOperativo(codigo="falla", nombre="FALLA", activo=True)
+    db.add(motivo)
+    db.flush()
+
+    _sync_unidades(db, motivo.id, [1, 2])
+    db.flush()
+    assert {row.unidad_negocio for row in db.query(MotivoNoOperativoUnidadNegocio).filter_by(activo=True).all()} == {1, 2}
+
+    _sync_unidades(db, motivo.id, [2])
+    db.flush()
+    activos = db.query(MotivoNoOperativoUnidadNegocio).filter_by(idMotivo=motivo.id, activo=True).all()
+    assert [row.unidad_negocio for row in activos] == [2]
+
+
+def test_motivo_global_inactivo_no_debe_considerarse_disponible():
+    db = _db()
+    motivo = MotivoNoOperativo(codigo="clima", nombre="CLIMA", activo=False)
+    db.add(motivo)
+    db.commit()
+    assert db.query(MotivoNoOperativo).filter(MotivoNoOperativo.activo.is_(True)).count() == 0

--- a/db_migrations/20260820_motivos_no_operativos.sql
+++ b/db_migrations/20260820_motivos_no_operativos.sql
@@ -1,0 +1,41 @@
+CREATE TABLE IF NOT EXISTS motivos_no_operativos (
+    id INT UNSIGNED NOT NULL AUTO_INCREMENT,
+    codigo VARCHAR(40) NOT NULL,
+    nombre VARCHAR(80) NOT NULL,
+    activo TINYINT(1) NOT NULL DEFAULT 1,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (id),
+    UNIQUE KEY uq_motivos_no_operativos_codigo (codigo)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS motivos_no_operativos_unidad_negocio (
+    id INT UNSIGNED NOT NULL AUTO_INCREMENT,
+    idMotivo INT UNSIGNED NOT NULL,
+    unidad_negocio INT UNSIGNED NOT NULL,
+    activo TINYINT(1) NOT NULL DEFAULT 1,
+    PRIMARY KEY (id),
+    UNIQUE KEY uq_motivo_no_operativo_un (idMotivo, unidad_negocio),
+    KEY idx_motivo_no_operativo_unidad (unidad_negocio, activo),
+    CONSTRAINT fk_motivo_no_operativo_catalogo
+        FOREIGN KEY (idMotivo) REFERENCES motivos_no_operativos(id) ON DELETE CASCADE,
+    CONSTRAINT fk_motivo_no_operativo_unidad
+        FOREIGN KEY (unidad_negocio) REFERENCES unidadnegocio(idUnidadNegocio) ON DELETE RESTRICT
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+INSERT IGNORE INTO motivos_no_operativos (codigo, nombre, activo) VALUES
+('aguardando_carreton', 'AGUARDANDO CARRETON', 1),
+('condiciones_climaticas', 'CONDICIONES CLIMATICAS', 1),
+('falla_mecanica', 'FALLA MECANICA', 1),
+('falta_repuestos', 'FALTA REPUESTOS', 1),
+('falta_operador', 'FALTA OPERADOR', 1),
+('falta_unidades_materia_prima', 'FALTA UNIDADES / MATERIA PRIMA', 1),
+('lavado_equipo_radiadores', 'LAVADO EQUIPO / RADIADORES', 1),
+('mantenimiento_preventivo', 'MANTENIMIENTO PREVENTIVO', 1),
+('otros', 'OTROS', 1),
+('rotura_parte_cambio_piezas', 'ROTURA PARTE / CAMBIO PIEZAS', 1),
+('traslado_mudanzas', 'TRASLADO / MUDANZAS', 1);
+
+INSERT IGNORE INTO motivos_no_operativos_unidad_negocio (idMotivo, unidad_negocio, activo)
+SELECT m.id, u.idUnidadNegocio, 1
+FROM motivos_no_operativos m
+CROSS JOIN unidadnegocio u;

--- a/docs/issue-122-motivos-no-operativos.md
+++ b/docs/issue-122-motivos-no-operativos.md
@@ -1,0 +1,12 @@
+# Motivos no operativos por unidad de negocio
+
+El catálogo de motivos no operativos se administra desde `/admin/gestion`, opción **Motivos no operativos**.
+
+- Los motivos se crean una sola vez y se asignan a una o varias unidades de negocio.
+- Un motivo puede activarse o desactivarse globalmente.
+- La asignación por unidad también puede cambiarse sin borrar el motivo.
+- El formulario de producción sigue aceptando texto libre en `motivo_no_op`.
+- El frontend consulta `/api/catalogos/motivos-no-operativos?un_id=<ID>` al cambiar de unidad y conserva una copia en IndexedDB para uso offline.
+- Si el endpoint todavía no está disponible durante un despliegue escalonado, se conservan como fallback los 11 motivos históricos incluidos en el frontend.
+
+La migración `db_migrations/20260820_motivos_no_operativos.sql` crea las tablas y asigna inicialmente los 11 motivos históricos a todas las unidades existentes.

--- a/frontend/src/config/adminEntityConfig.js.tmp
+++ b/frontend/src/config/adminEntityConfig.js.tmp
@@ -1,0 +1,1 @@
+placeholder

--- a/frontend/src/config/adminEntityConfig.js.tmp
+++ b/frontend/src/config/adminEntityConfig.js.tmp
@@ -1,1 +1,0 @@
-placeholder

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -73,6 +73,12 @@ const routes = [
         meta: { requiresAuth: true, requiresAdmin: true },
       },
       {
+        path: 'gestion/motivos-no-operativos',
+        name: 'admin-motivos-no-operativos',
+        component: () => import('../views/admin/MotivosNoOperativosAdminView.vue'),
+        meta: { requiresAuth: true, requiresAdmin: true },
+      },
+      {
         path: 'dashboard',
         name: 'admin-dashboard',
         component: () => import('../views/admin/AdminDashboardView.vue'),

--- a/frontend/src/stores/produccion.js
+++ b/frontend/src/stores/produccion.js
@@ -1,5 +1,6 @@
 import api from '@/services/api'
 import db from '@/services/db'
+import motivosNoOperativos from '@/data/motivosNoOperativos.json'
 import { ensurePendingIdentity, queuePendingProductionRecord } from '@/services/pendingRecords'
 import { useToastStore } from '@/stores/toast'
 import { extractApiErrorMessage, extractValidationErrorMessage } from '@/utils/apiError'
@@ -7,6 +8,7 @@ import { useProduccionStore as useLegacyProduccionStore } from '@/stores/producc
 
 const CAMINOS_MARKER = '__submission_kind'
 const CAMINOS_KIND = 'caminos'
+const MOTIVOS_CACHE_PREFIX = 'motivosNoOperativos'
 
 const createFormUuid = () => (
   globalThis.crypto?.randomUUID?.() || `${Date.now()}-${Math.random()}`
@@ -27,8 +29,60 @@ function pendingEndpoint(payload = {}) {
     : '/api/produccion/'
 }
 
+function motivosCacheKey(unId) {
+  return `${MOTIVOS_CACHE_PREFIX}:${Number(unId || 0)}`
+}
+
+function applyMotivos(items) {
+  const nombres = (Array.isArray(items) ? items : [])
+    .map((item) => String(item?.nombre ?? item ?? '').trim())
+    .filter(Boolean)
+  if (!nombres.length) return false
+  motivosNoOperativos.splice(0, motivosNoOperativos.length, ...nombres)
+  return true
+}
+
+async function fetchMotivosNoOperativos(unId) {
+  if (!unId) return motivosNoOperativos
+  try {
+    const { data } = await api.get('/api/catalogos/motivos-no-operativos', {
+      params: { un_id: Number(unId) },
+      _suppressErrorToast: true,
+    })
+    if (Array.isArray(data)) {
+      applyMotivos(data)
+      if (db.catalogos) {
+        await db.catalogos.put({
+          key: motivosCacheKey(unId),
+          catalog: MOTIVOS_CACHE_PREFIX,
+          scope: String(unId),
+          items: data,
+          timestamp: Date.now(),
+        })
+      }
+    }
+  } catch (error) {
+    if (db.catalogos) {
+      const cached = await db.catalogos.get(motivosCacheKey(unId))
+      if (cached?.items) applyMotivos(cached.items)
+    }
+  }
+  return motivosNoOperativos
+}
+
 export function useProduccionStore(...args) {
   const store = useLegacyProduccionStore(...args)
+
+  if (!store.__motivosNoOperativosCatalogReady) {
+    const legacyFetchTiposProceso = store.fetchTiposProceso.bind(store)
+    store.fetchTiposProceso = async (unId) => {
+      const result = await legacyFetchTiposProceso(unId)
+      await fetchMotivosNoOperativos(unId)
+      return result
+    }
+    store.fetchMotivosNoOperativos = fetchMotivosNoOperativos
+    store.__motivosNoOperativosCatalogReady = true
+  }
 
   if (typeof store.submitParteCaminos === 'function') {
     return store
@@ -84,9 +138,6 @@ export function useProduccionStore(...args) {
     }
   }
 
-  // Reemplaza la sincronización legacy por una compatible con ambos contratos.
-  // Los registros normales siguen enviándose al endpoint histórico y los partes
-  // multi-proceso de Caminos se reenvían al endpoint específico.
   store.syncPending = async () => {
     if (store.syncingPending) {
       return { successCount: 0, pendingCount: store.pendingCount, permanentFailureCount: 0 }
@@ -122,10 +173,7 @@ export function useProduccionStore(...args) {
         } catch (err) {
           const status = err?.response?.status
           if (isPermanentSyncError(status)) {
-            const detail = extractApiErrorMessage(
-              err,
-              'Error permanente al sincronizar el registro',
-            )
+            const detail = extractApiErrorMessage(err, 'Error permanente al sincronizar el registro')
             await db.pendingRecords.update(record.id, {
               synced: 1,
               syncStatus: 'failed',
@@ -141,10 +189,7 @@ export function useProduccionStore(...args) {
             syncStatus: 'pending',
             syncError: [401, 403].includes(status)
               ? 'La sesión debe validarse nuevamente antes de enviar.'
-              : extractApiErrorMessage(
-                  err,
-                  'Error transitorio. Se reintentará automáticamente.',
-                ),
+              : extractApiErrorMessage(err, 'Error transitorio. Se reintentará automáticamente.'),
           })
         }
       }
@@ -157,11 +202,7 @@ export function useProduccionStore(...args) {
         useToastStore().success('Pendientes sincronizados', `${successCount} registro(s) enviados.`)
       }
 
-      return {
-        successCount,
-        pendingCount: store.pendingCount,
-        permanentFailureCount,
-      }
+      return { successCount, pendingCount: store.pendingCount, permanentFailureCount }
     } finally {
       store.syncingPending = false
     }

--- a/frontend/src/views/admin/AdminCenterView.vue
+++ b/frontend/src/views/admin/AdminCenterView.vue
@@ -70,6 +70,7 @@ const adminGroups = [
       { key: 'unidades', label: 'Unidades de negocio', description: 'Estructura operativa y vinculaciones.', icon: 'unit', to: { name: 'admin-crud', params: { entity: 'unidades-negocio' } } },
       { key: 'procesos', label: 'Tipos de proceso', description: 'Procesos y requisitos de carga.', icon: 'process', to: { name: 'admin-crud', params: { entity: 'tipos-proceso' } } },
       { key: 'lugares', label: 'Lugares de carga', description: 'Puntos de carga por unidad.', icon: 'location', to: { name: 'admin-crud', params: { entity: 'lugares-carga' } } },
+      { key: 'motivos-no-operativos', label: 'Motivos no operativos', description: 'Motivos sugeridos y habilitación por unidad.', icon: 'records', to: { name: 'admin-motivos-no-operativos' } },
       { key: 'predios', label: 'Predios', description: 'Predios disponibles para producción.', icon: 'field', to: { name: 'admin-crud', params: { entity: 'predios' } } },
       { key: 'rodales', label: 'Rodales', description: 'Rodales y valores productivos.', icon: 'plot', to: { name: 'admin-crud', params: { entity: 'rodales' } } },
       { key: 'actas', label: 'Actas', description: 'Actas habilitadas para registrar producción.', icon: 'records', to: { name: 'admin-crud', params: { entity: 'actas' } } },

--- a/frontend/src/views/admin/MotivosNoOperativosAdminView.test.js
+++ b/frontend/src/views/admin/MotivosNoOperativosAdminView.test.js
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest'
+import { mount } from '@vue/test-utils'
+import MotivosNoOperativosAdminView from './MotivosNoOperativosAdminView.vue'
+
+vi.mock('@/services/api', () => ({
+  default: {
+    get: vi.fn(async (url) => ({ data: url.includes('unidades-negocio') ? [] : [] })),
+    post: vi.fn(),
+    put: vi.fn(),
+  },
+}))
+
+describe('MotivosNoOperativosAdminView', () => {
+  it('muestra la accion para crear un motivo', () => {
+    const wrapper = mount(MotivosNoOperativosAdminView, {
+      global: { stubs: { PageHeader: false, SectionCard: false, AppModal: true } },
+    })
+    expect(wrapper.text()).toContain('Nuevo motivo')
+  })
+})

--- a/frontend/src/views/admin/MotivosNoOperativosAdminView.vue
+++ b/frontend/src/views/admin/MotivosNoOperativosAdminView.vue
@@ -1,0 +1,144 @@
+<template>
+  <div class="space-y-3">
+    <PageHeader
+      kicker="Administración"
+      title="Motivos no operativos"
+      description="Agregá motivos y definí en qué unidades de negocio están disponibles."
+    >
+      <template #actions>
+        <AppButton variant="secondary" :loading="loading" @click="load">Refrescar</AppButton>
+        <AppButton @click="openCreate">Nuevo motivo</AppButton>
+      </template>
+    </PageHeader>
+
+    <SectionCard title="Catálogo">
+      <div class="mb-3 flex flex-col gap-2 sm:flex-row">
+        <input v-model="buscar" class="app-input min-h-10 flex-1 rounded-lg border px-3 py-2" placeholder="Buscar motivo" />
+        <select v-model="filtroUnidad" class="app-input min-h-10 rounded-lg border px-3 py-2 sm:w-64">
+          <option value="">Todas las unidades</option>
+          <option v-for="unidad in unidades" :key="unidad.idUnidadNegocio" :value="unidad.idUnidadNegocio">{{ unidad.nombre }}</option>
+        </select>
+      </div>
+
+      <div v-if="error" class="mb-3 rounded-lg border border-error/25 bg-error-light/30 p-3 text-sm font-semibold text-error-dark">{{ error }}</div>
+      <div v-if="loading" class="py-6 text-center text-sm text-neutral-500">Cargando...</div>
+      <div v-else class="space-y-2">
+        <article v-for="motivo in motivos" :key="motivo.id" class="app-card flex flex-col gap-3 rounded-xl p-3 sm:flex-row sm:items-center sm:justify-between">
+          <div class="min-w-0">
+            <div class="flex flex-wrap items-center gap-2">
+              <strong class="text-sm text-neutral-900">{{ motivo.nombre }}</strong>
+              <span :class="motivo.activo ? 'app-state-success' : 'app-state-inactive'" class="rounded-full border px-2 py-0.5 text-xs font-bold">
+                {{ motivo.activo ? 'Activo' : 'Inactivo' }}
+              </span>
+            </div>
+            <p class="mt-1 text-xs text-neutral-500">{{ unidadLabels(motivo.unidad_ids) }}</p>
+          </div>
+          <div class="flex gap-2">
+            <AppButton variant="secondary" @click="openEdit(motivo)">Editar</AppButton>
+            <AppButton :variant="motivo.activo ? 'danger' : 'secondary'" @click="toggleActivo(motivo)">
+              {{ motivo.activo ? 'Desactivar' : 'Activar' }}
+            </AppButton>
+          </div>
+        </article>
+        <p v-if="motivos.length === 0" class="py-6 text-center text-sm text-neutral-500">No hay motivos para estos filtros.</p>
+      </div>
+    </SectionCard>
+
+    <AppModal v-model="showForm" :title="editingId ? 'Editar motivo' : 'Nuevo motivo'" description="El motivo puede habilitarse para una o varias unidades de negocio.">
+      <div class="space-y-4">
+        <InputField v-model="form.nombre" label="Motivo" required placeholder="Ej: FALLA MECANICA" />
+        <label class="flex items-center gap-2 text-sm font-semibold text-neutral-700">
+          <input v-model="form.activo" type="checkbox" class="h-4 w-4 accent-primary" /> Activo
+        </label>
+        <div>
+          <p class="mb-2 text-sm font-semibold text-neutral-700">Unidades de negocio</p>
+          <div class="app-surface-muted grid gap-2 rounded-lg border p-3 sm:grid-cols-2">
+            <label v-for="unidad in unidades" :key="unidad.idUnidadNegocio" class="flex items-center gap-2 text-sm text-neutral-700">
+              <input
+                type="checkbox"
+                class="h-4 w-4 accent-primary"
+                :checked="form.unidad_ids.includes(Number(unidad.idUnidadNegocio))"
+                @change="toggleUnidad(unidad.idUnidadNegocio, $event.target.checked)"
+              />
+              {{ unidad.nombre }}
+            </label>
+          </div>
+        </div>
+        <div v-if="formError" class="rounded-lg border border-error/25 bg-error-light/30 p-3 text-sm font-semibold text-error-dark">{{ formError }}</div>
+        <div class="flex justify-end gap-2">
+          <AppButton variant="secondary" @click="showForm = false">Cancelar</AppButton>
+          <AppButton :loading="saving" @click="save">Guardar</AppButton>
+        </div>
+      </div>
+    </AppModal>
+  </div>
+</template>
+
+<script setup>
+import { onMounted, reactive, ref, watch } from 'vue'
+import api from '@/services/api'
+import AppButton from '@/components/ui/AppButton.vue'
+import AppModal from '@/components/ui/AppModal.vue'
+import InputField from '@/components/InputField.vue'
+import PageHeader from '@/components/ui/PageHeader.vue'
+import SectionCard from '@/components/SectionCard.vue'
+
+const motivos = ref([])
+const unidades = ref([])
+const loading = ref(false)
+const saving = ref(false)
+const error = ref('')
+const formError = ref('')
+const buscar = ref('')
+const filtroUnidad = ref('')
+const showForm = ref(false)
+const editingId = ref(null)
+const form = reactive({ nombre: '', activo: true, unidad_ids: [] })
+let timer = null
+
+function safeMessage(err, fallback) { return err?.response?.data?.detail || fallback }
+function unidadLabels(ids) {
+  const labels = unidades.value.filter(u => (ids || []).includes(Number(u.idUnidadNegocio))).map(u => u.nombre)
+  return labels.length ? labels.join(' · ') : 'Sin unidades asignadas'
+}
+function resetForm() { form.nombre = ''; form.activo = true; form.unidad_ids = unidades.value.map(u => Number(u.idUnidadNegocio)); formError.value = '' }
+function openCreate() { editingId.value = null; resetForm(); showForm.value = true }
+function openEdit(motivo) { editingId.value = motivo.id; form.nombre = motivo.nombre; form.activo = Boolean(motivo.activo); form.unidad_ids = [...(motivo.unidad_ids || [])].map(Number); formError.value = ''; showForm.value = true }
+function toggleUnidad(id, checked) { const value = Number(id); if (checked && !form.unidad_ids.includes(value)) form.unidad_ids.push(value); if (!checked) form.unidad_ids = form.unidad_ids.filter(x => x !== value) }
+
+async function loadUnidades() {
+  const { data } = await api.get('/api/admin/unidades-negocio', { params: { skip: 0, limit: 1000 }, _suppressErrorToast: true })
+  unidades.value = Array.isArray(data) ? data : []
+}
+async function load() {
+  loading.value = true; error.value = ''
+  try {
+    const params = { skip: 0, limit: 1000 }
+    if (buscar.value.trim()) params.buscar = buscar.value.trim()
+    if (filtroUnidad.value) params.unidad_id = Number(filtroUnidad.value)
+    const { data } = await api.get('/api/admin/motivos-no-operativos', { params, _suppressErrorToast: true })
+    motivos.value = Array.isArray(data) ? data : []
+  } catch (err) { motivos.value = []; error.value = safeMessage(err, 'No se pudieron cargar los motivos') }
+  finally { loading.value = false }
+}
+async function save() {
+  if (!form.nombre.trim()) { formError.value = 'Ingresá el nombre del motivo'; return }
+  saving.value = true; formError.value = ''
+  const payload = { nombre: form.nombre.trim(), activo: Boolean(form.activo), unidad_ids: form.unidad_ids }
+  try {
+    if (editingId.value) await api.put(`/api/admin/motivos-no-operativos/${editingId.value}`, payload)
+    else await api.post('/api/admin/motivos-no-operativos', payload)
+    showForm.value = false
+    await load()
+  } catch (err) { formError.value = safeMessage(err, 'No se pudo guardar el motivo') }
+  finally { saving.value = false }
+}
+async function toggleActivo(motivo) {
+  try {
+    await api.put(`/api/admin/motivos-no-operativos/${motivo.id}`, { activo: !motivo.activo })
+    await load()
+  } catch (err) { error.value = safeMessage(err, 'No se pudo actualizar el motivo') }
+}
+watch([buscar, filtroUnidad], () => { clearTimeout(timer); timer = setTimeout(load, 250) })
+onMounted(async () => { try { await loadUnidades(); await load() } catch (err) { error.value = safeMessage(err, 'No se pudo cargar la gestión de motivos') } })
+</script>


### PR DESCRIPTION
## Resumen

Implementa el issue #122 y amplía el alcance solicitado para administrar los motivos desde `/admin/gestion`.

### Backend
- nuevo catálogo `motivos_no_operativos`;
- relación M:N con unidades de negocio;
- migración idempotente con los 11 motivos históricos y asignación inicial a todas las UN;
- `GET /api/catalogos/motivos-no-operativos?un_id=X` para operadores;
- CRUD administrativo en `/api/admin/motivos-no-operativos`;
- alta, edición, activación/desactivación global y asignación por UN.

### Frontend administración
- nueva opción **Motivos no operativos** dentro de `/admin/gestion`;
- pantalla para crear, editar, activar/desactivar y seleccionar las unidades donde aparece cada motivo.

### Formulario de producción
- al cambiar de Unidad de Negocio, el store consulta el catálogo del backend;
- se mantiene el texto libre en `motivo_no_op`;
- cache en IndexedDB para trabajo offline;
- los 11 motivos históricos quedan como fallback durante despliegues escalonados o cuando aún no exista cache.

### Tests / documentación
- tests backend para asignación por UN y estado activo;
- test básico de la nueva pantalla administrativa;
- documentación de operación y despliegue.

Closes #122