### PR TITLE
Agregar alias Compose para Coolify

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,1 @@
+docker-compose.yml


### PR DESCRIPTION
Agrega docker-compose.yaml como alias versionado de docker-compose.yml para que Coolify detecte el Compose por defecto. No modifica servicios, datos ni secretos.