### PR TITLE
fix(caminos): respetar requisitos configurados en Tipos de Proceso

### DIFF
--- a/backend/app/api/routes/parte_caminos.py
+++ b/backend/app/api/routes/parte_caminos.py
@@ -17,16 +17,6 @@ from app.schemas.produccion import TableroProduccionCreate
 
 router = APIRouter(prefix="/produccion/caminos", tags=["produccion"])
 
-# Rules that belong specifically to the Caminos workflow. Keeping them here
-# avoids mutating the global tipo_de_proceso flags when a process such as
-# PERFILADO is also used by another business unit.
-_CAMINOS_LOCATION_REQUIREMENTS = {
-    "PERFILADO": {"predio": True, "acta": True, "rodal": True},
-    "DISPOSICION": {"predio": True, "acta": False, "rodal": False},
-    "REMOLQUE": {"predio": True, "acta": False, "rodal": False},
-}
-
-
 def _clean_text(value: str | None) -> str:
     return str(value or "").strip()
 
@@ -46,16 +36,9 @@ def _validate_location(tipo: TipoDeProceso, predio: str, acta: str, rodal: str) 
     def missing(value: str) -> bool:
         return not value or not value.strip() or value.strip() == "0"
 
-    nombre = (tipo.nombre or "").strip().upper()
-    scoped = _CAMINOS_LOCATION_REQUIREMENTS.get(nombre)
-    if scoped:
-        requiere_predio = scoped["predio"]
-        requiere_acta = scoped["acta"]
-        requiere_rodal = scoped["rodal"]
-    else:
-        requiere_predio = bool(tipo.requiere_predio)
-        requiere_acta = bool(tipo.requiere_acta)
-        requiere_rodal = bool(tipo.requiere_rodal)
+    requiere_predio = bool(tipo.requiere_predio)
+    requiere_acta = bool(tipo.requiere_acta)
+    requiere_rodal = bool(tipo.requiere_rodal)
 
     if requiere_predio and missing(predio):
         raise HTTPException(status_code=422, detail=f"{tipo.nombre}: el predio es obligatorio")

--- a/backend/tests/test_parte_caminos_location.py
+++ b/backend/tests/test_parte_caminos_location.py
@@ -15,33 +15,38 @@ def _tipo(nombre, *, predio=False, acta=False, rodal=False):
     )
 
 
-def test_perfilado_caminos_requires_predio_acta_and_rodal_even_if_global_flags_are_false():
+def test_perfilado_without_location_flags_does_not_require_location():
     tipo = _tipo("PERFILADO")
 
-    with pytest.raises(HTTPException, match="predio"):
-        _validate_location(tipo, "", "", "")
-
-    with pytest.raises(HTTPException, match="acta"):
-        _validate_location(tipo, "PREDIO", "", "")
-
-    with pytest.raises(HTTPException, match="rodal"):
-        _validate_location(tipo, "PREDIO", "ACTA", "")
-
-    _validate_location(tipo, "PREDIO", "ACTA", "RODAL")
+    _validate_location(tipo, "", "", "")
 
 
-def test_disposicion_and_remolque_only_add_caminos_predio_requirement():
+def test_disposicion_and_remolque_respect_configured_predio_requirement():
     for nombre in ("DISPOSICION", "REMOLQUE"):
-        tipo = _tipo(nombre)
+        tipo = _tipo(nombre, predio=True)
+
         with pytest.raises(HTTPException, match="predio"):
             _validate_location(tipo, "", "", "")
+
         _validate_location(tipo, "PREDIO", "", "")
 
 
-def test_unknown_process_falls_back_to_global_location_flags():
-    tipo = _tipo("OTRO", acta=True)
+@pytest.mark.parametrize(
+    ("kwargs", "predio", "acta", "rodal", "message"),
+    [
+        ({"predio": True}, "", "", "", "predio"),
+        ({"acta": True}, "", "", "", "acta"),
+        ({"rodal": True}, "", "", "", "rodal"),
+    ],
+)
+def test_location_validation_uses_tipo_de_proceso_flags(kwargs, predio, acta, rodal, message):
+    tipo = _tipo("CUALQUIER PROCESO", **kwargs)
 
-    with pytest.raises(HTTPException, match="acta"):
-        _validate_location(tipo, "", "", "")
+    with pytest.raises(HTTPException, match=message):
+        _validate_location(tipo, predio, acta, rodal)
 
-    _validate_location(tipo, "", "ACTA", "")
+
+def test_all_configured_location_fields_are_accepted_when_present():
+    tipo = _tipo("PERFILADO", predio=True, acta=True, rodal=True)
+
+    _validate_location(tipo, "PREDIO", "ACTA", "RODAL")

--- a/frontend/src/views/CaminosFormView.test.js
+++ b/frontend/src/views/CaminosFormView.test.js
@@ -3,14 +3,15 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
 
 const push = vi.fn()
+const defaultTiposProceso = () => [
+  { id: 9, nombre: 'PERFILADO', requiere_acta: false, requiere_predio: false, requiere_rodal: false },
+  { id: 20, nombre: 'DISPOSICION', requiere_acta: false, requiere_predio: true, requiere_rodal: false },
+  { id: 21, nombre: 'REMOLQUE', requiere_acta: false, requiere_predio: true, requiere_rodal: false },
+]
 const store = {
   operadores: [],
   moviles: [],
-  tiposProceso: [
-    { id: 9, nombre: 'PERFILADO' },
-    { id: 20, nombre: 'DISPOSICION' },
-    { id: 21, nombre: 'REMOLQUE' },
-  ],
+  tiposProceso: defaultTiposProceso(),
   predios: [],
   actas: [],
   rodales: [],
@@ -72,6 +73,12 @@ function mountView(unidad = { idUnidadNegocio: 7, nombre: 'Caminos' }) {
 describe('CaminosFormView', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    store.tiposProceso = defaultTiposProceso()
+    store.moviles = []
+    store.predios = []
+    store.actas = []
+    store.rodales = []
+    store.error = null
   })
 
   it('allows adding and removing process rows in the same daily part', async () => {
@@ -114,6 +121,22 @@ describe('CaminosFormView', () => {
     wrapper.vm.form.hrs_no_op = 0
     await nextTick()
     expect(wrapper.vm.form.motivo_no_op).toBe('')
+  })
+
+  it('respects configured location flags for PERFILADO', async () => {
+    const wrapper = mountView()
+    const proceso = wrapper.vm.procesos[0]
+
+    proceso.tipo_proceso_id = 9
+    proceso.km_perfilado = 2
+    wrapper.vm.pasoActual = 5
+    await nextTick()
+
+    const labels = wrapper.findAllComponents(AutocompleteField).map((component) => component.props('label'))
+    expect(labels).not.toContain('Predio')
+    expect(labels).not.toContain('Acta')
+    expect(labels).not.toContain('Rodal')
+    expect(wrapper.vm.puedeAvanzar).toBe(true)
   })
 
   it('allows disposition hours over meter difference when towing remains valid', async () => {
@@ -202,7 +225,12 @@ describe('CaminosFormView', () => {
     expect(payload.operacion).toBeUndefined()
   })
 
-  it('trims acta and rodal in the process payload', async () => {
+  it('trims acta and rodal in the process payload when configured as required', async () => {
+    store.tiposProceso = defaultTiposProceso().map((tipo) => (
+      tipo.id === 9
+        ? { ...tipo, requiere_acta: true, requiere_predio: true, requiere_rodal: true }
+        : tipo
+    ))
     store.predios = [{ idPredio: 1, nombre: '  PUERTO BOSSETTI  ' }]
     const wrapper = mountView({ idUnidadNegocio: 7, nombre: '  Caminos  ' })
     const proceso = wrapper.vm.procesos[0]

--- a/frontend/src/views/CaminosFormView.vue
+++ b/frontend/src/views/CaminosFormView.vue
@@ -323,9 +323,9 @@ function nombreProceso(id) { return tipoProceso(id)?.nombre || '' }
 function esProceso(p, n) { return nombreProceso(p.tipo_proceso_id).trim().toUpperCase() === n }
 function procesoUsado(id, key) { return procesos.some(x => x.key !== key && Number(x.tipo_proceso_id) === Number(id)) }
 function procesosDisponibles(proceso) { return (store.tiposProceso || []).filter(tipo => !procesoUsado(tipo.id, proceso.key) || Number(tipo.id) === Number(proceso.tipo_proceso_id)) }
-function requierePredio(p) { const n = nombreProceso(p.tipo_proceso_id).trim().toUpperCase(); return ['PERFILADO', 'DISPOSICION', 'REMOLQUE'].includes(n) || !!tipoProceso(p.tipo_proceso_id)?.requiere_predio }
-function requiereActa(p) { const n = nombreProceso(p.tipo_proceso_id).trim().toUpperCase(); if (n === 'PERFILADO') return true; if (['DISPOSICION', 'REMOLQUE'].includes(n)) return false; return !!tipoProceso(p.tipo_proceso_id)?.requiere_acta }
-function requiereRodal(p) { const n = nombreProceso(p.tipo_proceso_id).trim().toUpperCase(); if (n === 'PERFILADO') return true; if (['DISPOSICION', 'REMOLQUE'].includes(n)) return false; return !!tipoProceso(p.tipo_proceso_id)?.requiere_rodal }
+function requierePredio(p) { return !!tipoProceso(p.tipo_proceso_id)?.requiere_predio }
+function requiereActa(p) { return !!tipoProceso(p.tipo_proceso_id)?.requiere_acta }
+function requiereRodal(p) { return !!tipoProceso(p.tipo_proceso_id)?.requiere_rodal }
 function predioNombre(id) { return store.predios.find(x => Number(x.idPredio) === Number(id))?.nombre || '' }
 function operadorNombre(id) { if (!canSelectOperador.value) return authStore.userName || ''; return store.operadores.find(x => Number(x.idPersonal) === Number(id))?.nombre || '' }
 function equipoSeleccionado() { return store.moviles.find(x => Number(x.idMovil) === Number(form.cod_equipo)) || null }


### PR DESCRIPTION
Closes #166

## Qué cambia
- elimina las reglas hardcodeadas de ubicación para PERFILADO, DISPOSICION y REMOLQUE en Caminos;
- frontend y backend pasan a usar exclusivamente `requiere_acta`, `requiere_predio` y `requiere_rodal` del tipo de proceso;
- actualiza tests backend para validar la configuración como fuente de verdad;
- agrega cobertura frontend para PERFILADO sin requisitos de ubicación.

## Comportamiento esperado con la configuración actual
- PERFILADO: no exige Predio, Acta ni Rodal.
- DISPOSICION: exige solo Predio.
- REMOLQUE: exige solo Predio.

## Archivos
- `frontend/src/views/CaminosFormView.vue`
- `frontend/src/views/CaminosFormView.test.js`
- `backend/app/api/routes/parte_caminos.py`
- `backend/tests/test_parte_caminos_location.py`

Prioridad alta: corrige un bloqueo operativo en producción.