### PR TITLE
fix(auth): permitir ingreso offline cuando backend/MySQL está caído

### DIFF
--- a/frontend/src/stores/auth.backendDown.test.js
+++ b/frontend/src/stores/auth.backendDown.test.js
@@ -1,0 +1,105 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createPinia, setActivePinia } from 'pinia'
+
+vi.mock('@/services/api', () => ({
+  default: {
+    post: vi.fn(),
+    defaults: { headers: { common: {} } },
+  },
+}))
+
+import api from '@/services/api'
+import {
+  hashSecret,
+  useAuthStore,
+  LOGIN_ERROR_BAD_CREDENTIALS,
+  LOGIN_ERROR_SERVER,
+} from './auth'
+
+const CACHE_KEY = 'offline_session_cache'
+const user = { idPersonal: 7, dni: '12345678', nombre: 'Operador', is_admin: 0 }
+
+async function seedFreshCache(password = 'secreto') {
+  localStorage.setItem(
+    CACHE_KEY,
+    JSON.stringify({
+      user,
+      passwordHash: await hashSecret(password),
+      cachedAt: Date.now(),
+    }),
+  )
+}
+
+describe('auth store / fallback offline cuando backend esta caido', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    localStorage.clear()
+    vi.clearAllMocks()
+    delete api.defaults.headers.common.Authorization
+  })
+
+  it('entra con la sesion local si MySQL/backend responde 500', async () => {
+    await seedFreshCache()
+    api.post.mockRejectedValueOnce({
+      response: { status: 500, data: { detail: 'MySQL unavailable' } },
+    })
+
+    const store = useAuthStore()
+    const ok = await store.login('12345678', 'secreto')
+
+    expect(ok).toBe(true)
+    expect(store.offlineMode).toBe(true)
+    expect(store.isAuthenticatedOffline).toBe(true)
+    expect(store.user).toEqual(user)
+    expect(store.error).toBeNull()
+  })
+
+  it('entra con la sesion local si la request no obtiene respuesta', async () => {
+    await seedFreshCache()
+    api.post.mockRejectedValueOnce({ message: 'Network Error' })
+
+    const store = useAuthStore()
+    const ok = await store.login('12345678', 'secreto')
+
+    expect(ok).toBe(true)
+    expect(store.offlineMode).toBe(true)
+  })
+
+  it('no usa cache si el servidor responde 401', async () => {
+    await seedFreshCache()
+    api.post.mockRejectedValueOnce({
+      response: { status: 401, data: { detail: 'invalid credentials' } },
+    })
+
+    const store = useAuthStore()
+    const ok = await store.login('12345678', 'secreto')
+
+    expect(ok).toBe(false)
+    expect(store.offlineMode).toBe(false)
+    expect(store.error).toBe(LOGIN_ERROR_BAD_CREDENTIALS)
+  })
+
+  it('no permite fallback con password distinta a la cacheada', async () => {
+    await seedFreshCache('correcta')
+    api.post.mockRejectedValueOnce({ response: { status: 503, data: {} } })
+
+    const store = useAuthStore()
+    const ok = await store.login('12345678', 'incorrecta')
+
+    expect(ok).toBe(false)
+    expect(store.offlineMode).toBe(false)
+    expect(store.error).toBe(LOGIN_ERROR_SERVER)
+  })
+
+  it('no permite fallback con DNI distinto al cacheado', async () => {
+    await seedFreshCache()
+    api.post.mockRejectedValueOnce({ response: { status: 503, data: {} } })
+
+    const store = useAuthStore()
+    const ok = await store.login('99999999', 'secreto')
+
+    expect(ok).toBe(false)
+    expect(store.offlineMode).toBe(false)
+    expect(store.error).toBe(LOGIN_ERROR_SERVER)
+  })
+})

--- a/frontend/src/stores/auth.js
+++ b/frontend/src/stores/auth.js
@@ -31,8 +31,7 @@ function isTokenExpired(token) {
  * Returns a hex string. Returns a deterministic fallback only when crypto.subtle
  * is missing (e.g. insecure contexts / older test environments); the fallback
  * is NOT a security guarantee — it merely prevents crashes. The backend remains
- * the authority: the hash is only used to invalidate caches after the user
- * changes their password.
+ * the authority: the hash is only used to validate the cached offline login.
  */
 export async function hashSecret(value) {
   if (!value) return null
@@ -85,6 +84,17 @@ export function clearOfflineSessionCache() {
   } catch {
     /* ignore */
   }
+}
+
+/**
+ * True when the login request could not be validated because the backend itself
+ * is unavailable. This deliberately excludes 4xx responses (especially 401):
+ * when the server is reachable, it remains the authority for credentials.
+ */
+export function canFallbackToOfflineLogin(err) {
+  if (!err || typeof err !== 'object') return false
+  if (!err.response) return true
+  return Number(err.response.status) >= 500
 }
 
 /**
@@ -199,11 +209,42 @@ export const useAuthStore = defineStore('auth', {
         await this.cacheSession(password)
         return true
       } catch (err) {
+        // Hay Internet/Wi-Fi pero el backend o MySQL puede estar caído. En ese
+        // caso no debemos bloquear la operación: validamos DNI+contraseña contra
+        // la sesión local previamente cacheada y entramos en modo offline.
+        if (canFallbackToOfflineLogin(err)) {
+          const restored = await this.loginFromCache(dni, password)
+          if (restored) return true
+        }
+
         this.error = classifyLoginError(err)
         return false
       } finally {
         this.loading = false
       }
+    },
+
+    async loginFromCache(dni, password) {
+      const cached = readOfflineSessionCache()
+      this.cachedSession = cached
+      if (!cached || !this.isOfflineCacheValid()) return false
+
+      const requestedDni = String(dni ?? '').trim()
+      const cachedDni = String(cached.user?.dni ?? '').trim()
+      if (!requestedDni || requestedDni !== cachedDni) return false
+
+      const passwordHash = await hashSecret(password)
+      if (!passwordHash || passwordHash !== cached.passwordHash) return false
+
+      this.token = null
+      this.user = { ...cached.user }
+      this.offlineMode = true
+      this.initMode = 'offline'
+      this.error = null
+      localStorage.removeItem('token')
+      localStorage.setItem('user', JSON.stringify(this.user))
+      delete api.defaults.headers.common['Authorization']
+      return true
     },
 
     async sincronizar() {
@@ -280,6 +321,9 @@ export const useAuthStore = defineStore('auth', {
      *  - mode 'offline'        → sin red, operador entra con cache dentro de la gracia
      *  - mode 'login-required' → con red pero token vencido/ausente → mostrar /login
      *  - mode 'offline-locked' → sin red y cache fuera de gracia → mostrar /login
+     *
+     * Si navigator dice "online" pero el backend/MySQL está caído, el fallback
+     * se resuelve en login(): el operador puede validar contra la sesión local.
      */
     initAuth() {
       // Reset previous offline state at boot; restored below if applicable.


### PR DESCRIPTION
## Problema

Con Internet/Wi-Fi disponible pero el backend o MySQL caído, `navigator.onLine` seguía dando `true`. El login intentaba validar contra `/api/auth/login`, recibía error 5xx/Network Error y bloqueaba al operador, aunque existiera una sesión local válida.

Esto contradice el objetivo operativo de la PWA: poder seguir trabajando y guardar producción localmente para sincronizar después.

## Solución

- Ante errores sin respuesta o HTTP 5xx durante login, intentar fallback contra la sesión local cacheada.
- Validar que coincidan **DNI + hash de contraseña** y que la sesión siga dentro del período de gracia offline.
- Si valida, entrar en `offlineMode` sin token de backend y permitir el flujo normal offline.
- Nunca usar el fallback si el backend responde 401 u otro 4xx: cuando el servidor está disponible, sigue siendo la autoridad.
- Agregar tests específicos para:
  - backend 500 + cache válida;
  - Network Error + cache válida;
  - 401 sin fallback;
  - contraseña incorrecta;
  - DNI incorrecto.

## Comportamiento esperado

1. Operador ya autenticado previamente en ese dispositivo.
2. MySQL/backend se cae.
3. El operador ingresa DNI y contraseña.
4. La app valida contra el cache local y entra en modo offline.
5. Los registros se guardan localmente.
6. El mecanismo de sincronización existente los reintenta cuando vuelve el backend.

## Seguridad

El fallback solamente aplica a fallas de disponibilidad del backend. No permite saltar una respuesta 401 y respeta el `VITE_OFFLINE_GRACE_DAYS` vigente.

## Validación

Se agregaron tests unitarios focalizados. Falta la ejecución del CI del PR para confirmar suite completa y build antes de mergear.