### PR TITLE
fix: hacer compatibles los env protegidos con Coolify Compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,10 +11,13 @@ RUN pip install --upgrade pip \
     && pip install -r /app/requirements.txt
 
 COPY backend /app
+COPY docker-entrypoint.py /usr/local/bin/registro-entrypoint
+RUN chmod 755 /usr/local/bin/registro-entrypoint
 
 EXPOSE 8000
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
     CMD python -c "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8000/health', timeout=3)" || exit 1
 
+ENTRYPOINT ["/usr/local/bin/registro-entrypoint"]
 CMD ["gunicorn", "-w", "3", "-k", "uvicorn.workers.UvicornWorker", "-b", "0.0.0.0:8000", "app.main:app"]

--- a/docker-compose.demo.yml
+++ b/docker-compose.demo.yml
@@ -5,8 +5,10 @@ services:
       context: .
       dockerfile: Dockerfile
     container_name: registro_produccion_indufor_demo
-    env_file:
-      - /srv/env/registro_produccion/indufor_demo.env
+    environment:
+      REGISTRO_ENV_FILE: /run/secrets/registro.env
+    volumes:
+      - /srv/env/registro_produccion/indufor_demo.env:/run/secrets/registro.env:ro
     ports:
       - "127.0.0.1:18104:8000"
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,8 +17,10 @@ services:
     <<: *registro-produccion-base
     image: registro_produccion-indufor:latest
     container_name: registro_produccion_indufor
-    env_file:
-      - /srv/env/registro_produccion/indufor.env
+    environment:
+      REGISTRO_ENV_FILE: /run/secrets/registro.env
+    volumes:
+      - /srv/env/registro_produccion/indufor.env:/run/secrets/registro.env:ro
     ports:
       - "127.0.0.1:18004:8000"
 
@@ -26,7 +28,9 @@ services:
     <<: *registro-produccion-base
     image: registro_produccion-produccion-fg:latest
     container_name: registro_produccion_produccion_fg
-    env_file:
-      - /srv/env/registro_produccion/produccion_fg.env
+    environment:
+      REGISTRO_ENV_FILE: /run/secrets/registro.env
+    volumes:
+      - /srv/env/registro_produccion/produccion_fg.env:/run/secrets/registro.env:ro
     ports:
       - "127.0.0.1:18005:8000"

--- a/docker-entrypoint.py
+++ b/docker-entrypoint.py
@@ -1,0 +1,51 @@
+#!/usr/local/bin/python
+"""Load a protected runtime env file before starting the application."""
+
+from __future__ import annotations
+
+import ast
+import os
+import sys
+from pathlib import Path
+
+
+def load_env_file(path: Path) -> None:
+    if not path:
+        return
+    if not path.is_file():
+        raise SystemExit(f"Required environment file not found: {path}")
+
+    for line_number, raw_line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line.startswith("export "):
+            line = line[7:].lstrip()
+        if "=" not in line:
+            raise SystemExit(f"Invalid environment line {line_number} in {path}")
+
+        key, value = line.split("=", 1)
+        key = key.strip()
+        if not key or not key.replace("_", "").isalnum() or key[0].isdigit():
+            raise SystemExit(f"Invalid environment key on line {line_number} in {path}")
+
+        value = value.strip()
+        comment_index = value.find(" #")
+        if comment_index >= 0:
+            value = value[:comment_index].rstrip()
+        if value[:1] in {"'", '"'}:
+            try:
+                value = ast.literal_eval(value)
+            except (SyntaxError, ValueError) as exc:
+                raise SystemExit(f"Invalid quoted value on line {line_number} in {path}") from exc
+        os.environ[key] = value
+
+
+env_file = os.environ.get("REGISTRO_ENV_FILE")
+if env_file:
+    load_env_file(Path(env_file))
+
+if len(sys.argv) < 2:
+    raise SystemExit("No application command was provided")
+
+os.execvp(sys.argv[1], sys.argv[1:])


### PR DESCRIPTION
## Objetivo
Permitir que Coolify Compose cargue la configuracion protegida de cada instancia sin depender de env_file absolutos que Coolify descarta.

## Cambios
- entrypoint que carga REGISTRO_ENV_FILE sin imprimir valores
- bind mounts de solo lectura para indufor, produccion_fg e indufor_demo
- conserva imagenes diferenciadas por instancia

## Validacion
- python -m pytest backend/tests/test_deploy_scripts_contract.py -q
- python -m py_compile docker-entrypoint.py
- parse YAML de ambos Compose
- git diff --check