### PR TITLE
fix: completar circuito operativo offline PWA

### DIFF
--- a/frontend/nginx.conf.template
+++ b/frontend/nginx.conf.template
@@ -5,6 +5,15 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
+    location = /health {
+        proxy_pass http://${BACKEND_HOST}:8000/health;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
     location /api/ {
         proxy_pass http://${BACKEND_HOST}:8000;
         proxy_http_version 1.1;

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -375,6 +375,15 @@ watch(sidebarCollapsed, (value) => {
   localStorage.setItem('sidebarCollapsed', value ? '1' : '0')
 })
 
+watch(
+  () => authStore.isAuthenticated,
+  (authenticated, wasAuthenticated) => {
+    if (authenticated && !wasAuthenticated) {
+      produccionStore.refreshPendingCount().then(() => attemptPendingSync({ forceHealthCheck: true }))
+    }
+  },
+)
+
 // PWA install prompt
 const deferredInstallPrompt = ref(null)
 
@@ -413,11 +422,18 @@ const SYNC_INTERVAL_MS = 30 * 1000
 let syncIntervalId = null
 
 async function attemptPendingSync({ forceHealthCheck = false } = {}) {
-  if (!authStore.isAuthenticated || !navigator.onLine) return
+  if (!authStore.isSessionActive || !navigator.onLine) return
   const backendUp = await connectivityStore.refreshBackendHealth({ force: forceHealthCheck })
-  if (backendUp) {
-    await produccionStore.syncPending()
+  if (!backendUp) return
+
+  if (authStore.isAuthenticatedOffline) {
+    const redirect = route.fullPath && route.name !== 'login' ? route.fullPath : '/'
+    authStore.requireOnlineReauth()
+    await router.push({ name: 'login', query: { redirect, reauth: '1' } })
+    return
   }
+
+  await produccionStore.syncPending()
 }
 
 async function handleOnline() {

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -5,7 +5,7 @@
       :has-cached-session="hasCachedSession"
     />
 
-    <template v-if="authStore.isAuthenticated">
+    <template v-if="authStore.isSessionActive">
       <div :class="['min-h-screen', connectivityStore.isOffline ? 'pt-8' : '']">
         <header class="sticky top-0 z-30 border-b border-[#222D26] bg-[#090E0B] text-white md:hidden">
           <div class="flex h-14 items-center justify-between px-4">
@@ -428,7 +428,7 @@ onMounted(() => {
   window.addEventListener('beforeinstallprompt', handleBeforeInstallPrompt)
   window.addEventListener('appinstalled', handleAppInstalled)
   window.addEventListener('online', handleOnline)
-  if (authStore.isAuthenticated) {
+  if (authStore.isSessionActive) {
     produccionStore.refreshPendingCount().then(() => attemptPendingSync({ forceHealthCheck: true }))
   }
 

--- a/frontend/src/services/healthCheck.js
+++ b/frontend/src/services/healthCheck.js
@@ -13,7 +13,7 @@
  * without firing toasts.
  *
  * Configuration via env (Vite):
- *   VITE_HEALTHCHECK_PATH  Default: "/api/produccion/lugares-carga?un_id=1"
+ *   VITE_HEALTHCHECK_PATH  Default: "/health"
  *
  * @param {object} [opts]
  * @param {string} [opts.baseURL]  Override the API base URL. Defaults to VITE_API_URL.
@@ -32,7 +32,7 @@ export async function checkBackend({
 } = {}) {
   const rawBase = baseURL ?? import.meta.env?.VITE_API_URL ?? ''
   const rawPath =
-    path ?? import.meta.env?.VITE_HEALTHCHECK_PATH ?? '/api/produccion/lugares-carga?un_id=1'
+    path ?? import.meta.env?.VITE_HEALTHCHECK_PATH ?? '/health'
 
   // Normalize baseURL so a trailing /api collapses to empty (same convention
   // as the axios client). The path is taken as-is — it may already include
@@ -50,11 +50,8 @@ export async function checkBackend({
   const started = Date.now()
   const timer = setTimeout(() => ctrl.abort(), timeoutMs)
 
-  const defaultValidate = (data) => {
-    if (Array.isArray(data)) return true
-    if (data && typeof data === 'object') return Object.keys(data).length > 0
-    return false
-  }
+  const defaultValidate = (data) =>
+    !!data && typeof data === 'object' && data.status === 'ok' && data.database === 'ok'
   const isHealthyPayload = validate || defaultValidate
 
   try {
@@ -67,16 +64,10 @@ export async function checkBackend({
     })
     clearTimeout(timer)
 
-    if (res.status >= 500) {
-      onResult?.('degraded', Date.now() - started)
-      return 'degraded'
-    }
-    if (res.status === 404) {
-      // The probe path was removed from Nginx — treat as unreachable so the
-      // banner shows the right colour, and avoid marking the backend down for
-      // a missing route.
-      onResult?.('unreachable', Date.now() - started)
-      return 'unreachable'
+    if (!res.ok) {
+      const state = res.status === 404 ? 'unreachable' : 'degraded'
+      onResult?.(state, Date.now() - started)
+      return state
     }
 
     let data

--- a/frontend/src/services/healthCheck.test.js
+++ b/frontend/src/services/healthCheck.test.js
@@ -25,11 +25,10 @@ function jsonResponse(body, { status = 200 } = {}) {
 }
 
 describe('checkBackend', () => {
-  it('returns "ok" when the probe returns a JSON array', async () => {
+  it('uses /health by default and requires backend + database ok', async () => {
     let captured
-    fakeFetchOnce(jsonResponse([{ id: 1 }], { status: 200 }))
+    fakeFetchOnce(jsonResponse({ status: 'ok', database: 'ok' }, { status: 200 }))
     const result = await checkBackend({
-      path: '/api/produccion/lugares-carga?un_id=1',
       onResult: (state, latency) => {
         captured = { state, latency }
       },
@@ -37,20 +36,20 @@ describe('checkBackend', () => {
     expect(result).toBe('ok')
     expect(captured.state).toBe('ok')
     expect(globalThis.fetch).toHaveBeenCalledWith(
-      '/api/produccion/lugares-carga?un_id=1',
+      '/health',
       expect.objectContaining({ cache: 'no-store', credentials: 'omit' }),
     )
   })
 
-  it('returns "ok" when the probe returns a JSON object with at least one key', async () => {
+  it('returns "ok" when the health payload confirms backend and database', async () => {
     fakeFetchOnce(jsonResponse({ status: 'ok', database: 'ok' }, { status: 200 }))
-    const result = await checkBackend({ path: '/api/health' })
+    const result = await checkBackend({ path: '/health' })
     expect(result).toBe('ok')
   })
 
   it('returns "degraded" when the probe returns 503', async () => {
     fakeFetchOnce(jsonResponse({ status: 'error', database: 'error' }, { status: 503 }))
-    const result = await checkBackend({ path: '/api/health' })
+    const result = await checkBackend({ path: '/health' })
     expect(result).toBe('degraded')
   })
 
@@ -61,7 +60,6 @@ describe('checkBackend', () => {
   })
 
   it('returns "unreachable" when the response is 404 (probe path missing)', async () => {
-    // /api/health is currently blocked by Nginx -> 404 -> unreachable, not degraded.
     fakeFetchOnce(jsonResponse({ detail: 'Not Found' }, { status: 404 }))
     const result = await checkBackend({ path: '/api/health' })
     expect(result).toBe('unreachable')
@@ -135,5 +133,15 @@ describe('checkBackend', () => {
       validate: (data) => data && data.status === 'ok',
     })
     expect(result).toBe('degraded')
+  })
+})
+
+
+describe('checkBackend auth failures', () => {
+  it('never treats 401/403 JSON as healthy', async () => {
+    fakeFetchOnce(jsonResponse({ detail: 'Not authenticated' }, { status: 401 }))
+    expect(await checkBackend({ path: '/health' })).toBe('degraded')
+    fakeFetchOnce(jsonResponse({ detail: 'Forbidden' }, { status: 403 }))
+    expect(await checkBackend({ path: '/health' })).toBe('degraded')
   })
 })

--- a/frontend/src/services/pendingRecords.js
+++ b/frontend/src/services/pendingRecords.js
@@ -1,6 +1,27 @@
 import db from '@/services/db'
 
-const OFFLINE_SCHEMA_VERSION = 2
+const OFFLINE_SCHEMA_VERSION = 3
+
+export const SUBMISSION_KIND_FIELD = '__submission_kind'
+export const SUBMISSION_KIND_PRODUCCION = 'produccion'
+export const SUBMISSION_KIND_CAMINOS = 'caminos'
+export const SUBMISSION_KIND_COMBUSTIBLE = 'combustible'
+
+export function pendingSubmissionKind(payload = {}) {
+  return payload?.[SUBMISSION_KIND_FIELD] || SUBMISSION_KIND_PRODUCCION
+}
+
+export function pendingSubmissionEndpoint(payload = {}) {
+  const kind = pendingSubmissionKind(payload)
+  if (kind === SUBMISSION_KIND_CAMINOS) return '/api/produccion/caminos'
+  if (kind === SUBMISSION_KIND_COMBUSTIBLE) return '/api/combustible/cargas'
+  return '/api/produccion/'
+}
+
+export function stripPendingMetadata(payload = {}) {
+  const { [SUBMISSION_KIND_FIELD]: _kind, ...clean } = payload
+  return clean
+}
 
 function createClientId() {
   return crypto.randomUUID?.() || `${Date.now()}-${Math.random()}`

--- a/frontend/src/services/pendingRecords.test.js
+++ b/frontend/src/services/pendingRecords.test.js
@@ -10,7 +10,15 @@ vi.mock('@/services/db', () => ({
 }))
 
 import db from '@/services/db'
-import { ensurePendingIdentity, queuePendingProductionRecord } from './pendingRecords'
+import {
+  ensurePendingIdentity,
+  pendingSubmissionEndpoint,
+  queuePendingProductionRecord,
+  stripPendingMetadata,
+  SUBMISSION_KIND_FIELD,
+  SUBMISSION_KIND_CAMINOS,
+  SUBMISSION_KIND_COMBUSTIBLE,
+} from './pendingRecords'
 
 describe('pending production records', () => {
   beforeEach(() => vi.clearAllMocks())
@@ -35,5 +43,12 @@ describe('pending production records', () => {
       clientId: payload.form_uuid,
       payload,
     }))
+  })
+
+  it('routes each queued kind to its correct endpoint and strips local metadata', () => {
+    expect(pendingSubmissionEndpoint({})).toBe('/api/produccion/')
+    expect(pendingSubmissionEndpoint({ [SUBMISSION_KIND_FIELD]: SUBMISSION_KIND_CAMINOS })).toBe('/api/produccion/caminos')
+    expect(pendingSubmissionEndpoint({ [SUBMISSION_KIND_FIELD]: SUBMISSION_KIND_COMBUSTIBLE })).toBe('/api/combustible/cargas')
+    expect(stripPendingMetadata({ form_uuid: 'x', [SUBMISSION_KIND_FIELD]: SUBMISSION_KIND_COMBUSTIBLE })).toEqual({ form_uuid: 'x' })
   })
 })

--- a/frontend/src/stores/auth.js
+++ b/frontend/src/stores/auth.js
@@ -186,6 +186,9 @@ export const useAuthStore = defineStore('auth', {
     isAuthenticated: (state) => !!state.token && !isTokenExpired(state.token),
     isAuthenticatedOffline: (state) =>
       state.offlineMode && !!state.user && !!state.cachedSession,
+    isSessionActive() {
+      return this.isAuthenticated || this.isAuthenticatedOffline
+    },
     userName: (state) => state.user?.nombre || '',
     isAdmin: (state) => state.user?.is_admin === 1,
   },
@@ -304,10 +307,8 @@ export const useAuthStore = defineStore('auth', {
       localStorage.removeItem('token')
       localStorage.removeItem('user')
       delete api.defaults.headers.common['Authorization']
-      // Keep the offline session cache so the operator can come back without
-      // typing credentials while inside the grace period. Clear it explicitly
-      // via clearOfflineSessionCache() when the operator really wants to forget
-      // the device (e.g. reset / lost device flow).
+      clearOfflineSessionCache()
+      this.cachedSession = null
     },
 
     clearOfflineCache() {

--- a/frontend/src/stores/auth.js
+++ b/frontend/src/stores/auth.js
@@ -299,6 +299,14 @@ export const useAuthStore = defineStore('auth', {
       return true
     },
 
+    requireOnlineReauth() {
+      this.token = null
+      this.offlineMode = false
+      this.initMode = 'login-required'
+      localStorage.removeItem('token')
+      delete api.defaults.headers.common['Authorization']
+    },
+
     logout() {
       this.token = null
       this.user = null

--- a/frontend/src/stores/auth.test.js
+++ b/frontend/src/stores/auth.test.js
@@ -150,17 +150,28 @@ describe('auth store / initAuth offline', () => {
     expect(typeof cached?.cachedAt).toBe('number')
   })
 
-  it('logout keeps the offline cache so the operator can come back', () => {
+  it('logout clears the offline cache so another operator cannot reuse the device session', () => {
     const user = { idPersonal: 1, dni: '88888888', nombre: 'Op' }
     seedCache(user, Date.now())
     const store = useAuthStore()
     store.logout()
-    // token/user are cleared
     expect(store.token).toBeNull()
     expect(store.user).toBeNull()
-    // but the cache stays so they can re-enter offline within the grace period
-    const cached = readOfflineSessionCache()
-    expect(cached?.user.dni).toBe('88888888')
+    expect(readOfflineSessionCache()).toBeNull()
+    expect(store.cachedSession).toBeNull()
+  })
+
+  it('requireOnlineReauth keeps cached session while invalidating offline access', () => {
+    const user = { idPersonal: 1, dni: '88888888', nombre: 'Op' }
+    seedCache(user, Date.now())
+    const store = useAuthStore()
+    store.cachedSession = readOfflineSessionCache()
+    store.user = user
+    store.offlineMode = true
+    store.requireOnlineReauth()
+    expect(store.offlineMode).toBe(false)
+    expect(store.initMode).toBe('login-required')
+    expect(readOfflineSessionCache()?.user.dni).toBe('88888888')
   })
 
   it('clearOfflineCache removes the cache as well', () => {

--- a/frontend/src/stores/combustible.js
+++ b/frontend/src/stores/combustible.js
@@ -1,5 +1,11 @@
 import { defineStore } from 'pinia'
 import api from '@/services/api'
+import { queuePendingProductionRecord, SUBMISSION_KIND_FIELD, SUBMISSION_KIND_COMBUSTIBLE } from '@/services/pendingRecords'
+import { useProduccionStore } from '@/stores/produccion'
+
+const createFormUuid = () => (
+  globalThis.crypto?.randomUUID?.() || `${Date.now()}-${Math.random()}`
+)
 
 export const useCombustibleStore = defineStore('combustible', {
   state: () => ({
@@ -54,11 +60,33 @@ export const useCombustibleStore = defineStore('combustible', {
     async createCarga(payload) {
       this.saving = true
       this.error = null
+      const submissionPayload = {
+        ...payload,
+        form_uuid: payload.form_uuid || createFormUuid(),
+      }
+      const pendingPayload = {
+        ...submissionPayload,
+        [SUBMISSION_KIND_FIELD]: SUBMISSION_KIND_COMBUSTIBLE,
+      }
+
       try {
-        const { data } = await api.post('/api/combustible/cargas', payload)
+        if (!navigator.onLine) {
+          await queuePendingProductionRecord(pendingPayload)
+          await useProduccionStore().refreshPendingCount()
+          this.lastCarga = { ...submissionPayload, offline: true }
+          return this.lastCarga
+        }
+
+        const { data } = await api.post('/api/combustible/cargas', submissionPayload)
         this.lastCarga = data
         return data
       } catch (error) {
+        if (!error.response || Number(error.response?.status) >= 500) {
+          await queuePendingProductionRecord(pendingPayload)
+          await useProduccionStore().refreshPendingCount()
+          this.lastCarga = { ...submissionPayload, offline: true }
+          return this.lastCarga
+        }
         this.error = error.response?.data?.detail || 'No se pudo registrar la carga de combustible'
         throw error
       } finally {

--- a/frontend/src/stores/combustible.test.js
+++ b/frontend/src/stores/combustible.test.js
@@ -8,7 +8,18 @@ vi.mock('@/services/api', () => ({
   },
 }))
 
+vi.mock('@/services/pendingRecords', () => ({
+  queuePendingProductionRecord: vi.fn(),
+  SUBMISSION_KIND_FIELD: '__submission_kind',
+  SUBMISSION_KIND_COMBUSTIBLE: 'combustible',
+}))
+
+vi.mock('@/stores/produccion', () => ({
+  useProduccionStore: () => ({ refreshPendingCount: vi.fn(async () => 1) }),
+}))
+
 import api from '@/services/api'
+import { queuePendingProductionRecord } from '@/services/pendingRecords'
 import { useCombustibleStore } from './combustible'
 
 
@@ -16,6 +27,7 @@ describe('combustible store', () => {
   beforeEach(() => {
     setActivePinia(createPinia())
     vi.clearAllMocks()
+    Object.defineProperty(navigator, 'onLine', { configurable: true, value: true })
   })
 
   it('loads places for the selected equipment business unit', async () => {
@@ -62,5 +74,52 @@ describe('combustible store', () => {
     expect(api.post).toHaveBeenCalledWith('/api/combustible/cargas', payload)
     expect(result.id_carga).toBe(99)
     expect(store.lastCarga.form_uuid).toBe('carga-fisica-1')
+  })
+
+  it('queues combustible locally when offline and keeps a stable form_uuid', async () => {
+    Object.defineProperty(navigator, 'onLine', { configurable: true, value: false })
+    const store = useCombustibleStore()
+    const result = await store.createCarga({
+      fecha: '2026-09-04',
+      id_movil: 10,
+      litros: 120,
+      km: 15000,
+      id_lugar_carga: 42,
+      id_tipo_comb: 1,
+      remito: 'R-9',
+      remito2: '',
+      remito3: '',
+    })
+
+    expect(api.post).not.toHaveBeenCalled()
+    expect(queuePendingProductionRecord).toHaveBeenCalledWith(expect.objectContaining({
+      __submission_kind: 'combustible',
+      form_uuid: expect.any(String),
+    }))
+    expect(result.offline).toBe(true)
+    expect(result.form_uuid).toBeTruthy()
+  })
+
+  it('queues combustible locally when backend/MySQL responds 503', async () => {
+    api.post.mockRejectedValueOnce({ response: { status: 503, data: { detail: 'DB unavailable' } } })
+    const store = useCombustibleStore()
+    const result = await store.createCarga({
+      form_uuid: 'comb-503',
+      fecha: '2026-09-04',
+      id_movil: 10,
+      litros: 120,
+      km: 15000,
+      id_lugar_carga: 42,
+      id_tipo_comb: 1,
+      remito: 'R-10',
+      remito2: '',
+      remito3: '',
+    })
+
+    expect(queuePendingProductionRecord).toHaveBeenCalledWith(expect.objectContaining({
+      __submission_kind: 'combustible',
+      form_uuid: 'comb-503',
+    }))
+    expect(result).toEqual(expect.objectContaining({ offline: true, form_uuid: 'comb-503' }))
   })
 })

--- a/frontend/src/stores/produccion.js
+++ b/frontend/src/stores/produccion.js
@@ -1,13 +1,18 @@
 import api from '@/services/api'
 import db from '@/services/db'
 import motivosNoOperativos from '@/data/motivosNoOperativos.json'
-import { ensurePendingIdentity, queuePendingProductionRecord } from '@/services/pendingRecords'
+import {
+  ensurePendingIdentity,
+  pendingSubmissionEndpoint,
+  queuePendingProductionRecord,
+  stripPendingMetadata,
+  SUBMISSION_KIND_FIELD,
+  SUBMISSION_KIND_CAMINOS,
+} from '@/services/pendingRecords'
 import { useToastStore } from '@/stores/toast'
 import { extractApiErrorMessage, extractValidationErrorMessage } from '@/utils/apiError'
 import { useProduccionStore as useLegacyProduccionStore } from '@/stores/produccionLegacy'
 
-const CAMINOS_MARKER = '__submission_kind'
-const CAMINOS_KIND = 'caminos'
 const MOTIVOS_CACHE_PREFIX = 'motivosNoOperativos'
 
 const createFormUuid = () => (
@@ -17,17 +22,6 @@ const createFormUuid = () => (
 const isPermanentSyncError = (status) => (
   status >= 400 && status < 500 && ![401, 403, 408, 429].includes(status)
 )
-
-function withoutSyncMetadata(payload = {}) {
-  const { [CAMINOS_MARKER]: _kind, ...clean } = payload
-  return clean
-}
-
-function pendingEndpoint(payload = {}) {
-  return payload?.[CAMINOS_MARKER] === CAMINOS_KIND
-    ? '/api/produccion/caminos'
-    : '/api/produccion/'
-}
 
 function motivosCacheKey(unId) {
   return `${MOTIVOS_CACHE_PREFIX}:${Number(unId || 0)}`
@@ -98,7 +92,7 @@ export function useProduccionStore(...args) {
     }
     const pendingPayload = {
       ...payload,
-      [CAMINOS_MARKER]: CAMINOS_KIND,
+      [SUBMISSION_KIND_FIELD]: SUBMISSION_KIND_CAMINOS,
     }
 
     try {
@@ -116,7 +110,7 @@ export function useProduccionStore(...args) {
       useToastStore().success('Parte de Caminos guardado')
       return data
     } catch (err) {
-      if (!err.response) {
+      if (!err.response || Number(err.response?.status) >= 500) {
         await queuePendingProductionRecord(pendingPayload)
         await store.refreshPendingCount()
         useToastStore().info(
@@ -164,8 +158,8 @@ export function useProduccionStore(...args) {
           })
 
           const identifiedPayload = await ensurePendingIdentity(record)
-          const endpoint = pendingEndpoint(identifiedPayload)
-          const submissionPayload = withoutSyncMetadata(identifiedPayload)
+          const endpoint = pendingSubmissionEndpoint(identifiedPayload)
+          const submissionPayload = stripPendingMetadata(identifiedPayload)
 
           await api.post(endpoint, submissionPayload, { _suppressErrorToast: true })
           await db.pendingRecords.delete(record.id)

--- a/frontend/src/stores/produccion.test.js
+++ b/frontend/src/stores/produccion.test.js
@@ -38,6 +38,13 @@ vi.mock('@/services/pendingRecords', () => ({
     form_uuid: record.payload?.form_uuid || record.clientId,
   })),
   queuePendingProductionRecord: vi.fn(),
+  pendingSubmissionEndpoint: vi.fn((payload) => payload?.__submission_kind === 'caminos' ? '/api/produccion/caminos' : payload?.__submission_kind === 'combustible' ? '/api/combustible/cargas' : '/api/produccion/'),
+  stripPendingMetadata: vi.fn((payload) => {
+    const { __submission_kind: _kind, ...clean } = payload
+    return clean
+  }),
+  SUBMISSION_KIND_FIELD: '__submission_kind',
+  SUBMISSION_KIND_CAMINOS: 'caminos',
 }))
 
 import api from '@/services/api'

--- a/frontend/src/stores/produccionLegacy.js
+++ b/frontend/src/stores/produccionLegacy.js
@@ -341,7 +341,7 @@ export const useProduccionStore = defineStore('produccion', {
         return data
       } catch (err) {
         // Network error → queue for later
-        if (!err.response) {
+        if (!err.response || Number(err.response?.status) >= 500) {
           await queuePendingProductionRecord(submissionPayload)
           await this.refreshPendingCount()
           useToastStore().info(

--- a/frontend/src/views/LoginView.vue
+++ b/frontend/src/views/LoginView.vue
@@ -315,6 +315,10 @@ const errorCategory = computed(() => {
 })
 
 onMounted(() => {
+  if (route.query.reauth === '1') {
+    offlineNotice.value = 'Volvió el servidor. Validá tu DNI y contraseña para enviar automáticamente los registros pendientes.'
+  }
+
   // If the operator landed on /login with a cached offline session still valid,
   // send them straight to home. They are already authenticated, just without
   // network — they should not have to retype credentials.

--- a/frontend/src/views/LoginView.vue
+++ b/frontend/src/views/LoginView.vue
@@ -355,7 +355,6 @@ async function handleLogin() {
   authStore.error = null
   const success = await authStore.login(dni.value, password.value)
   if (success) {
-    authStore.clearOfflineCache()
     const redirect = typeof route.query.redirect === 'string' ? route.query.redirect : null
     router.push(redirect ? { path: redirect } : { name: 'home' })
   }

--- a/frontend/src/views/PendientesView.vue
+++ b/frontend/src/views/PendientesView.vue
@@ -189,7 +189,7 @@
 <script setup>
 import { computed, onMounted, onUnmounted, ref } from 'vue'
 import api from '@/services/api'
-import { ensurePendingIdentity } from '@/services/pendingRecords'
+import { ensurePendingIdentity, pendingSubmissionEndpoint, stripPendingMetadata } from '@/services/pendingRecords'
 import db from '@/services/db'
 import { useAuthStore } from '@/stores/auth'
 import { useProduccionStore } from '@/stores/produccion'
@@ -423,8 +423,10 @@ async function retryRecord(record) {
       lastAttemptAt: Date.now(),
       retryCount: Number(record.retryCount || 0) + 1,
     })
-    const submissionPayload = await ensurePendingIdentity(record)
-    await api.post('/api/produccion', submissionPayload, {
+    const identifiedPayload = await ensurePendingIdentity(record)
+    const endpoint = pendingSubmissionEndpoint(identifiedPayload)
+    const submissionPayload = stripPendingMetadata(identifiedPayload)
+    await api.post(endpoint, submissionPayload, {
       _suppressErrorToast: true,
     })
     await db.pendingRecords.delete(record.id)


### PR DESCRIPTION
## Resumen

Implementa el bloque principal de los issues #158, #159, #160, #161, #162 y #163.

### Cambios
- preserva la sesión offline después del login online;
- unifica sesión operativa online/offline en el layout;
- logout explícito invalida la cache del dispositivo;
- usa `/health` real (backend + MySQL) y lo expone por Nginx;
- ante 5xx de backend/MySQL, Producción y Caminos quedan en IndexedDB;
- Combustible ahora soporta guardado offline con `form_uuid` estable;
- la cola identifica Producción/Caminos/Combustible y despacha cada registro al endpoint correcto;
- Reintentar deja de hardcodear `/api/produccion`;
- al volver backend, una sesión offline solicita revalidación controlada sin borrar Pendientes y sincroniza al completar el login online;
- agrega/actualiza tests de sesión, healthcheck, routing de pendientes y combustible offline.

## Pendiente de validación
El issue #164 queda como smoke E2E real posterior a CI/merge: login online → corte → cargas offline → recuperación → reauth → sync → verificación sin duplicados.

Closes #158
Closes #159
Closes #160
Closes #161
Closes #162
Closes #163
