### PR TITLE
fix: evitar doble conteo de horas en Caminos multiproceso

### DIFF
--- a/backend/app/api/routes/dashboard.py
+++ b/backend/app/api/routes/dashboard.py
@@ -95,8 +95,6 @@ def _apply_process_filter(base, process_filter: dict | None):
 
 def _base_filters(query, tp_ids: list[int], movil_id: int | None, fecha_desde: date | None, fecha_hasta: date | None):
     """Aplica los filtros comunes a un query sobre tablero_produccion usando text SQL for operacion matching."""
-    # Filtrar por operación: obtener nombres de tipo_proceso
-    # Usamos un subquery con los nombres reales
     query = query.filter(TableroProduccion.cod_un.isnot(None))
 
     if tp_ids:
@@ -123,26 +121,65 @@ def _apply_data_filters(base, process_filter: dict | None, movil_id: int | None,
     return base
 
 
-def _compute_kpi_value(db: Session, kpi: KpiDefinicion, process_filter: dict | None, movil_id: int | None, fecha_desde: date | None, fecha_hasta: date | None, un_id: int) -> float:
-    """Calcula el valor de un KPI dado los filtros.
-    
-    filter_tp_ids: lista con un solo ID cuando el usuario eligió un tipo de proceso
-                   explícitamente, o None/[] para mostrar todos los datos de la UN.
+def _jornada_key(registro_id, form_uuid) -> str:
+    """Clave lógica de jornada: form_uuid para multiproceso, id para legacy."""
+    normalized = str(form_uuid or "").strip()
+    return f"form:{normalized}" if normalized else f"legacy:{registro_id}"
+
+
+def _aggregate_jornadas(rows, dimension_indexes: tuple[int, ...] = ()) -> dict[tuple, dict[str, float]]:
+    """Deduplica campos de cabecera replicados entre filas hermanas.
+
+    Cada row debe terminar en: id, form_uuid, hr_inicio, hr_fin, hrs_no_op.
+    Los índices previos pueden usarse como dimensiones (fecha, máquina, etc.).
+    Se usa MAX dentro de la jornada porque las filas multiproceso replican la
+    misma cabecera. Los registros legacy sin form_uuid conservan semántica por fila.
     """
+    grouped: dict[tuple, dict[str, float]] = {}
+    for row in rows:
+        registro_id, form_uuid, hr_inicio, hr_fin, hrs_no_op = row[-5:]
+        dims = tuple(row[index] for index in dimension_indexes)
+        key = dims + (_jornada_key(registro_id, form_uuid),)
+        horas = float(hr_fin or 0) - float(hr_inicio or 0)
+        no_op = float(hrs_no_op or 0)
+        current = grouped.setdefault(key, {"horas": horas, "hrs_no_op": no_op})
+        current["horas"] = max(current["horas"], horas)
+        current["hrs_no_op"] = max(current["hrs_no_op"], no_op)
+    return grouped
+
+
+def _jornada_rows(base, *dimensions):
+    return base.with_entities(
+        *dimensions,
+        TableroProduccion.id,
+        TableroProduccion.form_uuid,
+        TableroProduccion.hr_inicio,
+        TableroProduccion.hr_fin,
+        TableroProduccion.hrs_no_op,
+    ).all()
+
+
+def _jornada_totals(base) -> tuple[float, float]:
+    jornadas = _aggregate_jornadas(_jornada_rows(base))
+    return (
+        round(sum(item["horas"] for item in jornadas.values()), 2),
+        round(sum(item["hrs_no_op"] for item in jornadas.values()), 2),
+    )
+
+
+def _compute_kpi_value(db: Session, kpi: KpiDefinicion, process_filter: dict | None, movil_id: int | None, fecha_desde: date | None, fecha_hasta: date | None, un_id: int) -> float:
+    """Calcula el valor de un KPI dado los filtros."""
     campo = kpi.campo_origen
 
     base = db.query(TableroProduccion).filter(TableroProduccion.cod_un == un_id)
     base = _apply_data_filters(base, process_filter, movil_id, fecha_desde, fecha_hasta)
 
     if campo == "CUSTOM:horas_trabajadas":
-        result = base.with_entities(func.sum(TableroProduccion.hr_fin - TableroProduccion.hr_inicio)).scalar()
-        return round(float(result or 0), 2)
+        hrs_trab, _ = _jornada_totals(base)
+        return hrs_trab
 
     if campo == "CUSTOM:eficiencia":
-        hrs_trab = base.with_entities(func.sum(TableroProduccion.hr_fin - TableroProduccion.hr_inicio)).scalar()
-        hrs_no_op = base.with_entities(func.sum(TableroProduccion.hrs_no_op)).scalar()
-        hrs_trab = float(hrs_trab or 0)
-        hrs_no_op = float(hrs_no_op or 0)
+        hrs_trab, hrs_no_op = _jornada_totals(base)
         if hrs_trab == 0:
             return 0.0
         return round((hrs_trab - hrs_no_op) / hrs_trab * 100, 2)
@@ -151,7 +188,6 @@ def _compute_kpi_value(db: Session, kpi: KpiDefinicion, process_filter: dict | N
         result = base.with_entities(func.count(TableroProduccion.id)).scalar()
         return float(result or 0)
 
-    # Standard aggregation
     col = getattr(TableroProduccion, campo, None)
     if col is None:
         return 0.0
@@ -200,13 +236,12 @@ def _fallback_kpis(db: Session, process_filter: dict | None, movil_id: int | Non
         func.count(TableroProduccion.id).label("registros"),
         func.sum(TableroProduccion.produccion).label("produccion"),
         func.sum(TableroProduccion.combustible).label("combustible"),
-        func.sum(TableroProduccion.hr_fin - TableroProduccion.hr_inicio).label("horas"),
     ).first()
 
     registros = float(row.registros or 0)
     produccion = round(float(row.produccion or 0), 2)
     combustible = round(float(row.combustible or 0), 2)
-    horas = round(float(row.horas or 0), 2)
+    horas, _ = _jornada_totals(base)
     principal = produccion > 0
 
     return [
@@ -227,7 +262,6 @@ def _process_label(db: Session, process_filter: dict | None) -> str | None:
     return None
 
 
-# ─── Helper compartido para listado/detalle de registros ───────────────────
 def _resolve_records_query(
     db: Session,
     user: Personal,
@@ -241,48 +275,24 @@ def _resolve_records_query(
     only_self: bool = False,
     self_cod_operador: int | None = None,
 ):
-    """Devuelve un query sobre ``TableroProduccion`` con filtros de alcance, tipo, móvil y fecha.
-
-    Caso de uso (issue #104):
-    - Encargado/Admin consultan el listado de registros del dashboard: se
-      filtran por las unidades de negocio autorizadas (multi-UN para encargado,
-      single o ninguna para admin según reciba ``un_id``).
-    - Operador consulta sus propios registros (``only_self=True``): se filtra
-      por ``cod_operador == self_cod_operador`` y no se permite un_id externo.
-
-    Levanta ``HTTPException 403`` si el usuario pide una UN que no le pertenece
-    (delega en ``_verify_un``).
-    """
     if only_self:
         if not self_cod_operador:
-            raise HTTPException(
-                status_code=400,
-                detail="Falta el cod_operador del usuario autenticado",
-            )
-        # El operador no puede escapar de su propio cod_operador. Ignoramos
-        # cualquier un_id que pudiera llegar acá: su alcance es el personal.
-        query = db.query(TableroProduccion).filter(
-            TableroProduccion.cod_operador == self_cod_operador
-        )
+            raise HTTPException(status_code=400, detail="Falta el cod_operador del usuario autenticado")
+        query = db.query(TableroProduccion).filter(TableroProduccion.cod_operador == self_cod_operador)
     else:
         if un_id is not None:
             _verify_un(user, un_id, db)
             query = db.query(TableroProduccion).filter(TableroProduccion.cod_un == un_id)
         else:
-            # Sin un_id: encargado ve sus unidades autorizadas, admin ve todo.
             if user.is_admin == 1:
                 query = db.query(TableroProduccion)
             else:
                 allowed = _personal_unidad_ids(db, user)
                 if not allowed:
-                    # Encargado sin unidades asignadas: no ve nada
                     query = db.query(TableroProduccion).filter(TableroProduccion.id == -1)
                 else:
-                    query = db.query(TableroProduccion).filter(
-                        TableroProduccion.cod_un.in_(allowed)
-                    )
+                    query = db.query(TableroProduccion).filter(TableroProduccion.cod_un.in_(allowed))
 
-    # Filtros compartidos de datos
     process_filter = _resolve_process_filter(tipo_proceso_key, tipo_proceso_id)
     query = _apply_process_filter(query, process_filter)
     if movil_id is not None:
@@ -291,13 +301,10 @@ def _resolve_records_query(
         query = query.filter(TableroProduccion.fecha >= fecha_desde)
     if fecha_hasta is not None:
         query = query.filter(TableroProduccion.fecha <= fecha_hasta)
-
     return query
 
 
-# ─── Helpers para paginación ───────────────────────────────────────────────
 def _normalize_pagination(page: int, page_size: int) -> tuple[int, int]:
-    """Sanea los parametros de paginacion: page>=1, 1<=page_size<=100."""
     if page < 1:
         page = 1
     if page_size < 1:
@@ -306,10 +313,6 @@ def _normalize_pagination(page: int, page_size: int) -> tuple[int, int]:
         page_size = 100
     return page, page_size
 
-
-# ═══════════════════════════════════════════════════════════════
-# ENDPOINTS
-# ═══════════════════════════════════════════════════════════════
 
 @router.get("/tipos-proceso-disponibles", response_model=List[TipoProcesoDisponible])
 async def tipos_proceso_disponibles(
@@ -325,17 +328,8 @@ async def tipos_proceso_disponibles(
         .order_by(TipoDeProceso.nombre)
         .all()
     )
-    options = [
-        {
-            "id": row.id,
-            "nombre": row.nombre,
-            "value": f"tipo:{row.id}",
-            "source": "catalogo",
-        }
-        for row in catalog_rows
-    ]
+    options = [{"id": row.id, "nombre": row.nombre, "value": f"tipo:{row.id}", "source": "catalogo"} for row in catalog_rows]
     seen_names = {str(row.nombre or "").strip().upper() for row in catalog_rows}
-
     operation_rows = (
         db.query(TableroProduccion.operacion)
         .filter(
@@ -353,14 +347,8 @@ async def tipos_proceso_disponibles(
         name = str(operacion or "").strip()
         if not name or name.upper() in seen_names:
             continue
-        options.append({
-            "id": next_id,
-            "nombre": name,
-            "value": f"operacion:{name}",
-            "source": "historico",
-        })
+        options.append({"id": next_id, "nombre": name, "value": f"operacion:{name}", "source": "historico"})
         next_id -= 1
-
     return options
 
 
@@ -374,15 +362,12 @@ async def moviles_disponibles(
 ):
     _verify_un(user, un_id, db)
     process_filter = _resolve_process_filter(tipo_proceso_key, tipo_proceso_id)
-
-    # Máquinas que tienen al menos un registro en tablero_produccion para esa UN
     query = (
         db.query(Movil.idMovil, Movil.Patente, Movil.Detalle)
         .join(TableroProduccion, TableroProduccion.cod_equipo == Movil.idMovil)
         .filter(TableroProduccion.cod_un == un_id)
     )
     query = _apply_process_filter(query, process_filter)
-
     query = query.group_by(Movil.idMovil, Movil.Patente, Movil.Detalle).order_by(Movil.Detalle)
     rows = query.all()
     return [MovilDisponible(idMovil=r[0], patente=r[1], detalle=r[2]) for r in rows]
@@ -401,14 +386,11 @@ async def get_kpis(
 ):
     _verify_un(user, un_id, db)
     process_filter = _resolve_process_filter(tipo_proceso_key, tipo_proceso_id)
-    # config_tp_ids: tipos de proceso para buscar configuración de KPIs
-    # filter_tp_ids: para filtrar datos de tablero_produccion
     if process_filter and process_filter["mode"] == "tipo":
         config_tp_ids = process_filter["ids"]
     else:
         config_tp_ids = _get_tipo_proceso_ids(db, un_id)
 
-    # Obtener KPIs aplicables según el tipo de proceso seleccionado
     kpi_rows = []
     if config_tp_ids:
         kpi_rows = (
@@ -419,87 +401,43 @@ async def get_kpis(
             .all()
         )
 
-    # Deduplicar KPIs (un KPI puede aparecer en varios tipo_proceso)
-    # Cuando hay múltiples tipos seleccionados ("Todos"), solo mostrar KPIs comunes
-    # y usar Horas Trabajadas como principal del resumen general.
     is_multi = len(config_tp_ids) > 1
     seen = set()
     kpis_result: list[KpiItem] = []
 
     if is_multi:
-        # Contar en cuántos tipos aparece cada KPI
         from collections import Counter
         kpi_tp_count = Counter()
         for kpi_def, _, _ in kpi_rows:
             kpi_tp_count[kpi_def.id] += 1
         total_tps = len(config_tp_ids)
-
-        # Solo KPIs que aparecen en todos los tipos de proceso (comunes)
         common_kpi_ids = {kid for kid, cnt in kpi_tp_count.items() if cnt >= total_tps}
-
         for kpi_def, es_principal, orden in kpi_rows:
-            if kpi_def.id in seen:
-                continue
-            if kpi_def.id not in common_kpi_ids:
+            if kpi_def.id in seen or kpi_def.id not in common_kpi_ids:
                 continue
             seen.add(kpi_def.id)
-
-            # En vista "Todos", Horas Trabajadas es el KPI principal
-            is_hero = (kpi_def.campo_origen == "CUSTOM:horas_trabajadas")
-
+            is_hero = kpi_def.campo_origen == "CUSTOM:horas_trabajadas"
             valor = _compute_kpi_value(db, kpi_def, process_filter, movil_id, fecha_desde, fecha_hasta, un_id)
             variacion = _compute_variation(db, kpi_def, process_filter, movil_id, fecha_desde, fecha_hasta, un_id)
-
-            kpis_result.append(KpiItem(
-                id=kpi_def.id,
-                nombre=kpi_def.nombre,
-                valor=valor,
-                unidad=kpi_def.unidad,
-                icono=kpi_def.icono,
-                es_principal=is_hero,
-                variacion_porcentual=variacion,
-            ))
-
-        # Ordenar: principal primero, luego por orden
+            kpis_result.append(KpiItem(id=kpi_def.id, nombre=kpi_def.nombre, valor=valor, unidad=kpi_def.unidad, icono=kpi_def.icono, es_principal=is_hero, variacion_porcentual=variacion))
         kpis_result.sort(key=lambda k: (not k.es_principal, 0))
     else:
         for kpi_def, es_principal, orden in kpi_rows:
             if kpi_def.id in seen:
                 continue
             seen.add(kpi_def.id)
-
             valor = _compute_kpi_value(db, kpi_def, process_filter, movil_id, fecha_desde, fecha_hasta, un_id)
             variacion = _compute_variation(db, kpi_def, process_filter, movil_id, fecha_desde, fecha_hasta, un_id)
-
-            kpis_result.append(KpiItem(
-                id=kpi_def.id,
-                nombre=kpi_def.nombre,
-                valor=valor,
-                unidad=kpi_def.unidad,
-                icono=kpi_def.icono,
-                es_principal=bool(es_principal),
-                variacion_porcentual=variacion,
-            ))
+            kpis_result.append(KpiItem(id=kpi_def.id, nombre=kpi_def.nombre, valor=valor, unidad=kpi_def.unidad, icono=kpi_def.icono, es_principal=bool(es_principal), variacion_porcentual=variacion))
 
     if not kpis_result:
         kpis_result = _fallback_kpis(db, process_filter, movil_id, fecha_desde, fecha_hasta, un_id)
 
     tp_nombre = _process_label(db, process_filter)
-
     movil_nombre = None
     if movil_id:
-        m = db.query(Movil.Patente).filter(Movil.idMovil == movil_id).scalar()
-        movil_nombre = m
-
-    return KpisResponse(
-        kpis=kpis_result,
-        filtros_aplicados=FiltrosAplicados(
-            tipo_proceso=tp_nombre,
-            movil=movil_nombre,
-            fecha_desde=str(fecha_desde) if fecha_desde else None,
-            fecha_hasta=str(fecha_hasta) if fecha_hasta else None,
-        ),
-    )
+        movil_nombre = db.query(Movil.Patente).filter(Movil.idMovil == movil_id).scalar()
+    return KpisResponse(kpis=kpis_result, filtros_aplicados=FiltrosAplicados(tipo_proceso=tp_nombre, movil=movil_nombre, fecha_desde=str(fecha_desde) if fecha_desde else None, fecha_hasta=str(fecha_hasta) if fecha_hasta else None))
 
 
 @router.get("/evolucion", response_model=EvolucionResponse)
@@ -532,16 +470,9 @@ async def get_evolucion(
     elif filter_tp_ids:
         filter_tp_ids = {"mode": "tipo", "ids": filter_tp_ids}
 
-    # Obtener el KPI principal del tipo de proceso seleccionado
     is_multi = len(config_tp_ids) > 1
     if is_multi:
-        # En vista "Todos", usar Horas Trabajadas como KPI del gráfico
-        kpi_def = db.query(KpiDefinicion).filter(
-            KpiDefinicion.campo_origen == "CUSTOM:horas_trabajadas",
-            KpiDefinicion.activo == 1,
-        ).first()
-        if not kpi_def:
-            kpi_def = None
+        kpi_def = db.query(KpiDefinicion).filter(KpiDefinicion.campo_origen == "CUSTOM:horas_trabajadas", KpiDefinicion.activo == 1).first()
     else:
         principal = (
             db.query(KpiDefinicion, TipoProcesoKpi)
@@ -549,27 +480,26 @@ async def get_evolucion(
             .filter(TipoProcesoKpi.tipo_proceso_id.in_(config_tp_ids), TipoProcesoKpi.es_principal == 1, KpiDefinicion.activo == 1)
             .first()
         )
-        if not principal:
-            kpi_def = None
-        else:
-            kpi_def = principal[0]
+        kpi_def = principal[0] if principal else None
     campo = getattr(kpi_def, "campo_origen", "produccion")
     label = getattr(kpi_def, "nombre", "Produccion")
     if metric == "combustible":
         campo = "combustible"
         label = "Combustible"
 
-    # Base query
     base = db.query(TableroProduccion).filter(TableroProduccion.cod_un == un_id)
     base = _apply_data_filters(base, filter_tp_ids, movil_id, fecha_desde, fecha_hasta)
 
-    # Agrupar por fecha
-    if campo == "CUSTOM:horas_trabajadas":
-        agg_expr = func.sum(TableroProduccion.hr_fin - TableroProduccion.hr_inicio)
-    elif campo == "CUSTOM:eficiencia":
-        # No graficamos eficiencia como evolución; usar horas trabajadas como fallback
-        agg_expr = func.sum(TableroProduccion.hr_fin - TableroProduccion.hr_inicio)
-    elif campo == "CUSTOM:registros":
+    if campo in ("CUSTOM:horas_trabajadas", "CUSTOM:eficiencia"):
+        grouped = _aggregate_jornadas(_jornada_rows(base, TableroProduccion.fecha), (0,))
+        by_date: dict[date, float] = {}
+        for key, values in grouped.items():
+            fecha = key[0]
+            by_date[fecha] = by_date.get(fecha, 0.0) + values["horas"]
+        ordered = sorted(by_date.items(), key=lambda item: item[0] or date.min)
+        return EvolucionResponse(labels=[str(fecha) if fecha else "" for fecha, _ in ordered], datasets=[DatasetItem(nombre=label, valores=[round(valor, 2) for _, valor in ordered])])
+
+    if campo == "CUSTOM:registros":
         agg_expr = func.count(TableroProduccion.id)
     else:
         col = getattr(TableroProduccion, campo, None)
@@ -577,20 +507,8 @@ async def get_evolucion(
             return EvolucionResponse(labels=[], datasets=[])
         agg_expr = func.sum(col)
 
-    rows = (
-        base.with_entities(TableroProduccion.fecha, agg_expr.label("valor"))
-        .group_by(TableroProduccion.fecha)
-        .order_by(TableroProduccion.fecha)
-        .all()
-    )
-
-    labels = [str(r[0]) if r[0] else "" for r in rows]
-    valores = [round(float(r[1] or 0), 2) for r in rows]
-
-    return EvolucionResponse(
-        labels=labels,
-        datasets=[DatasetItem(nombre=label, valores=valores)],
-    )
+    rows = base.with_entities(TableroProduccion.fecha, agg_expr.label("valor")).group_by(TableroProduccion.fecha).order_by(TableroProduccion.fecha).all()
+    return EvolucionResponse(labels=[str(r[0]) if r[0] else "" for r in rows], datasets=[DatasetItem(nombre=label, valores=[round(float(r[1] or 0), 2) for r in rows])])
 
 
 @router.get("/ranking-maquinas", response_model=List[RankingMaquinaItem])
@@ -623,16 +541,9 @@ async def get_ranking_maquinas(
     elif filter_tp_ids:
         filter_tp_ids = {"mode": "tipo", "ids": filter_tp_ids}
 
-    # Obtener KPI principal del tipo de proceso seleccionado
     is_multi = len(config_tp_ids) > 1
     if is_multi:
-        # En vista "Todos", usar Horas Trabajadas como KPI del ranking
-        kpi_def = db.query(KpiDefinicion).filter(
-            KpiDefinicion.campo_origen == "CUSTOM:horas_trabajadas",
-            KpiDefinicion.activo == 1,
-        ).first()
-        if not kpi_def:
-            kpi_def = None
+        kpi_def = db.query(KpiDefinicion).filter(KpiDefinicion.campo_origen == "CUSTOM:horas_trabajadas", KpiDefinicion.activo == 1).first()
     else:
         principal = (
             db.query(KpiDefinicion, TipoProcesoKpi)
@@ -640,15 +551,11 @@ async def get_ranking_maquinas(
             .filter(TipoProcesoKpi.tipo_proceso_id.in_(config_tp_ids), TipoProcesoKpi.es_principal == 1, KpiDefinicion.activo == 1)
             .first()
         )
-        if not principal:
-            kpi_def = None
-        else:
-            kpi_def = principal[0]
+        kpi_def = principal[0] if principal else None
     campo = getattr(kpi_def, "campo_origen", "produccion")
     if metric == "combustible":
         campo = "combustible"
 
-    # Base
     base = (
         db.query(TableroProduccion)
         .join(Movil, Movil.idMovil == TableroProduccion.cod_equipo)
@@ -656,11 +563,19 @@ async def get_ranking_maquinas(
     )
     base = _apply_data_filters(base, filter_tp_ids, movil_id, fecha_desde, fecha_hasta)
 
-    if campo == "CUSTOM:horas_trabajadas":
-        agg_expr = func.sum(TableroProduccion.hr_fin - TableroProduccion.hr_inicio)
-    elif campo == "CUSTOM:eficiencia":
-        agg_expr = func.sum(TableroProduccion.hr_fin - TableroProduccion.hr_inicio)
-    elif campo == "CUSTOM:registros":
+    if campo in ("CUSTOM:horas_trabajadas", "CUSTOM:eficiencia"):
+        rows = _jornada_rows(base, Movil.idMovil, Movil.Patente, Movil.Detalle)
+        grouped = _aggregate_jornadas(rows, (0, 1, 2))
+        machines: dict[tuple, dict[str, float | int]] = {}
+        for key, values in grouped.items():
+            machine_key = key[:3]
+            current = machines.setdefault(machine_key, {"valor": 0.0, "registros": 0})
+            current["valor"] += values["horas"]
+            current["registros"] += 1
+        ordered = sorted(machines.items(), key=lambda item: item[1]["valor"], reverse=True)
+        return [RankingMaquinaItem(patente=key[1], detalle=key[2], valor=round(float(values["valor"]), 2), registros=int(values["registros"])) for key, values in ordered]
+
+    if campo == "CUSTOM:registros":
         agg_expr = func.count(TableroProduccion.id)
     else:
         col = getattr(TableroProduccion, campo, None)
@@ -669,29 +584,14 @@ async def get_ranking_maquinas(
         agg_expr = func.sum(col)
 
     rows = (
-        base.with_entities(
-            Movil.Patente,
-            Movil.Detalle,
-            agg_expr.label("valor"),
-            func.count(TableroProduccion.id).label("registros"),
-        )
+        base.with_entities(Movil.Patente, Movil.Detalle, agg_expr.label("valor"), func.count(TableroProduccion.id).label("registros"))
         .group_by(Movil.idMovil, Movil.Patente, Movil.Detalle)
         .order_by(agg_expr.desc())
         .all()
     )
-
-    return [
-        RankingMaquinaItem(
-            patente=r[0],
-            detalle=r[1],
-            valor=round(float(r[2] or 0), 2),
-            registros=int(r[3]),
-        )
-        for r in rows
-    ]
+    return [RankingMaquinaItem(patente=r[0], detalle=r[1], valor=round(float(r[2] or 0), 2), registros=int(r[3])) for r in rows]
 
 
-# ─── Listado paginado de registros (issue #104) ───────────────────────────
 @router.get("/registros", response_model=RegistrosPagedResponse)
 async def list_registros(
     un_id: int | None = None,
@@ -705,67 +605,26 @@ async def list_registros(
     user: Personal = Depends(get_current_admin_or_encargado),
     db: Session = Depends(get_db),
 ):
-    """Lista paginada de los registros individuales que componen los KPIs del dashboard.
-
-    - Encargado/Admin ven registros de sus unidades autorizadas (o la UN
-      puntual si pasan ``un_id``).
-    - El conjunto de filtros (un_id, tipo_proceso, móvil, fechas) es el mismo
-      que consumen /kpis, /evolucion y /ranking-maquinas, de modo que el total
-      del listado coincide con el KPI Registros bajo la misma combinación.
-    - El listado se ordena por fecha desc + id desc (consistente con
-      /mis-registros).
-    """
     page, page_size = _normalize_pagination(page, page_size)
-
-    base = _resolve_records_query(
-        db, user,
-        un_id=un_id,
-        tipo_proceso_id=tipo_proceso_id,
-        tipo_proceso_key=tipo_proceso_key,
-        movil_id=movil_id,
-        fecha_desde=fecha_desde,
-        fecha_hasta=fecha_hasta,
-    )
+    base = _resolve_records_query(db, user, un_id=un_id, tipo_proceso_id=tipo_proceso_id, tipo_proceso_key=tipo_proceso_key, movil_id=movil_id, fecha_desde=fecha_desde, fecha_hasta=fecha_hasta)
     total = int(base.with_entities(func.count(TableroProduccion.id)).scalar() or 0)
-    rows = (
-        base.order_by(TableroProduccion.fecha.desc(), TableroProduccion.id.desc())
-        .offset((page - 1) * page_size)
-        .limit(page_size)
-        .all()
-    )
+    rows = base.order_by(TableroProduccion.fecha.desc(), TableroProduccion.id.desc()).offset((page - 1) * page_size).limit(page_size).all()
     items = [RegistroListItem.model_validate(r) for r in rows]
     total_pages = (total + page_size - 1) // page_size if total else 0
-    return RegistrosPagedResponse(
-        items=items,
-        total=total,
-        page=page,
-        page_size=page_size,
-        total_pages=total_pages,
-    )
+    return RegistrosPagedResponse(items=items, total=total, page=page, page_size=page_size, total_pages=total_pages)
 
 
-# ─── Detalle de un registro (issue #104) ──────────────────────────────────
 @router.get("/registros/{registro_id}", response_model=RegistroDetail)
 async def get_registro_detalle(
     registro_id: int,
     user: Personal = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
-    """Devuelve el detalle completo de un registro.
-
-    Aplica la regla de alcance segun el rol del usuario:
-    - Encargado/Admin: solo registros de sus unidades autorizadas.
-    - Operador: solo registros cuyo ``cod_operador`` coincide con su id.
-
-    Si el registro no existe o esta fuera del alcance del usuario, devolvemos
-    404 para no filtrar la existencia del registro.
-    """
     row = db.query(TableroProduccion).filter(TableroProduccion.id == registro_id).first()
     if not row:
         raise HTTPException(status_code=404, detail="Registro no encontrado")
 
     if int(user.is_admin or 0) == 1 or int(user.encargado or 0) == 1:
-        # Encargado/Admin: valida por UN
         if row.cod_un is not None:
             try:
                 _verify_un(user, int(row.cod_un), db)
@@ -775,7 +634,6 @@ async def get_registro_detalle(
             if int(user.is_admin or 0) != 1:
                 raise HTTPException(status_code=404, detail="Registro no encontrado")
     else:
-        # Operador: solo puede ver registros donde el es el operador
         if int(row.cod_operador or 0) != int(user.idPersonal):
             raise HTTPException(status_code=404, detail="Registro no encontrado")
 

--- a/backend/tests/test_dashboard_jornadas_multiproceso.py
+++ b/backend/tests/test_dashboard_jornadas_multiproceso.py
@@ -1,0 +1,72 @@
+"""Regresión: las filas hermanas de Caminos comparten una sola jornada."""
+
+from datetime import date
+
+from app.api.routes.dashboard import _aggregate_jornadas, _jornada_key
+
+
+def row(fecha, registro_id, form_uuid, hr_inicio, hr_fin, hrs_no_op=0):
+    return (fecha, registro_id, form_uuid, hr_inicio, hr_fin, hrs_no_op)
+
+
+def test_jornada_key_usa_form_uuid_y_legacy_por_id():
+    assert _jornada_key(10, " abc ") == "form:abc"
+    assert _jornada_key(10, None) == "legacy:10"
+    assert _jornada_key(11, "") == "legacy:11"
+
+
+def test_dos_procesos_mismo_form_uuid_suman_una_sola_jornada():
+    fecha = date(2026, 8, 20)
+    grouped = _aggregate_jornadas(
+        [
+            row(fecha, 1, "FORM-A", 8351, 8359),
+            row(fecha, 2, "FORM-A", 8351, 8359),
+        ],
+        (0,),
+    )
+
+    assert len(grouped) == 1
+    assert sum(item["horas"] for item in grouped.values()) == 8
+
+
+def test_dos_form_uuid_distintos_suman_dos_jornadas():
+    fecha = date(2026, 8, 20)
+    grouped = _aggregate_jornadas(
+        [
+            row(fecha, 1, "FORM-A", 8351, 8359),
+            row(fecha, 2, "FORM-B", 8359, 8367),
+        ],
+        (0,),
+    )
+
+    assert len(grouped) == 2
+    assert sum(item["horas"] for item in grouped.values()) == 16
+
+
+def test_legacy_sin_form_uuid_conserva_semantica_por_fila():
+    fecha = date(2026, 8, 20)
+    grouped = _aggregate_jornadas(
+        [
+            row(fecha, 1, None, 8351, 8359),
+            row(fecha, 2, None, 8351, 8359),
+        ],
+        (0,),
+    )
+
+    assert len(grouped) == 2
+    assert sum(item["horas"] for item in grouped.values()) == 16
+
+
+def test_cabecera_no_operativa_tambien_se_deduplica_en_eficiencia():
+    fecha = date(2026, 8, 20)
+    grouped = _aggregate_jornadas(
+        [
+            row(fecha, 1, "FORM-A", 8351, 8359, 2),
+            row(fecha, 2, "FORM-A", 8351, 8359, 2),
+        ],
+        (0,),
+    )
+
+    values = list(grouped.values())
+    assert values[0]["horas"] == 8
+    assert values[0]["hrs_no_op"] == 2


### PR DESCRIPTION
Corrige los indicadores del dashboard para que las filas hermanas de un mismo `form_uuid` representen una sola jornada al calcular horas.

Incluye:
- deduplicación de `hr_fin - hr_inicio` por `form_uuid`;
- compatibilidad legacy: filas sin `form_uuid` siguen contando individualmente;
- corrección de eficiencia para no duplicar `hrs_no_op` de la cabecera compartida;
- aplicación a KPI de horas, fallback, evolución y ranking por máquina;
- tests de regresión para multiproceso, jornadas independientes y registros legacy.

No cambia la persistencia: DISPOSICION, REMOLQUE, PERFILADO, etc. siguen siendo filas separadas.